### PR TITLE
[PULL REQUEST] Merge up HEMCO 3.0.0-rc.3 into dev

### DIFF
--- a/src/Core/hco_config_mod.F90
+++ b/src/Core/hco_config_mod.F90
@@ -924,8 +924,8 @@ CONTAINS
                 ! - "RY"  : range, always use simulation year
                 ! - "E"   : exact, read/query once
                 ! - "EF"  : exact, forced (error if not exist), read/query once
-                ! - "EFY" : exact, forced, always use simulation year, read/query once
-                ! - "EFYK": exact, always use simulation year, keep reading
+                ! - "EFY" : exact, forced, always use sim year
+                ! - "EFYO": exact, forced, always use sim year, read once
                 ! - "EC"  : exact, read/query continuously (e.g. for ESMF interface)
                 ! - "ECF" : exact, forced, read/query continuously
                 ! - "EY"  : exact, always use simulation year, read/query once
@@ -977,12 +977,11 @@ CONTAINS
                    Dta%MustFind  = .TRUE.
                 ELSEIF ( TRIM(TmCycle) == "EFY" ) THEN
                    Dta%CycleFlag = HCO_CFLAG_EXACT
-                   Dta%UpdtFlag  = HCO_UFLAG_ONCE
                    Dta%MustFind  = .TRUE.
                    Dta%UseSimYear= .TRUE.
-                ELSEIF ( TRIM(TmCycle) == "EFYK" ) THEN
+                ELSEIF ( TRIM(TmCycle) == "EFYO" ) THEN
                    Dta%CycleFlag = HCO_CFLAG_EXACT
-                   Dta%UpdtFlag  = HCO_UFLAG_ALWAYS
+                   Dta%UpdtFlag  = HCO_UFLAG_ONCE
                    Dta%MustFind  = .TRUE.
                    Dta%UseSimYear= .TRUE.
                 ELSEIF ( TRIM(TmCycle) == "EC" ) THEN
@@ -1236,8 +1235,8 @@ CONTAINS
              ! - "RY"  : range, always use simulation year
              ! - "E"   : exact, read/query once
              ! - "EF"  : exact, forced (error if not exist), read/query once
-             ! - "EFY" : exact, forced, always use sim year, read/query once
-             ! - "EFYK": exact, always use simulation year, keep reading
+             ! - "EFY" : exact, forced, always use sim year
+             ! - "EFYO": exact, forced, always use sim year, read once
              ! - "EC"  : exact, read/query continuousl (e.g. for ESMF interface)
              ! - "ECF" : exact, forced, read/query continuously
              ! - "EY"  : exact, always use simulation year, read/query once
@@ -1288,12 +1287,11 @@ CONTAINS
                 Dta%MustFind  = .TRUE.
              ELSEIF ( TRIM(TmCycle) == "EFY" ) THEN
                 Dta%CycleFlag = HCO_CFLAG_EXACT
-                Dta%UpdtFlag  = HCO_UFLAG_ONCE
                 Dta%MustFind  = .TRUE.
                 Dta%UseSimYear= .TRUE.
-             ELSEIF ( TRIM(TmCycle) == "EFYK" ) THEN
+             ELSEIF ( TRIM(TmCycle) == "EFYO" ) THEN
                 Dta%CycleFlag = HCO_CFLAG_EXACT
-                Dta%UpdtFlag  = HCO_UFLAG_ALWAYS
+                Dta%UpdtFlag  = HCO_UFLAG_ONCE
                 Dta%MustFind  = .TRUE.
                 Dta%UseSimYear= .TRUE.
              ELSEIF ( TRIM(TmCycle) == "EC" ) THEN

--- a/src/Core/hco_config_mod.F90
+++ b/src/Core/hco_config_mod.F90
@@ -912,25 +912,26 @@ CONTAINS
 #endif
 
                 ! Set time cycling behaviour. Possible values are:
-                ! - "C"  : cycling <-- DEFAULT
-                ! - "CS" : cycling, skip if not exist
-                ! - "CY" : cycling, always use simulation year
-                ! - "CYS": cycling, always use simulation yr, skip if not exist
-                ! - "R"  : range
-                ! - "RA" : range, average outside
-                ! - "RF" : range, forced (error if not in range)
-                ! - "RFY": range, forced, always use simulation year
-                ! - "RFY3: range, forced, always use simulation year, 3-hourly
-                ! - "RY" : range, always use simulation year
-                ! - "E"  : exact, read/query once
-                ! - "EF" : exact, forced (error if not exist), read/query once
-                ! - "EFY": exact, forced, always use simulation year, read/query once
-                ! - "EC" : exact, read/query continuously (e.g. for ESMF interface)
-                ! - "ECF": exact, forced, read/query continuously
-                ! - "EY" : exact, always use simulation year, read/query once
-                ! - "A"  : average
-                ! - "I"  : interpolate
-                ! - "ID" : interpolate, discontinuous dataset
+                ! - "C"   : cycling <-- DEFAULT
+                ! - "CS"  : cycling, skip if not exist
+                ! - "CY"  : cycling, always use simulation year
+                ! - "CYS" : cycling, always use simulation yr, skip if not exist
+                ! - "R"   : range
+                ! - "RA"  : range, average outside
+                ! - "RF"  : range, forced (error if not in range)
+                ! - "RFY" : range, forced, always use simulation year
+                ! - "RFY3 : range, forced, always use simulation year, 3-hourly
+                ! - "RY"  : range, always use simulation year
+                ! - "E"   : exact, read/query once
+                ! - "EF"  : exact, forced (error if not exist), read/query once
+                ! - "EFY" : exact, forced, always use simulation year, read/query once
+                ! - "EFYK": exact, always use simulation year, keep reading
+                ! - "EC"  : exact, read/query continuously (e.g. for ESMF interface)
+                ! - "ECF" : exact, forced, read/query continuously
+                ! - "EY"  : exact, always use simulation year, read/query once
+                ! - "A"   : average
+                ! - "I"   : interpolate
+                ! - "ID"  : interpolate, discontinuous dataset
                 Dta%MustFind  = .FALSE.
                 Dta%UseSimYear= .FALSE.
                 Dta%Discontinuous = .FALSE.
