### PR TITLE
Fix: Add a missing HCO_LEAVE call to GetHcoDiagn.

### DIFF
--- a/src/Interfaces/Shared/hco_interface_common.F90
+++ b/src/Interfaces/Shared/hco_interface_common.F90
@@ -329,6 +329,7 @@ CONTAINS
 
     ! Leave with success
     RC = HCO_SUCCESS
+    CALL HCO_LEAVE ( HcoState%Config%Err, RC )
 
   END SUBROUTINE GetHcoDiagn
 !EOC


### PR DESCRIPTION
This minor update adds a missing `HCO_LEAVE` call to `GetHcoDiagn`. This may have to be pulled into multiple branches. Thanks!