### PR TITLE
Do not populate HEMCO data arrays for dry-run simulations

### DIFF
--- a/src/Core/hcoio_read_std_mod.F90
+++ b/src/Core/hcoio_read_std_mod.F90
@@ -315,24 +315,7 @@ CONTAINS
 
        !====================================================================
        ! HEMCO is in a "dry-run" mode!
-       ! Populate the data container with dummy values
-       ! to ensure GEOS-Chem plays along
        !====================================================================
-
-       ! 2D array init
-       IF ( Lct%Dct%Dta%SpaceDim <= 2 ) THEN
-          CALL FileData_ArrInit( Lct%Dct%Dta, 1,                             &
-                                 HcoState%NX, HcoState%NY, RC               )
-          IF ( RC /= 0 ) RETURN
-       ENDIF
-
-       ! 3D data and index data is first written into a temporary array,
-       ! REGR_4D.
-       IF ( Lct%Dct%Dta%SpaceDim == 3 ) THEN
-          CALL FileData_ArrInit( Lct%Dct%Dta, 1,           HcoState%NX,      &
-                                 HcoState%NY, HcoState%NZ, RC               )
-          IF ( RC /= 0 ) RETURN
-       ENDIF
 
        ! Simulate file read buffer
        IF ( TRIM(HcoState%ReadLists%FileInArchive) == TRIM(srcFile) ) THEN


### PR DESCRIPTION
In HEMCO/src/Core/hcoio_read_std_mod.F90, we have removed calls to
FileData_ArrInit that populate arrays with dummy values when doing
a GEOS-Chem or HEMCO dry-run simulation.  This causes an excessive
amount of memory to be allocated.

With this fix, even a geosfp_2x25_standard benchmark now only requires
5.3 GB of memory (instead of 32GB, as was the case previously).

Signed-off-by: Bob Yantosca <yantosca@seas.harvard.edu>