### PR TITLE
Dryrun fix: Do not attempt to go back in time if a file is not found

### DIFF
--- a/src/Core/hcoio_read_std_mod.F90
+++ b/src/Core/hcoio_read_std_mod.F90
@@ -317,7 +317,6 @@ CONTAINS
        ! HEMCO is in a "dry-run" mode!
        !====================================================================
 
-
        ! Simulate file read buffer
        IF ( TRIM(HcoState%ReadLists%FileInArchive) == TRIM(srcFile) ) THEN
           CALL HCO_LEAVE ( HcoState%Config%Err,  RC )
@@ -2903,6 +2902,15 @@ CONTAINS
     ! If the direction flag is on, force HasFile to be false.
     IF ( PRESENT(Direction) ) THEN
        IF ( Direction /= 0 ) HasFile = .FALSE.
+    ENDIF
+
+    ! If this is a HEMCO dry-run simulation then do not enter the loop
+    ! where we will attempt to go back in time until a file is found.
+    ! For the dry-run we need to report all files, even missing.
+    ! This fixes Github issue geoschem/geos-chem #312. (bmy, 6/4/20)
+    IF ( HcoState%Options%isDryRun ) THEN
+       RC = HCO_SUCCESS
+       RETURN
     ENDIF
 
     ! If file does not exist, check if we can adjust prefYr, prefMt, etc.


### PR DESCRIPTION
We have placed a shunt in routine SrcFile_Parse (in module
HEMCO/src/Core/hcoio_read_std_mod.F90) for the GEOS-Chem/HEMCO dry-run.

Prior to this fix, if a file (say for 2019/08/10) was not found,
the program flow would enter a loop and attempt to keep going back
in time until the most recent file was found (say 2019/08/01).  This
resulted in GEOS-Chem/HEMCO dry-run simulations not being able to
pick up missing files if at least one file already existed.

The fix is to exit routine SrcFile_Parse before entering the loop
where we attempt to go back in time if we are doing a dry-run
simulation.

This code was taken from the bugfix/dryrun branch of geoschem/geos-chem,
which is slated to be merged into GEOS-Chem 12.9.0.

Signed-off-by: Bob Yantosca <yantosca@seas.harvard.edu>