### PR TITLE
[PULL REQUEST] Remove duplicate Inst%FLUXSABI allocation in MEGAN HCO extension

### DIFF
--- a/src/Extensions/hcox_megan_mod.F90
+++ b/src/Extensions/hcox_megan_mod.F90
@@ -4064,13 +4064,6 @@ CONTAINS
 
     ALLOCATE( Inst%FLUXSABI( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'FLUXBPIN', RC )
-       RETURN
-    ENDIF
-    Inst%FLUXBPIN = 0.0_sp
-
-    ALLOCATE( Inst%FLUXSABI( NX, NY ), STAT=AS )
-    IF ( AS /= 0 ) THEN
        CALL HCO_ERROR( HcoState%Config%Err, 'FLUXSABI', RC )
        RETURN
     ENDIF


### PR DESCRIPTION
Hi GCST,

This is a minor fix sent to me from Thibaud Fritz from MIT (@fritzt). He wrote:

> I found what seems to be a minor bug/typo in HEMCO Extensions. In hcox_megan_mod.F90, Inst%FLUXSABI seems to get allocated twice which I don't see a reason why this is the case.
> https://github.com/geoschem/HEMCO/blob/f2e5f9b8c8a1a78dcff5d59fb406036687502c57/src/Extensions/hcox_megan_mod.F90#L4065-L4077

This PR removes the duplicate allocation. Thanks!