### PR TITLE
Unify HCOIO interfaces for Standard and MAPL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,6 +214,11 @@ endif()
 #-----------------------------------------------------------------------------
 if(NOT HEMCO_EXTERNAL_CONFIG)
 
+    # Set HEMCO compile flag to standalone
+    target_compile_definitions(HEMCOBuildProperties
+        INTERFACE "HEMCO_STANDALONE"
+    )
+
     # Set CMAKE_BUILD_TYPE to Release by default
     if(NOT CMAKE_BUILD_TYPE)
         set(CMAKE_BUILD_TYPE "Release"

--- a/src/Core/CMakeLists.txt
+++ b/src/Core/CMakeLists.txt
@@ -28,9 +28,9 @@ add_library(HCO STATIC EXCLUDE_FROM_ALL
 	hcoio_diagn_mod.F90
 	hcoio_messy_mod.F90
 	hcoio_util_mod.F90
-	hcoio_read_esmf_mod.F90
+	hcoio_read_mapl_mod.F90
 	hcoio_read_std_mod.F90
-	hcoio_write_esmf_mod.F90
+	hcoio_write_mapl_mod.F90
 	hcoio_write_std_mod.F90
 	interpreter.F90
 	messy_ncregrid_base.F90

--- a/src/Core/hco_readlist_mod.F90
+++ b/src/Core/hco_readlist_mod.F90
@@ -408,9 +408,9 @@ CONTAINS
 !
 ! !USES:
 !
+    USE HCOIO_Util_Mod,     ONLY : HCOIO_ReadOther
+    USE HCOIO_Read_Mod,     ONLY : HCOIO_CloseAll
     USE HCOIO_DataRead_Mod, ONLY : HCOIO_DataRead
-    USE HCOIO_Read_Std_Mod, ONLY : HCOIO_ReadOther
-    USE HCOIO_Read_Std_Mod, ONLY : HCOIO_CloseAll
     USE HCO_FileData_Mod,   ONLY : FileData_ArrIsDefined
     USE HCO_FileData_Mod,   ONLY : FileData_ArrIsTouched
     USE HCO_EmisList_Mod,   ONLY : EmisList_Pass

--- a/src/Core/hcoio_diagn_mod.F90
+++ b/src/Core/hcoio_diagn_mod.F90
@@ -188,11 +188,7 @@ CONTAINS
 ! !USES:
 !
     USE HCO_State_Mod,        ONLY : HCO_State
-#if defined(ESMF_)
-    USE HCOIO_WRITE_ESMF_MOD, ONLY : HCOIO_WRITE_ESMF
-#else
-    USE HCOIO_WRITE_STD_MOD,  ONLY : HCOIO_WRITE_STD
-#endif
+    USE HCOIO_Write_Mod,      ONLY : HCOIO_Write
 !
 ! !INPUT PARAMETERS:
 !
@@ -205,7 +201,6 @@ CONTAINS
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
-
     INTEGER,          INTENT(INOUT) :: RC          ! Failure or success
 !
 ! !REVISION HISTORY:
@@ -223,21 +218,21 @@ CONTAINS
     ! HCOIO_DIAGN_WRITEOUT begins here!
     !=================================================================
 
+#if defined(ESMF_)
     !-----------------------------------------------------------------
     ! ESMF environment: call ESMF output routines
     !-----------------------------------------------------------------
-#if defined(ESMF_)
-    CALL HCOIO_WRITE_ESMF ( HcoState,                &
-                            RC,                      &
-                            OnlyIfFirst=OnlyIfFirst, &
-                            COL=COL                   )
+    CALL HCOIO_Write     ( HcoState,                &
+                           RC,                      &
+                           OnlyIfFirst=OnlyIfFirst, &
+                           COL=COL                   )
     IF ( RC /= HCO_SUCCESS ) RETURN
 
+#else
     !-----------------------------------------------------------------
     ! Standard environment: call default output routines
     !-----------------------------------------------------------------
-#else
-    CALL HCOIO_WRITE_STD( HcoState,                 &
+    CALL HCOIO_Write    ( HcoState,                 &
                           ForceWrite,               &
                           RC,                       &
                           PREFIX      =PREFIX,      &

--- a/src/Core/hcoio_read_mapl_mod.F90
+++ b/src/Core/hcoio_read_mapl_mod.F90
@@ -1,17 +1,24 @@
+!BOC
+#if defined ( ESMF_ )
+! The 'standard' HEMCO I/O module is used for:
+! - GEOS-Chem High Performance / GCHP and GEOS (ESMF_)
+!EOC
 !------------------------------------------------------------------------------
 !                   Harmonized Emissions Component (HEMCO)                    !
 !------------------------------------------------------------------------------
 !BOP
 !
-! !MODULE: hcoio_read_esmf_mod.F90
+! !MODULE: hcoio_read_mapl_mod.F90
 !
-! !DESCRIPTION: Module HCOIO\_Read\_ESMF\_mod is the HEMCO interface for
-!  data reading within the ESMF framework.
+! !DESCRIPTION: Module HCOIO\_Read\_mod is the HEMCO interface for
+!  data reading within the MAPL library.
+!
+!  This module implements the MAPL environment.
 !\\
 !\\
 ! !INTERFACE:
 !
-MODULE HCOIO_Read_ESMF_mod
+MODULE HCOIO_Read_Mod
 !
 ! !USES:
 !
@@ -24,8 +31,8 @@ MODULE HCOIO_Read_ESMF_mod
 !
 ! !PUBLIC MEMBER FUNCTIONS:
 !
-#if defined(ESMF_)
-  PUBLIC  :: HCOIO_Read_ESMF
+  PUBLIC  :: HCOIO_Read
+  PUBLIC  :: HCOIO_CloseAll
 !
 ! !REVISION HISTORY:
 !  22 Aug 2013 - C. Keller   - Initial version
@@ -50,7 +57,7 @@ CONTAINS
 !\\
 ! !INTERFACE:
   !
-  SUBROUTINE HCOIO_Read_ESMF( HcoState, Lct, RC )
+  SUBROUTINE HCOIO_Read( HcoState, Lct, RC )
 !
 ! !USES:
 !
@@ -85,7 +92,7 @@ CONTAINS
     REAL,             POINTER  :: Ptr2D(:,:)
     TYPE(ESMF_State), POINTER  :: IMPORT
     CHARACTER(LEN=255)         :: MSG
-    CHARACTER(LEN=255), PARAMETER :: LOC = 'HCOIO_READ_ESMF (hcoio_read_esmf_mod.F90)'
+    CHARACTER(LEN=255), PARAMETER :: LOC = 'HCOIO_READ (hcoio_read_mapl_mod.F90)'
     CHARACTER(LEN=ESMF_MAXSTR) :: Iam
 
     !=================================================================
@@ -199,5 +206,47 @@ CONTAINS
 
   END SUBROUTINE HCOIO_Read_ESMF
 !EOC
+!------------------------------------------------------------------------------
+!                   Harmonized Emissions Component (HEMCO)                    !
+!------------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE: HCOIO_CloseAll
+!
+! !DESCRIPTION: Subroutine HCOIO\_CloseAll makes sure that there is no open
+! netCDF file left in the stream. This is a stub as there is no such handling
+! within HEMCO for the MAPL environment, it is performed by MAPL.
+!\\
+!\\
+! !INTERFACE:
+!
+  SUBROUTINE HCOIO_CloseAll( HcoState, RC )
+!
+! !INPUT PARAMTERS:
+!
+    TYPE(HCO_State), POINTER          :: HcoState    ! HEMCO state
+!
+! !INPUT/OUTPUT PARAMETERS:
+!
+    INTEGER,          INTENT(INOUT)   :: RC
+!
+! !REVISION HISTORY:
+!  24 Mar 2016 - C. Keller: Initial version
+!  See https://github.com/geoschem/hemco for complete history
+!EOP
+!------------------------------------------------------------------------------
+!BOC
+!
+! !LOCAL VARIABLES:
+!
+    !======================================================================
+    ! HCOIO_CloseAll begins here
+    !======================================================================
+
+    ! Return w/ success
+    RC = HCO_SUCCESS
+
+  END SUBROUTINE HCOIO_CloseAll
+!EOC
+END MODULE HCOIO_Read_Mod
 #endif
-END MODULE HCOIO_Read_ESMF_mod

--- a/src/Core/hcoio_util_mod.F90
+++ b/src/Core/hcoio_util_mod.F90
@@ -41,6 +41,7 @@ MODULE HCOIO_Util_Mod
   PUBLIC :: CheckMissVal
   PUBLIC :: GetArbDimIndex
 #endif
+  PUBLIC :: HCOIO_ReadOther
   PUBLIC :: HCOIO_ReadCountryValues
   PUBLIC :: HCOIO_ReadFromConfig
   PUBLIC :: GetDataVals
@@ -2026,6 +2027,78 @@ CONTAINS
   END SUBROUTINE GetArbDimIndex
 !EOC
 #endif
+!------------------------------------------------------------------------------
+!                   Harmonized Emissions Component (HEMCO)                    !
+!------------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE: HCOIO_ReadOther
+!
+! !DESCRIPTION: Subroutine HCOIO\_ReadOther is a wrapper routine to
+! read data from sources other than netCDF.
+!\\
+!\\
+! If a file name is given (ending with '.txt'), the data are assumed
+! to hold country-specific values (e.g. diurnal scale factors). In all
+! other cases, the data is directly read from the configuration file
+! (scalars).
+!\\
+!\\
+! !INTERFACE:
+!
+  SUBROUTINE HCOIO_ReadOther( HcoState, Lct, RC )
+!
+! !USES:
+!
+!
+! !INPUT PARAMTERS:
+!
+    TYPE(HCO_State), POINTER          :: HcoState    ! HEMCO state
+!
+! !INPUT/OUTPUT PARAMETERS:
+!
+    TYPE(ListCont),   POINTER         :: Lct
+    INTEGER,          INTENT(INOUT)   :: RC
+!
+! !REVISION HISTORY:
+!  22 Dec 2014 - C. Keller: Initial version
+!  See https://github.com/geoschem/hemco for complete history
+!EOP
+!------------------------------------------------------------------------------
+!BOC
+!
+! !LOCAL VARIABLES:
+!
+    CHARACTER(LEN=255) :: MSG
+
+    !======================================================================
+    ! HCOIO_ReadOther begins here
+    !======================================================================
+
+    ! Error check: data must be in local time
+    IF ( .NOT. Lct%Dct%Dta%IsLocTime ) THEN
+       MSG = 'Cannot read data from file that is not in local time: ' // &
+             TRIM(Lct%Dct%cName)
+       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC='HCOIO_ReadOther (hcoio_dataread_mod.F90)' )
+       RETURN
+    ENDIF
+
+    ! Read an ASCII file as country values
+    IF ( INDEX( TRIM(Lct%Dct%Dta%ncFile), '.txt' ) > 0 ) THEN
+       CALL HCOIO_ReadCountryValues( HcoState, Lct, RC )
+       IF ( RC /= HCO_SUCCESS ) RETURN
+
+    ! Directly read from configuration file otherwise
+    ELSE
+       CALL HCOIO_ReadFromConfig( HcoState, Lct, RC )
+       IF ( RC /= HCO_SUCCESS ) RETURN
+    ENDIF
+
+    ! Return w/ success
+    RC = HCO_SUCCESS
+
+  END SUBROUTINE HCOIO_ReadOther
+!EOC
 !------------------------------------------------------------------------------
 !                   Harmonized Emissions Component (HEMCO)                    !
 !------------------------------------------------------------------------------

--- a/src/Core/hcoio_write_mapl_mod.F90
+++ b/src/Core/hcoio_write_mapl_mod.F90
@@ -1,3 +1,7 @@
+!BOC
+#if defined ( ESMF_ )
+! The 'standard' HEMCO I/O module is used for:
+! - GEOS-Chem High Performance / GCHP and GEOS (ESMF_)
 !EOC
 !------------------------------------------------------------------------------
 !                   Harmonized Emissions Component (HEMCO)                    !
@@ -6,7 +10,7 @@
 !
 ! !MODULE: hcoio_write_esmf_mod.F90
 !
-! !DESCRIPTION: Module HCOIO\_Write\_ESMF\_Mod.F90 is the HEMCO output
+! !DESCRIPTION: Module HCOIO\_Write\_Mod.F90 is the HEMCO output
 ! interface for the ESMF environment.
 ! In an ESMF/MAPL environment, the HEMCO diagnostics are not directly
 ! written to disk but passed to the gridded component export state, where
@@ -15,7 +19,7 @@
 !\\
 ! !INTERFACE:
 !
-MODULE HCOIO_WRITE_ESMF_MOD
+MODULE HCOIO_Write_Mod
 !
 ! !USES:
 !
@@ -27,8 +31,7 @@ MODULE HCOIO_WRITE_ESMF_MOD
 !
 ! !PUBLIC MEMBER FUNCTIONS:
 !
-#if defined(ESMF_)
-  PUBLIC :: HCOIO_WRITE_ESMF
+  PUBLIC :: HCOIO_Write
 !
 ! !REMARKS:
 !  HEMCO diagnostics are still in testing mode. We will fully activate them
@@ -50,7 +53,7 @@ CONTAINS
 !------------------------------------------------------------------------------
 !BOP
 !
-! !IROUTINE: HCOIO_Diagn_WriteOut
+! !IROUTINE: HCOIO_Write
 !
 ! !DESCRIPTION: Subroutine HCOIO\_Diagn\_WriteOut is the interface routine to
 ! link the HEMCO diagnostics arrays to the corresponding data pointers of the
@@ -76,7 +79,7 @@ CONTAINS
 !\\
 ! !INTERFACE:
 !
-  SUBROUTINE HCOIO_WRITE_ESMF ( HcoState, RC, OnlyIfFirst, COL )
+  SUBROUTINE HCOIO_WRITE ( HcoState, RC, OnlyIfFirst, COL )
 !
 ! !USES:
 !
@@ -193,8 +196,7 @@ CONTAINS
     ! Return
     RC = HCO_SUCCESS
 
-  END SUBROUTINE HCOIO_WRITE_ESMF
+  END SUBROUTINE HCOIO_Write
 !EOC
+END MODULE HCOIO_Write_Mod
 #endif
-END MODULE HCOIO_WRITE_ESMF_MOD
-

--- a/src/Core/hcoio_write_std_mod.F90
+++ b/src/Core/hcoio_write_std_mod.F90
@@ -1,19 +1,26 @@
+!BOC
+#if defined ( MODEL_CLASSIC ) || defined( MODEL_WRF ) || defined( MODEL_CESM ) || defined( HEMCO_STANDALONE )
+! The 'standard' HEMCO I/O module is used for:
+! - HEMCO Standalone (HEMCO_STANDALONE)
+! - GEOS-Chem 'Classic' (MODEL_CLASSIC)
+! - WRF-GC (MODEL_WRF)
+! - CESM-GC and CAM-Chem / HEMCO-CESM (MODEL_CESM)
 !EOC
 !------------------------------------------------------------------------------
 !                   Harmonized Emissions Component (HEMCO)                    !
 !------------------------------------------------------------------------------
 !BOP
 !
-! !MODULE: hcoio_write_std_mod.F90
+! !MODULE: hcoio_write_mod.F90
 !
-! !DESCRIPTION: Module HCOIO\_write\_std\_mod.F90 is the HEMCO data output
+! !DESCRIPTION: Module HCOIO\_write\_mod.F90 is the HEMCO data output
 ! interface for the 'standard' model environment. It contains routines to
 ! write out diagnostics into a netCDF file.
 !\\
 !\\
 ! !INTERFACE:
 !
-MODULE HCOIO_WRITE_STD_MOD
+MODULE HCOIO_Write_Mod
 !
 ! !USES:
 !
@@ -22,11 +29,10 @@ MODULE HCOIO_WRITE_STD_MOD
 
   IMPLICIT NONE
   PRIVATE
-#if !defined(ESMF_)
 !
 ! !PUBLIC MEMBER FUNCTIONS:
 !
-  PUBLIC :: HCOIO_WRITE_STD
+  PUBLIC :: HCOIO_Write
 !
 ! !PRIVATE MEMBER FUNCTIONS:
 !
@@ -76,7 +82,7 @@ CONTAINS
 !\\
 ! !INTERFACE:
 !
-  SUBROUTINE HCOIO_write_std( HcoState, ForceWrite,  &
+  SUBROUTINE HCOIO_Write    ( HcoState, ForceWrite,  &
                               RC,          PREFIX,   UsePrevTime, &
                               OnlyIfFirst, COL                     )
 !
@@ -779,7 +785,7 @@ CONTAINS
     ! Return
     RC = HCO_SUCCESS
 
-  END SUBROUTINE HCOIO_write_std
+  END SUBROUTINE HCOIO_Write
 !EOC
 !------------------------------------------------------------------------------
 !                   Harmonized Emissions Component (HEMCO)                    !
@@ -918,6 +924,5 @@ CONTAINS
 
   END SUBROUTINE ConstructTimeStamp
 !EOC
+END MODULE HCOIO_WRITE_MOD
 #endif
-END MODULE HCOIO_WRITE_STD_MOD
-


### PR DESCRIPTION
Hi GCST,

This update changes the module definitions of the old STD and ESMF
HCOIO modules into unified modules, `HCOIO_Read_Mod` and `HCOIO_Write_Mod`.

It also renames `HCOIO_*_ESMF_MOD` to `HCOIO_*_MAPL_MOD`, as it is the more
accurate description.

A pre-processor constant `HEMCO_STANDALONE` is added when compiling HEMCO standalone, so that the correct "standard" I/O module is loaded (since `MODEL_CLASSIC` etc. isn't defined for HEMCO standalone.)

These changes are intended to minimize code path decisions outside of
the HCOIO module implementations themselves, so that more Data Input Layers
can be added to HEMCO 3.0+ in the future, to support more IO capabilities.

All read/write modules in HCOIO now implement the same module and subroutine
names, and they are chosen to be compiled by pre-processor flags.
To all modules outside these specific I/O implementations, `HCOIO_Read_Mod`
and `HCOIO_Write_Mod` act the same regardless of underlying implementation
(model environment).

Right now, `HCOIO_Write_Mod` still has some MAPL specific code. Either a stub
should be added or these features could be supported by MAPL.

The intentions of this commit should be much clearer by looking at the code.

Thanks!

Best,
Haipeng

P.S. - I made this PR against `main` but perhaps we could create a new branch for the upcoming 3.0.0 HEMCO release for GEOS-Chem 13.1.0. Please feel free to merge this into a different branch. The changes here were made based on main or the `13.0.0-rc2` tag.