@@ -977,6 +978,11 @@ CONTAINS
                 ELSEIF ( TRIM(TmCycle) == "EFY" ) THEN
                    Dta%CycleFlag = HCO_CFLAG_EXACT
                    Dta%UpdtFlag  = HCO_UFLAG_ONCE
+                   Dta%MustFind  = .TRUE.
+                   Dta%UseSimYear= .TRUE.
+                ELSEIF ( TRIM(TmCycle) == "EFYK" ) THEN
+                   Dta%CycleFlag = HCO_CFLAG_EXACT
+                   Dta%UpdtFlag  = HCO_UFLAG_ALWAYS
                    Dta%MustFind  = .TRUE.
                    Dta%UseSimYear= .TRUE.
                 ELSEIF ( TRIM(TmCycle) == "EC" ) THEN

--- a/src/Core/hco_config_mod.F90
+++ b/src/Core/hco_config_mod.F90
@@ -1224,25 +1224,26 @@ CONTAINS
 #endif
 
              ! Set time cycling behaviour. Possible values are:
-             ! - "C"  : cycling <-- DEFAULT
-             ! - "CS" : cycling, skip if not exist
-             ! - "CY" : cycling, always use simulation year
-             ! - "CYS": cycling, always use simulation yr, skip if not exist
-             ! - "R"  : range
-             ! - "RA" : range, average outside
-             ! - "RF" : range, forced (error if not in range)
-             ! - "RFY": range, forced, always use simulation year
-             ! - "RFY3: range, forced, always use simulation year, 3-hourly
-             ! - "RY" : range, always use simulation year
-             ! - "E"  : exact, read/query once
-             ! - "EF" : exact, forced (error if not exist), read/query once
-             ! - "EFY": exact, forced, always use simulation year, read/query once
-             ! - "EC" : exact, read/query continuousl (e.g. for ESMF interface)
-             ! - "ECF": exact, forced, read/query continuously
-             ! - "EY" : exact, always use simulation year, read/query once
-             ! - "A"  : average
-             ! - "I"  : interpolate
-             ! - "ID" : interpolate, discontinuous dataset
+             ! - "C"   : cycling <-- DEFAULT
+             ! - "CS"  : cycling, skip if not exist
+             ! - "CY"  : cycling, always use simulation year
+             ! - "CYS" : cycling, always use simulation yr, skip if not exist
+             ! - "R"   : range
+             ! - "RA"  : range, average outside
+             ! - "RF"  : range, forced (error if not in range)
+             ! - "RFY" : range, forced, always use simulation year
+             ! - "RFY3": range, forced, always use simulation year, 3-hourly
+             ! - "RY"  : range, always use simulation year
+             ! - "E"   : exact, read/query once
+             ! - "EF"  : exact, forced (error if not exist), read/query once
+             ! - "EFY" : exact, forced, always use sim year, read/query once
+             ! - "EFYK": exact, always use simulation year, keep reading
+             ! - "EC"  : exact, read/query continuousl (e.g. for ESMF interface)
+             ! - "ECF" : exact, forced, read/query continuously
+             ! - "EY"  : exact, always use simulation year, read/query once
+             ! - "A"   : average
+             ! - "I"   : interpolate
+             ! - "ID"  : interpolate, discontinuous dataset
              Dta%MustFind  = .FALSE.
              Dta%UseSimYear= .FALSE.
              IF ( TRIM(TmCycle) == "C" ) THEN
@@ -1288,6 +1289,11 @@ CONTAINS
              ELSEIF ( TRIM(TmCycle) == "EFY" ) THEN
                 Dta%CycleFlag = HCO_CFLAG_EXACT
                 Dta%UpdtFlag  = HCO_UFLAG_ONCE
+                Dta%MustFind  = .TRUE.
+                Dta%UseSimYear= .TRUE.
+             ELSEIF ( TRIM(TmCycle) == "EFYK" ) THEN
+                Dta%CycleFlag = HCO_CFLAG_EXACT
+                Dta%UpdtFlag  = HCO_UFLAG_ALWAYS
                 Dta%MustFind  = .TRUE.
                 Dta%UseSimYear= .TRUE.
              ELSEIF ( TRIM(TmCycle) == "EC" ) THEN


### PR DESCRIPTION
This PR brings in commits that fix https://github.com/geoschem/geos-chem/issues/686. namely that in GEOS_Chem "Classic", met fields were only being read on the first timestep.  This was released as HEMCO 3.0.0-rc.3, which is contained in GEOS-Chem 13.0.2 and GCHP 13.0.2.