### PR TITLE
Adds HEMCO_INTERFACE cache variable to CMake build (fix for #87)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,6 +219,12 @@ if(NOT HEMCO_EXTERNAL_CONFIG)
         INTERFACE "HEMCO_STANDALONE"
     )
 
+    # Specify the HEMCO interface being used
+    set(HEMCO_INTERFACE
+        standalone
+        CACHE STRING "HEMCO interface type (used to choose appropriate I/O option)"
+    )
+
     # Set CMAKE_BUILD_TYPE to Release by default
     if(NOT CMAKE_BUILD_TYPE)
         set(CMAKE_BUILD_TYPE "Release"
@@ -264,6 +270,12 @@ if(HEMCO_EXTERNAL_CONFIG AND GCCLASSIC_WRAPPER)
     target_compile_definitions(HEMCOBuildProperties
         INTERFACE MODEL_GCCLASSIC
     )
+
+    # Specify the HEMCO interface being used
+    set(HEMCO_INTERFACE
+        gcclassic
+        CACHE STRING "HEMCO interface type (used to choose appropriate I/O option)"
+    )
 endif()
 
 #-----------------------------------------------------------------------------
@@ -278,6 +290,12 @@ if(HEMCO_EXTERNAL_CONFIG AND MAPL_ESMF)
     )
     target_compile_definitions(HEMCOBuildProperties
         INTERFACE ESMF_
+    )
+
+    # Specify the HEMCO interface being used
+    set(HEMCO_INTERFACE
+        mapl
+        CACHE STRING "HEMCO interface type (used to choose appropriate I/O option)"
     )
 endif()
 

--- a/src/Core/CMakeLists.txt
+++ b/src/Core/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(HCO STATIC EXCLUDE_FROM_ALL
+set(src_HCOCore
 	hco_arr_mod.F90
 	hco_calc_mod.F90
 	hco_chartools_mod.F90
@@ -28,14 +28,35 @@ add_library(HCO STATIC EXCLUDE_FROM_ALL
 	hcoio_diagn_mod.F90
 	hcoio_messy_mod.F90
 	hcoio_util_mod.F90
-	hcoio_read_mapl_mod.F90
-	hcoio_read_std_mod.F90
-	hcoio_write_mapl_mod.F90
-	hcoio_write_std_mod.F90
 	interpreter.F90
 	messy_ncregrid_base.F90
 	messy_ncregrid_mpi.F90
 )
+
+# Choose the appropriate HEMCO I/O library for the given interface.
+# Currently available: standard ("HEMCO default") and mapl (MAPL)
+#
+# To add a future option:
+# elseif(HEMCO_INTERFACE STREQUAL future)
+# 	list(APPEND src_HCOCore hcoio_read_future_mod.F90 hcoio_write_future_mod.F90)
+#
+# Note that models that do not use CMake, i.e. WRF-GC (std); CESM2-GC (std) will
+# completely bypass CMake and include their own build option, hence all the HCOIO_
+# modules still have to include C-Preprocessor variables.
+#
+# For discussion, refer to: https://github.com/geoschem/HEMCO/issues/87
+if(HEMCO_INTERFACE STREQUAL standalone)
+	list(APPEND src_HCOCore hcoio_read_std_mod.F90 hcoio_write_std_mod.F90)
+elseif(HEMCO_INTERFACE STREQUAL gcclassic)
+	list(APPEND src_HCOCore hcoio_read_std_mod.F90 hcoio_write_std_mod.F90)
+elseif(HEMCO_INTERFACE STREQUAL mapl)
+	list(APPEND src_HCOCore hcoio_read_mapl_mod.F90 hcoio_write_mapl_mod.F90)
+endif()
+
+add_library(HCO STATIC EXCLUDE_FROM_ALL
+	${src_HCOCore}
+)
+
 target_link_libraries(HCO
 	PUBLIC GeosUtilHco NcdfUtilHco
 )


### PR DESCRIPTION
Hi GCST,

This is a fix for https://github.com/geoschem/HEMCO/issues/87 - please refer to the discussion in #87 and merge this when ready. Thank you!

Best,
Haipeng