### PR TITLE
Make error handling robust for mpi

### DIFF
--- a/src/Core/hco_calc_mod.F90
+++ b/src/Core/hco_calc_mod.F90
@@ -503,7 +503,7 @@ CONTAINS
              ! Cannot use temporary array for more than one species!
              IF ( nnSpec > 1 ) THEN
                 MSG = 'Cannot fill buffer for more than one species!'
-                CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+                CALL HCO_ERROR( MSG, RC )
                 RETURN
              ENDIF
 
@@ -512,14 +512,14 @@ CONTAINS
              OutArr => HcoState%Buffer3D%Val
              IF ( .NOT. ASSOCIATED( OutArr ) ) THEN
                 MSG = 'Buffer array is not associated'
-                CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+                CALL HCO_ERROR( MSG, RC )
                 RETURN
              ENDIF
              IF ( (SIZE(OutArr,1) /= nI) .OR. &
                   (SIZE(OutArr,2) /= nJ) .OR. &
                   (SIZE(OutArr,3) /= nL)       ) THEN
                 MSG = 'Buffer array has wrong dimension!'
-                CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+                CALL HCO_ERROR( MSG, RC )
                 RETURN
              ENDIF
 
@@ -582,7 +582,7 @@ CONTAINS
              ELSE
                 MSG = 'Negative emissions in: '// TRIM(Dct%cName) // '. ' // &
                 'To allow negatives, edit settings in the configuration file.'
-                CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+                CALL HCO_ERROR( MSG, RC )
                 RETURN
              ENDIF
           ENDIF
@@ -833,7 +833,7 @@ CONTAINS
     ! Check if container contains data
     IF ( .NOT. FileData_ArrIsDefined(BaseDct%Dta) ) THEN
        MSG = 'Array not defined: ' // TRIM(BaseDct%cName)
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+       CALL HCO_ERROR( MSG, RC )
        RETURN
     ENDIF
 
@@ -850,7 +850,7 @@ CONTAINS
     ! Put check for PBLHEIGHT here (bmy, 3/4/21)
     IF ( .NOT. ASSOCIATED(HcoState%Grid%PBLHEIGHT%Val) ) THEN
        MSG = 'PBLHEIGHT (in meters) is missing in HEMCO state'
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+       CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
        RETURN
     ENDIF
 
@@ -891,7 +891,7 @@ CONTAINS
        LevDct1_Unit = GetEmisLUnit( HcoState, LevDct1 )
        IF ( LevDct1_Unit < 0 ) THEN
           MSG = 'LevDct1 units are not defined!'
-          CALL HCO_ERROR ( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR ( MSG, RC, THISLOC=LOC )
           RC = HCO_FAIL
           RETURN
        ENDIF
@@ -902,7 +902,7 @@ CONTAINS
        LevDct2_Unit = GetEmisLUnit( HcoState, LevDct2 )
        IF ( LevDct2_Unit < 0 ) THEN
           MSG = 'LevDct2_Units are not defined!'
-          CALL HCO_ERROR ( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR ( MSG, RC, THISLOC=LOC )
           RETURN
        ENDIF
     ENDIF
@@ -912,7 +912,7 @@ CONTAINS
          LevDct2_Unit == HCO_EMISL_M ) THEN
        IF ( .NOT. ASSOCIATED(HcoState%Grid%BXHEIGHT_M%Val) ) THEN
           MSG = 'Boxheight (in meters) is missing in HEMCO state'
-          CALL HCO_ERROR ( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR ( MSG, RC, THISLOC=LOC )
           RETURN
        ENDIF
     ENDIF
@@ -922,7 +922,7 @@ CONTAINS
          LevDct2_Unit == HCO_EMISL_PBL ) THEN
        IF ( .NOT. ASSOCIATED(HcoState%Grid%PBLHEIGHT%Val) ) THEN
           MSG = 'Boundary layer height is missing in HEMCO state'
-          CALL HCO_ERROR ( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR ( MSG, RC, THISLOC=LOC )
           RETURN
        ENDIF
     ENDIF
@@ -1028,7 +1028,7 @@ CONTAINS
 
     ! Check for error
     IF ( ERROR == 1 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+       CALL HCO_ERROR( MSG, RC )
        RETURN
     ENDIF
 
@@ -1053,7 +1053,7 @@ CONTAINS
        ! Sanity check: scale field cannot be a base field
        IF ( (ScalDct%DctType == HCO_DCTTYPE_BASE) ) THEN
           MSG = 'Wrong scale field type: ' // TRIM(ScalDct%cName)
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+          CALL HCO_ERROR( MSG, RC )
           RETURN
        ENDIF
 
@@ -1094,7 +1094,7 @@ CONTAINS
           IF ( MaskDct%DctType /= HCO_DCTTYPE_MASK ) THEN
              MSG = 'Invalid mask for scale factor: '//TRIM(ScalDct%cName)
              MSG = TRIM(MSG) // '; mask: '//TRIM(MaskDct%cName)
-             CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+             CALL HCO_ERROR( MSG, RC )
              RETURN
           ENDIF
        ENDIF
@@ -1308,7 +1308,7 @@ CONTAINS
              MSG = 'Error when applying scale factor: ' // TRIM(ScalDct%cName)
           ENDIF
           ScalDct => NULL()
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+          CALL HCO_ERROR( MSG, RC )
           RETURN
        ENDIF
 
@@ -1429,7 +1429,7 @@ CONTAINS
     ! Check if field data is defined
     IF ( .NOT. FileData_ArrIsDefined(BaseDct%Dta) ) THEN
        MSG = 'Array not defined: ' // TRIM(BaseDct%cName)
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+       CALL HCO_ERROR( MSG, RC )
        RETURN
     ENDIF
 
@@ -1567,7 +1567,7 @@ CONTAINS
              IF ( MaskDct%DctType /= HCO_DCTTYPE_MASK ) THEN
                 MSG = 'Invalid mask for scale factor: '//TRIM(ScalDct%cName)
                 MSG = TRIM(MSG) // '; mask: '//TRIM(MaskDct%cName)
-                CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+                CALL HCO_ERROR( MSG, RC )
                 ERROR = 5
                 EXIT
              ENDIF
@@ -1699,7 +1699,7 @@ CONTAINS
              ! Return w/ error otherwise (Oper 3 only allowed for masks!)
              ELSE
                 MSG = 'Illegal data operator: ' // TRIM(ScalDct%cName)
-                CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+                CALL HCO_ERROR( MSG, RC )
                 ERROR = 2
                 EXIT
              ENDIF
@@ -1734,7 +1734,7 @@ CONTAINS
        ELSE
           MSG = 'Error when applying scale factor: ' // TRIM(ScalDct%cName)
        ENDIF
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+       CALL HCO_ERROR( MSG, RC )
        ScalDct => NULL()
        RETURN
     ENDIF
@@ -1832,7 +1832,7 @@ CONTAINS
           RETURN
        ELSE
           MSG = 'Cannot find in EmisList: ' // TRIM(cName)
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
           RETURN
        ENDIF
     ENDIF
@@ -1848,14 +1848,14 @@ CONTAINS
     ! Sanity check: horizontal grid dimensions are expected to be on HEMCO grid
     IF ( nI /= HcoState%NX .OR. nJ /= HcoState%nY ) THEN
        WRITE(MSG,*) "Horizontal dimension error: ", TRIM(cName), nI, nJ
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+       CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
        RETURN
     ENDIF
 
     ! Make sure mask array is defined
     ALLOCATE(MASK(nI,nJ,nL),STAT=AS)
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'Cannot allocate MASK', RC, THISLOC=LOC )
+       CALL HCO_ERROR( 'Cannot allocate MASK', RC, THISLOC=LOC )
        RETURN
     ENDIF
 
@@ -1953,7 +1953,7 @@ CONTAINS
           RETURN
        ELSE
           MSG = 'Cannot find in EmisList: ' // TRIM(cName)
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
           RETURN
        ENDIF
     ENDIF
@@ -1969,14 +1969,14 @@ CONTAINS
     ! Sanity check: horizontal grid dimensions are expected to be on HEMCO grid
     IF ( nI /= HcoState%NX .OR. nJ /= HcoState%nY ) THEN
        WRITE(MSG,*) "Horizontal dimension error: ", TRIM(cName), nI, nJ
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+       CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
        RETURN
     ENDIF
 
     ! Make sure mask array is defined
     ALLOCATE(MASK(nI,nJ,nL),Arr3D(nI,nJ,nL),STAT=AS)
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'Cannot allocate MASK', RC, THISLOC=LOC )
+       CALL HCO_ERROR( 'Cannot allocate MASK', RC, THISLOC=LOC )
        RETURN
     ENDIF
     Arr3D = 0.0_hp
@@ -2165,7 +2165,7 @@ CONTAINS
        CALL HCO_MSG(HcoState%Config%Err,MSG)
        MSG = '5000 TESTMASK     -140/10/-40/90 - - - xy 1 1 -140/10/-40/90 yes'
        CALL HCO_MSG(HcoState%Config%Err,MSG)
-       CALL HCO_ERROR ( HcoState%Config%Err, &
+       CALL HCO_ERROR ( &
                         'Error reading mask '//TRIM(MaskName), RC, THISLOC=LOC )
        RETURN
     ENDIF
@@ -2181,7 +2181,7 @@ CONTAINS
        IF ( SIZE(MASK,1) /= HcoState%NX .OR. SIZE(MASK,2) /= HcoState%NY ) THEN
           WRITE(MSG,*) 'Input mask array has wrong dimensions. Must be ', &
              HcoState%NX, HcoState%NY, ' but found ', SIZE(MASK,1), SIZE(MASK,2)
-          CALL HCO_ERROR ( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR ( MSG, RC, THISLOC=LOC )
           RETURN
        ENDIF
 
@@ -2203,7 +2203,7 @@ CONTAINS
        ! Error check
        IF ( ERR ) THEN
           MSG = 'Error in GetMaskVal'
-          CALL HCO_ERROR ( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR ( MSG, RC, THISLOC=LOC )
           RETURN
        ENDIF
 
@@ -2554,7 +2554,7 @@ END FUNCTION GetEmisLUnit
 
     ELSE
        MSG = 'Illegal altitude unit'
-       CALL HCO_ERROR ( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+       CALL HCO_ERROR ( MSG, RC, THISLOC=LOC )
        RETURN
     ENDIF
 
@@ -2684,7 +2684,7 @@ END FUNCTION GetEmisLUnit
           DilFact = dh / ( h2 - h1 )
        ELSE
           MSG = 'GetDilFact h2 not greater than h1'
-          CALL HCO_ERROR ( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR ( MSG, RC, THISLOC=LOC )
           RETURN
        ENDIF
 
@@ -2809,7 +2809,7 @@ END FUNCTION GetEmisLUnit
     ! Check if container contains data
     IF ( .NOT. FileData_ArrIsDefined(BaseDct%Dta) ) THEN
        MSG = 'Array not defined: ' // TRIM(BaseDct%cName)
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+       CALL HCO_ERROR( MSG, RC )
        RETURN
     ENDIF
 
@@ -2935,7 +2935,7 @@ END FUNCTION GetEmisLUnit
 
     ! Check for error
     IF ( ERROR == 1 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+       CALL HCO_ERROR( MSG, RC )
        RETURN
     ENDIF
 
@@ -2960,7 +2960,7 @@ END FUNCTION GetEmisLUnit
        ! Sanity check: scale field cannot be a base field 
        IF ( (ScalDct%DctType == HCO_DCTTYPE_BASE) ) THEN
           MSG = 'Wrong scale field type: ' // TRIM(ScalDct%cName)
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+          CALL HCO_ERROR( MSG, RC )
           RETURN
        ENDIF
 
@@ -3001,7 +3001,7 @@ END FUNCTION GetEmisLUnit
           IF ( MaskDct%DctType /= HCO_DCTTYPE_MASK ) THEN
              MSG = 'Invalid mask for scale factor: '//TRIM(ScalDct%cName)
              MSG = TRIM(MSG) // '; mask: '//TRIM(MaskDct%cName)
-             CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+             CALL HCO_ERROR( MSG, RC )
              RETURN
           ENDIF
        ENDIF
@@ -3207,7 +3207,7 @@ END FUNCTION GetEmisLUnit
              MSG = 'Error when applying scale factor: ' // TRIM(ScalDct%cName)
           ENDIF
           ScalDct => NULL()
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+          CALL HCO_ERROR( MSG, RC )
           RETURN
        ENDIF
 

--- a/src/Core/hco_clock_mod.F90
+++ b/src/Core/hco_clock_mod.F90
@@ -212,35 +212,35 @@ CONTAINS
 
        ALLOCATE ( HcoState%Clock%ThisLocYear(HcoState%Clock%ntz), STAT=AS )
        IF ( AS /= 0 ) THEN
-          CALL HCO_ERROR ( HcoState%Config%Err, 'ThisLocYear', RC )
+          CALL HCO_ERROR ( 'ThisLocYear', RC )
           RETURN
        ENDIF
        HcoState%Clock%ThisLocYear(:) = -1
 
        ALLOCATE ( HcoState%Clock%ThisLocMonth(HcoState%Clock%ntz), STAT=AS )
        IF ( AS /= 0 ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, 'ThisLocMonth', RC )
+          CALL HCO_ERROR( 'ThisLocMonth', RC )
           RETURN
        ENDIF
        HcoState%Clock%ThisLocMonth(:) = -1
 
        ALLOCATE ( HcoState%Clock%ThisLocDay(HcoState%Clock%ntz), STAT=AS )
        IF ( AS /= 0 ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, 'ThisLocDay', RC )
+          CALL HCO_ERROR( 'ThisLocDay', RC )
           RETURN
        ENDIF
        HcoState%Clock%ThisLocDay(:) = -1
 
        ALLOCATE ( HcoState%Clock%ThisLocWD(HcoState%Clock%ntz), STAT=AS )
        IF ( AS /= 0 ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, 'ThisLocWD', RC )
+          CALL HCO_ERROR( 'ThisLocWD', RC )
           RETURN
        ENDIF
        HcoState%Clock%ThisLocWD(:) = -1
 
        ALLOCATE ( HcoState%Clock%ThisLocHour(HcoState%Clock%ntz), STAT=AS )
        IF ( AS /= 0 ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, 'ThisLocHour', RC )
+          CALL HCO_ERROR( 'ThisLocHour', RC )
           RETURN
        ENDIF
        HcoState%Clock%ThisLocHour(:) = -1.0_sp
@@ -410,7 +410,7 @@ CONTAINS
                        FOUND=FND, RC=RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Error getting emission year'
-          CALL HCO_Error( HcoState%Config%Err, ErrMsg, RC )
+          CALL HCO_Error( ErrMsg, RC )
           RETURN
        ENDIF
        IF ( FND ) THEN
@@ -423,7 +423,7 @@ CONTAINS
                        FOUND=FND, RC=RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Error getting emission month'
-          CALL HCO_Error( HcoState%Config%Err, ErrMsg, RC )
+          CALL HCO_Error( ErrMsg, RC )
           RETURN
        ENDIF
 
@@ -437,7 +437,7 @@ CONTAINS
                        FOUND=FND, RC=RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Error getting emission day'
-          CALL HCO_Error( HcoState%Config%Err, ErrMsg, RC )
+          CALL HCO_Error( ErrMsg, RC )
           RETURN
        ENDIF
 
@@ -451,7 +451,7 @@ CONTAINS
                        FOUND=FND, RC=RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Error getting emission hour'
-          CALL HCO_Error( HcoState%Config%Err, ErrMsg, RC )
+          CALL HCO_Error( ErrMsg, RC )
           RETURN
        ENDIF
 
@@ -540,7 +540,7 @@ CONTAINS
        CALL Set_LocalTime ( HcoState, Clock, UTC, RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Error setting local time'
-          CALL HCO_Error( HcoState%Config%Err, ErrMsg, RC )
+          CALL HCO_Error( ErrMsg, RC )
           RETURN
        ENDIF
 
@@ -922,7 +922,7 @@ CONTAINS
 
     ! Check time zone index
     IF ( IX > HcoState%Clock%ntz ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, 'time zone index too large!', RC )
+       CALL HCO_ERROR ( 'time zone index too large!', RC )
        RETURN
     ENDIF
 

--- a/src/Core/hco_config_mod.F90
+++ b/src/Core/hco_config_mod.F90
@@ -704,7 +704,7 @@ CONTAINS
 
        ! Error if not enough entries found
        IF ( STAT == 100 ) THEN
-          CALL HCO_ERROR ( HcoConfig%Err, 'STAT == 100', RC, THISLOC=LOC )
+          CALL HCO_ERROR ( 'STAT == 100', RC, THISLOC=LOC )
           RETURN
        ENDIF
 
@@ -744,7 +744,7 @@ CONTAINS
 
        ! Output status should be 0 if none of the statuses above applies
        IF ( STAT /= 0 ) THEN
-          CALL HCO_ERROR ( HcoConfig%Err, 'STAT /= 0', RC, THISLOC=LOC )
+          CALL HCO_ERROR ( 'STAT /= 0', RC, THISLOC=LOC )
           RETURN
        ENDIF
 
@@ -781,7 +781,7 @@ CONTAINS
              IF ( RC /= HCO_SUCCESS ) THEN
                 ErrMsg = 'Error retrieving tag name for' //            &
                          ' wildcard ' // TRIM(tagId)
-                CALL HCO_Error( HcoConfig%Err, ErrMsg, RC )
+                CALL HCO_Error( ErrMsg, RC )
                 RETURN
              ENDIF
 
@@ -859,7 +859,7 @@ CONTAINS
              IF ( TRIM(srcFile) == '-' ) THEN
                 IF ( .NOT. ASSOCIATED(Dta) ) THEN
                    MSG = 'Cannot use previous data container: '//TRIM(tagcName)
-                   CALL HCO_ERROR ( HcoConfig%Err, MSG, RC, THISLOC=LOC )
+                   CALL HCO_ERROR ( MSG, RC, THISLOC=LOC )
                    RETURN
                 ENDIF
                 Lct%Dct%DtaHome = Lct%Dct%DtaHome - 1
@@ -1005,7 +1005,7 @@ CONTAINS
                 ELSE
                    MSG = 'Invalid time cycling attribute: ' // &
                          TRIM(TmCycle) // ' - in ' // TRIM(tagcName)
-                   CALL HCO_ERROR ( HcoConfig%Err, MSG, RC, THISLOC=LOC )
+                   CALL HCO_ERROR ( MSG, RC, THISLOC=LOC )
                    RETURN
                 ENDIF
 
@@ -1050,7 +1050,7 @@ CONTAINS
                    IF ( nEdges /= 4 ) THEN
                       MSG = 'Cannot properly read mask coverage: ' // &
                            TRIM(Lct%Dct%cName)
-                      CALL HCO_ERROR ( HcoConfig%Err, MSG, RC, THISLOC=LOC )
+                      CALL HCO_ERROR ( MSG, RC, THISLOC=LOC )
                       RETURN
                    ENDIF
 
@@ -1148,7 +1148,7 @@ CONTAINS
              ENDIF
 
           ELSE
-             CALL HCO_ERROR ( HcoConfig%Err, 'Invalid data type!', RC, &
+             CALL HCO_ERROR ( 'Invalid data type!', RC, &
                               THISLOC=LOC )
              RETURN
           ENDIF
@@ -1170,7 +1170,7 @@ CONTAINS
           IF ( TRIM(srcFile) == '-' ) THEN
              IF ( .NOT. ASSOCIATED(Dta) ) THEN
                 MSG = 'Cannot use previous data container: '//TRIM(cName)
-                CALL HCO_ERROR ( HcoConfig%Err, MSG, RC, THISLOC=LOC )
+                CALL HCO_ERROR ( MSG, RC, THISLOC=LOC )
                 RETURN
              ENDIF
              Lct%Dct%DtaHome = Lct%Dct%DtaHome - 1
@@ -1315,7 +1315,7 @@ CONTAINS
              ELSE
                 MSG = 'Invalid time cycling attribute: ' // &
                      TRIM(TmCycle) // ' - in ' // TRIM(tagcName)
-                CALL HCO_ERROR ( HcoConfig%Err, MSG, RC, THISLOC=LOC )
+                CALL HCO_ERROR ( MSG, RC, THISLOC=LOC )
                 RETURN
              ENDIF
 
@@ -1360,7 +1360,7 @@ CONTAINS
                 IF ( nEdges /= 4 ) THEN
                    MSG = 'Cannot properly read mask coverage: ' // &
                          TRIM(Lct%Dct%cName)
-                   CALL HCO_ERROR ( HcoConfig%Err, MSG, RC, THISLOC=LOC )
+                   CALL HCO_ERROR ( MSG, RC, THISLOC=LOC )
                    RETURN
                 ENDIF
 
@@ -1396,7 +1396,7 @@ CONTAINS
              ! nCat cannot exceed CatMax
              IF ( nCat > CatMax ) THEN
                 MSG = 'Category max exceeded'
-                CALL HCO_ERROR ( HcoConfig%Err, MSG, RC, THISLOC=LOC )
+                CALL HCO_ERROR ( MSG, RC, THISLOC=LOC )
                 RETURN
              ENDIF
 
@@ -1503,7 +1503,7 @@ CONTAINS
     IF ( STAT == 5 .OR. STAT == 6 ) THEN
        STRLEN     = LEN(LINE)
        IF ( STRLEN < 4 ) THEN
-          CALL HCO_ERROR ( HcoConfig%Err, &
+          CALL HCO_ERROR ( &
                           'Illegal bracket length: '//TRIM(LINE), &
                            RC, THISLOC=LOC )
           RETURN
@@ -1522,7 +1522,7 @@ CONTAINS
        NEST = NEST + 1
        IF ( NEST > MAXBRACKNEST ) THEN
           MSG = 'Too many nested brackets'
-          CALL HCO_ERROR( HcoConfig%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
           RETURN
        ENDIF
        AllBrackets(NEST) = TmpBracket
@@ -1639,7 +1639,7 @@ CONTAINS
        IF ( TRIM(TmpBracket) /= TRIM(AllBrackets(NEST)) ) THEN
           MSG = 'Closing bracket does not match opening bracket: '// &
              TRIM(TmpBracket)//', expected: '//TRIM(AllBrackets(NEST))
-          CALL HCO_ERROR( HcoConfig%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
           RETURN
        ENDIF
 
@@ -2051,7 +2051,7 @@ CONTAINS
              CALL STRSPLIT( SUBSTR(idx), &
                      HCO_GetOpt(HcoConfig%ExtList,'Separator'), SPECS, N )
              IF ( N < 1 ) THEN
-                CALL HCO_ERROR ( HcoConfig%Err, 'No species defined', RC, THISLOC=LOC )
+                CALL HCO_ERROR ( 'No species defined', RC, THISLOC=LOC )
                 RETURN
              ENDIF
              DO I = 1, N
@@ -2197,7 +2197,7 @@ CONTAINS
              GridRes = '0.25x0.3125'
           CASE DEFAULT
              Msg = 'Improperly formatted grid resolution: ' // TRIM( GridRes )
-             CALL HCO_Error( HcoConfig%Err, Msg, RC, Loc )
+             CALL HCO_Error( Msg, RC, Loc )
              RETURN
        END SELECT
        HcoConfig%GridRes = TRIM( GridRes )
@@ -2729,7 +2729,7 @@ CONTAINS
        IF ( .NOT. ASSOCIATED(Lct) ) THEN
           WRITE ( strID, * ) ThisScalID
           MSG = 'Container ID not found: ' // strID
-          CALL HCO_ERROR ( HcoState%Config%Err, MSG, RC)
+          CALL HCO_ERROR ( MSG, RC)
           RETURN
        ENDIF
 
@@ -2737,7 +2737,7 @@ CONTAINS
        IF ( Lct%Dct%DctType == HCO_DCTTYPE_BASE ) THEN
           WRITE ( strID, * ) ThisScalID
           MSG = 'Container ID belongs to base field: ' // strID
-          CALL HCO_ERROR ( HcoState%Config%Err, MSG, RC)
+          CALL HCO_ERROR ( MSG, RC)
           RETURN
        ENDIF
 
@@ -2912,7 +2912,7 @@ CONTAINS
           IF ( .NOT. FOUND ) THEN
              WRITE ( strID, * ) Lct%Dct%Scal_cID(I)
              MSG = 'No scale factor with cID: ' // TRIM(strID)
-             CALL HCO_ERROR ( HcoState%Config%Err, MSG, RC)
+             CALL HCO_ERROR ( MSG, RC)
              RETURN
           ENDIF
 
@@ -3025,7 +3025,7 @@ CONTAINS
              ! Error if container not found
              IF ( .NOT. FOUND ) THEN
                 WRITE(MSG,*) 'No scale factor with ID: ', tmpID
-                CALL HCO_ERROR ( HcoState%Config%Err, MSG, RC)
+                CALL HCO_ERROR ( MSG, RC)
                 RETURN
              ENDIF
 
@@ -4234,19 +4234,19 @@ CONTAINS
     IF ( PRESENT(SpecNames) ) THEN
        IF ( .NOT. ASSOCIATED(SpecNames) ) THEN
           IF ( N <= 0 ) THEN
-             CALL HCO_ERROR ( HcoConfig%Err, &
+             CALL HCO_ERROR ( &
                 'Cannot allocate SpecNames - N is size 0 or smaller', RC, THISLOC=LOC )
              RETURN
           ENDIF
           ALLOCATE(SpecNames(N), STAT=AS )
           IF ( AS/= 0 ) THEN
-             CALL HCO_ERROR ( HcoConfig%Err, &
+             CALL HCO_ERROR ( &
                 'SpecNames allocation error', RC, THISLOC=LOC )
              RETURN
           ENDIF
           SpecNames(:) = ''
        ELSEIF ( SIZE(SpecNames) /= N ) THEN
-          CALL HCO_ERROR ( HcoConfig%Err, &
+          CALL HCO_ERROR ( &
              'SpecNames size error', RC, THISLOC=LOC )
           RETURN
        ENDIF
@@ -4430,13 +4430,13 @@ CONTAINS
 
        ! There must be at least 3 characters (e.g. xyz)
        IF ( strLen < 3 ) THEN
-          CALL HCO_ERROR ( HcoConfig%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR ( MSG, RC, THISLOC=LOC )
           RETURN
        ENDIF
 
        ! First two entries must be xy
        IF ( str1(1:2) /= 'xy' ) THEN
-          CALL HCO_ERROR ( HcoConfig%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR ( MSG, RC, THISLOC=LOC )
           RETURN
        ENDIF
 
@@ -4445,7 +4445,7 @@ CONTAINS
        ! emitted into level 4.
        IF ( str1(3:3) == 'L' .OR. str1(3:3) == 'l' ) THEN
           IF ( strLen < 4 ) THEN
-             CALL HCO_ERROR ( HcoConfig%Err, MSG, RC, THISLOC=LOC )
+             CALL HCO_ERROR ( MSG, RC, THISLOC=LOC )
              RETURN
           ENDIF
           Dta%SpaceDim = 2
@@ -4528,7 +4528,7 @@ CONTAINS
            // 'and contain the name/value pair, e.g. xyz+"ens"=3'
        idx = INDEX( TRIM(str2), '=' )
        IF ( idx <= 0 ) THEN
-          CALL HCO_ERROR( HcoConfig%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
           RETURN
        ENDIF
 
@@ -4622,7 +4622,7 @@ CONTAINS
        IF ( nModelSpecies > 0 ) THEN
           ALLOCATE ( HcoConfig%ModelSpc( nModelSpecies ), STAT=AS )
           IF ( AS /= 0 ) THEN
-             CALL HCO_ERROR( HcoConfig%Err, 'ModelSpecies', RC )
+             CALL HCO_ERROR( 'ModelSpecies', RC )
              RETURN
           ENDIF
 
@@ -4782,7 +4782,7 @@ CONTAINS
 
     IF ( Duplicate ) THEN
        MSG = 'Error: HEMCO field already exists:'//TRIM(cName)
-       CALL HCO_ERROR ( HcoConfig%Err, MSG, RC )
+       CALL HCO_ERROR ( MSG, RC )
        RETURN
     ENDIF
 
@@ -4856,7 +4856,7 @@ CONTAINS
     ! Exit with error if getting tag name but index not specified
     IF ( isTagName .AND. .NOT. isN ) THEN
        ErrMsg = 'Index must be specified if retrieving an individual tag name'
-       CALL HCO_ERROR( HcoConfig%Err, ErrMsg, RC )
+       CALL HCO_ERROR( ErrMsg, RC )
        RETURN
     ENDIF
 
@@ -4872,7 +4872,7 @@ CONTAINS
           FOUND = .FALSE.
           ErrMsg = 'Handling of tagId ' // TRIM(tagId) // &
                    ' is not implemented for getting number of tags'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC )
+          CALL HCO_Error( ErrMsg, RC )
           RETURN
     END SELECT
 
@@ -4890,7 +4890,7 @@ CONTAINS
     IF ( isTagName .AND. .NOT. isN ) THEN
        ErrMsg = 'Index must be greater than total number of tags for wildcard' &
                 // TRIM(tagId)
-       CALL HCO_Error( HcoConfig%Err, ErrMsg, RC )
+       CALL HCO_Error( ErrMsg, RC )
        RETURN
     ENDIF
 
@@ -4904,7 +4904,7 @@ CONTAINS
           FOUND = .FALSE.
           ErrMsg = 'Handling of tagId ' // TRIM( tagId ) // &
                    ' is not implemented for getting tag name'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC )
+          CALL HCO_Error( ErrMsg, RC )
           RETURN
     END SELECT
 

--- a/src/Core/hco_datacont_mod.F90
+++ b/src/Core/hco_datacont_mod.F90
@@ -565,7 +565,7 @@ CONTAINS
     ! Check input
     IF ( cID > HcoState%nnDataCont ) THEN
        MSG = 'cID higher than number of containers'
-       CALL HCO_ERROR ( HcoState%Config%Err, MSG, RC, THISLOC=LOC)
+       CALL HCO_ERROR ( MSG, RC, THISLOC=LOC)
        RETURN
     ENDIF
 
@@ -575,7 +575,7 @@ CONTAINS
     ! Check if data container allocated
     IF ( .NOT. ASSOCIATED( Dct ) ) THEN
        MSG = 'Data container is not associated!'
-       CALL HCO_ERROR ( HcoState%Config%Err, MSG, RC, THISLOC=LOC)
+       CALL HCO_ERROR ( MSG, RC, THISLOC=LOC)
        RETURN
     ENDIF
 

--- a/src/Core/hco_diagn_mod.F90
+++ b/src/Core/hco_diagn_mod.F90
@@ -874,7 +874,7 @@ CONTAINS
     IF ( .NOT. FOUND ) THEN
        WRITE(MSG,*) 'Cannot create diagnostics ', TRIM(cName), &
                     ' - collection does not exist: ', PS
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+       CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
        RETURN
     ENDIF
 
@@ -989,13 +989,13 @@ CONTAINS
        IF ( ThisDiagn%DtaIsPtr ) THEN
           MSG = 'Cannot use scale factor on diagnostics that '// &
                 'are pointers to other data: '//TRIM(cName)
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
           RETURN
        ENDIF
        IF ( TRIM(OutOper) == 'CumulSum' ) THEN
           MSG = 'Cannot use scale factor on diagnostics that '// &
                 'are cumulative sums: '//TRIM(cName)
-          CALL HCO_ERROR( HcoState%config%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
           RETURN
        ENDIF
        ThisDiagn%ScaleFact = ScaleFact
@@ -1030,7 +1030,7 @@ CONTAINS
              MSG = TRIM(MSG) // '. Allowed are `Mean`, `Sum`, '// &
                    '`CumulSum`, `Instantaneous`.'
              MSG = TRIM(MSG) // ' (' // TRIM(cName) // ')'
-             CALL HCO_ERROR( HcoState%config%Err, MSG, RC, THISLOC=LOC )
+             CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
              RETURN
           ENDIF
 
@@ -1098,7 +1098,7 @@ CONTAINS
           ! Error otherwise
           ELSE
              MSG = 'Cannot determine time normalization: '//TRIM(OutUnit)
-             CALL HCO_ERROR( HcoState%config%Err, MSG, RC, THISLOC=LOC )
+             CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
              RETURN
           ENDIF
        ENDIF ! OutOper not set
@@ -1111,7 +1111,7 @@ CONTAINS
                         Trim(ADJUSTL(cName)), -1, FOUND, TmpDiagn, COL=PS )
     IF ( FOUND ) THEN
 !       MSG = 'There is already a diagnostics with this name: ' // TRIM(cName)
-!       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+!       CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
 !       RETURN
        ThisDiagn%cName = trim(cName) // '_a'
        MSG = 'Changed Diagn name to ' // trim(ThisDiagn%cName)
@@ -1133,7 +1133,7 @@ CONTAINS
              WRITE(MSG,*) 'Diagnostics ', TRIM(TmpDiagn%cName), ' already has ID ', &
                 cID, ' - cannot create diagnostics ', TRIM(cName)
 
-             CALL HCO_ERROR( HcoState%config%Err, MSG, RC, THISLOC=LOC )
+             CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
              RETURN
           ENDIF
 
@@ -1929,7 +1929,7 @@ CONTAINS
              ELSEIF ( PRESENT(Array3D_HP) ) THEN
                 ALLOCATE( Arr3D(ThisColl%NX,ThisColl%NY,ThisColl%NZ),STAT=AS)
                 IF ( AS /= 0 ) THEN
-                   CALL HCO_ERROR( HcoState%Config%Err,&
+                   CALL HCO_ERROR( &
                                    'Allocation error Arr3D', RC, THISLOC=LOC )
                    RETURN
                 ENDIF
@@ -1937,7 +1937,7 @@ CONTAINS
              ELSEIF( PRESENT(Array3D) ) THEN
                 ALLOCATE( Arr3D(ThisColl%NX,ThisColl%NY,ThisColl%NZ),STAT=AS)
                 IF ( AS /= 0 ) THEN
-                   CALL HCO_ERROR( HcoState%Config%Err,&
+                   CALL HCO_ERROR( &
                                    'Allocation error Arr3D', RC, THISLOC=LOC )
                    RETURN
                 ENDIF
@@ -1950,7 +1950,7 @@ CONTAINS
              ELSEIF ( PRESENT(Array2D_HP) ) THEN
                 ALLOCATE( Arr2D(ThisColl%NX,ThisColl%NY),STAT=AS)
                 IF ( AS /= 0 ) THEN
-                   CALL HCO_ERROR( HcoState%Config%Err,&
+                   CALL HCO_ERROR( &
                                    'Allocation error Arr2D', RC, THISLOC=LOC )
                    RETURN
                 ENDIF
@@ -1958,7 +1958,7 @@ CONTAINS
              ELSEIF( PRESENT(Array2D) ) THEN
                 ALLOCATE( Arr2D(ThisColl%NX,ThisColl%NY),STAT=AS)
                 IF ( AS /= 0 ) THEN
-                   CALL HCO_ERROR( HcoState%Config%Err,&
+                   CALL HCO_ERROR( &
                                    'Allocation error Arr2D', RC, THISLOC=LOC )
                    RETURN
                 ENDIF
@@ -2056,7 +2056,7 @@ CONTAINS
                    ENDIF
                 ELSE
                    MSG = 'No array passed for updating ' // TRIM(ThisDiagn%cName)
-                   CALL HCO_ERROR ( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+                   CALL HCO_ERROR ( MSG, RC, THISLOC=LOC )
                    RETURN
                 ENDIF
 
@@ -3005,7 +3005,7 @@ CONTAINS
     IF ( .NOT. FOUND .OR. .NOT. ASSOCIATED(ThisColl) ) THEN
        WRITE(MSG,*) 'Diagnostics ', TRIM(DgnCont%cName), ' has invalid ', &
                     'collection ID of ', DgnCont%CollectionID
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+       CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
        RETURN
     ENDIF
 
@@ -3105,7 +3105,7 @@ CONTAINS
        ELSE
           WRITE(MSG,*) 'Illegal time averaging of ', DgnCont%TimeAvg, &
                        ' for diagnostics ', TRIM(DgnCont%cName)
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
           RETURN
        ENDIF
 
@@ -3114,7 +3114,7 @@ CONTAINS
     ! Error trap
     IF ( norm1 <= 0.0_hp ) THEN
        MSG = 'Illegal normalization factor: ' // TRIM(DgnCont%cName)
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+       CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
        RETURN
     ENDIF
 
@@ -3430,7 +3430,7 @@ CONTAINS
     IF ( DgnCont%SpaceDim /= 2 ) THEN
        MSG = 'Diagnostics is not 2D: ' // TRIM(DgnCont%cName)
        IF ( PRESENT(HcoState) ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
        ELSE
           CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
        ENDIF
@@ -3441,7 +3441,7 @@ CONTAINS
          SIZE(Trgt2D,2) /= ThisColl%NY       ) THEN
        MSG = 'Incorrect target array size: ' // TRIM(DgnCont%cName)
        IF ( PRESENT(HcoState) ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
        ELSE
           CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
        ENDIF
@@ -3521,7 +3521,7 @@ CONTAINS
     IF ( DgnCont%AutoFill == 1 ) THEN
        MSG = 'Cannot link AutoFill container: ' // TRIM(DgnCont%cName)
        IF ( PRESENT(HcoState) ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
        ELSE
           CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
        ENDIF
@@ -3540,7 +3540,7 @@ CONTAINS
     IF ( DgnCont%SpaceDim /= 3 ) THEN
        MSG = 'Diagnostics is not 3D: ' // TRIM(DgnCont%cName)
        IF ( PRESENT(HcoState) ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
        ELSE
           CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
        ENDIF
@@ -3553,7 +3553,7 @@ CONTAINS
          SIZE(Trgt3D,3) /= ThisColl%NZ       ) THEN
        MSG = 'Incorrect target array size: ' // TRIM(DgnCont%cName)
        IF ( PRESENT(HcoState) ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
        ELSE
           CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
        ENDIF
@@ -3795,7 +3795,7 @@ CONTAINS
              'stamp of ', OutTimeStamp, ' is invalid, must be one of: ', &
              HcoDiagnStart, HcoDiagnMid, HcoDiagnEnd
           IF ( PRESENT(HcoState) ) THEN
-             CALL HCO_ERROR(HcoState%Config%Err,MSG,RC,THISLOC=LOC)
+             CALL HCO_ERROR(MSG,RC,THISLOC=LOC)
           ELSE
              CALL HCO_ERROR(MSG,RC,THISLOC=LOC)
           ENDIF
@@ -3960,7 +3960,7 @@ CONTAINS
        ELSE
           WRITE(MSG,*) 'Not allowed to select all collections ', PS
           IF ( PRESENT(HcoState) ) THEN
-             CALL HCO_ERROR ( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+             CALL HCO_ERROR ( MSG, RC, THISLOC=LOC )
           ELSE
              CALL HCO_ERROR ( MSG, RC, THISLOC=LOC )
           ENDIF
@@ -3981,7 +3981,7 @@ CONTAINS
        ELSEIF ( .NOT. FOUND ) THEN
           WRITE(MSG,*) 'Diagnostics collection not defined: ', PS
           IF ( PRESENT(HcoState) ) THEN
-             CALL HCO_ERROR ( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+             CALL HCO_ERROR ( MSG, RC, THISLOC=LOC )
           ELSE
              CALL HCO_ERROR ( MSG, RC, THISLOC=LOC )
           ENDIF
@@ -4176,7 +4176,7 @@ CONTAINS
                 TRIM(WriteFreq) // '. The output frequency must be one of '  // &
                 '`Hourly`, `Daily`, `Monthly`, `Annually`, `Always`, `End`,' // &
                 ' or the explicit YYYYMMDD HHMMSS interval (15 characters).'
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC)
+          CALL HCO_ERROR( MSG, RC, THISLOC=LOC)
           RETURN
        ENDIF
 
@@ -4409,7 +4409,7 @@ CONTAINS
     ! Trap potential errors
     IF ( RC /= HCO_SUCCESS ) THEN
        MSG = 'Could not find "DiagnFile" in configuration file!'
-       CALL HCO_Error( HcoConfig%Err, MSG, RC, LOC )
+       CALL HCO_Error( MSG, RC, LOC )
        RETURN
     ENDIF
 
@@ -4449,7 +4449,7 @@ CONTAINS
        ! If the diagnostics file doesn't exist, then exit
        IF ( .NOT. EXISTS ) THEN
           MSG = 'Cannot read file - it does not exist: ' // TRIM(DiagnFile)
-          CALL HCO_ERROR( HcoConfig%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
           RETURN
        ENDIF
 
@@ -4457,7 +4457,7 @@ CONTAINS
        OPEN ( LUN, FILE=TRIM( DiagnFile ), STATUS='OLD', IOSTAT=IOS )
        IF ( IOS /= 0 ) THEN
           MSG = 'Error opening ' // TRIM(DiagnFile)
-          CALL HCO_ERROR( HcoConfig%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
           RETURN
        ENDIF
 
@@ -4558,7 +4558,7 @@ CONTAINS
        ! There must be at least 7 entries
        IF ( N < 7 ) THEN
           MSG = 'Diagnostics entries must have 7 elements: '// TRIM(LINE)
-          CALL HCO_ERROR( HcoConfig%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
           RETURN
        ENDIF
 

--- a/src/Core/hco_emislist_mod.F90
+++ b/src/Core/hco_emislist_mod.F90
@@ -498,7 +498,7 @@ CONTAINS
        IF ( .NOT. FOUND ) THEN
           MSG = 'Cannot add emissions to target array: error in ' // &
                TRIM(Lct%Dct%cName)
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+          CALL HCO_ERROR( MSG, RC )
           RETURN
        ENDIF
 
@@ -533,33 +533,33 @@ CONTAINS
           ! Check extension number
           IF ( Lct%Dct%ExtNr /= TargetLct%Dct%ExtNr ) THEN
              MSG = 'Wrong ext. number: ' // TRIM(Lct%Dct%cName)
-             CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+             CALL HCO_ERROR( MSG, RC )
              RETURN
           ENDIF
 
           ! Check data type
           IF ( Lct%Dct%DctType /= TargetLct%Dct%DctType ) THEN
              MSG = 'Wrong data type: ' // TRIM(Lct%Dct%cName)
-             CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+             CALL HCO_ERROR( MSG, RC )
              RETURN
           ENDIF
 
           ! Check species ID
           IF ( Lct%Dct%HcoID /= TargetLct%Dct%HcoID ) THEN
              MSG = 'Wrong species ID: ' // TRIM(Lct%Dct%cName)
-             CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+             CALL HCO_ERROR( MSG, RC )
              RETURN
           ENDIF
 
           ! Check for array dimensions
           IF ( Lct%Dct%Dta%SpaceDim /= TargetLct%Dct%Dta%SpaceDim ) THEN
              MSG = 'Wrong space dimension: ' // TRIM(Lct%Dct%cName)
-             CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+             CALL HCO_ERROR( MSG, RC )
              RETURN
           ENDIF
           IF ( Lct%Dct%Dta%nt /= TargetLct%Dct%Dta%nt ) THEN
              MSG = 'Wrong time dim: ' // TRIM(Lct%Dct%cName)
-             CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+             CALL HCO_ERROR( MSG, RC )
              RETURN
           ENDIF
           IF ( Lct%Dct%Dta%SpaceDim <= 2) THEN
@@ -590,21 +590,21 @@ CONTAINS
           ! Check operator
           IF ( Lct%Dct%Oper /= TargetLct%Dct%Oper ) THEN
              MSG = 'Wrong operator: ' // TRIM(Lct%Dct%cName)
-             CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+             CALL HCO_ERROR( MSG, RC )
              RETURN
           ENDIF
 
           ! Check category
           IF ( Lct%Dct%Cat /= TargetLct%Dct%Cat ) THEN
              MSG = 'Wrong category: ' // TRIM(Lct%Dct%cName)
-             CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+             CALL HCO_ERROR( MSG, RC )
              RETURN
           ENDIF
 
           ! Check hierarchy
           IF ( Lct%Dct%Hier /= TargetLct%Dct%Hier ) THEN
              MSG = 'Wrong hierarchy: ' // TRIM(Lct%Dct%cName)
-             CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+             CALL HCO_ERROR( MSG, RC )
              RETURN
           ENDIF
 
@@ -613,7 +613,7 @@ CONTAINS
                Lct%Dct%Oper    == 3                       ) THEN
              MSG = 'Cannot add masks if operator is 3: ' // &
                   TRIM(Lct%Dct%cName)
-             CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+             CALL HCO_ERROR( MSG, RC )
              RETURN
           ENDIF
 
@@ -763,7 +763,7 @@ CONTAINS
           RETURN
        ELSE
           MSG = 'Container not found: ' // TRIM(DctName)
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
           RETURN
        ENDIF
     ENDIF
@@ -771,14 +771,14 @@ CONTAINS
     ! Check spatial dimension
     IF ( Lct%Dct%Dta%SpaceDim /= 3 ) THEN
        MSG = 'Container is not 3D: ' // TRIM(DctName)
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+       CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
        RETURN
     ENDIF
 
     ! Check time dimension
     IF ( Lct%Dct%Dta%nt < T ) THEN
        MSG = 'not enough time slices: ' // TRIM(DctName)
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+       CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
        RETURN
     ENDIF
 
@@ -790,7 +790,7 @@ CONTAINS
           Ptr3D  => NULL()
        ELSE
           MSG = 'Container data not filled: ' // TRIM(DctName)
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
           RETURN
        ENDIF
     ENDIF
@@ -886,7 +886,7 @@ CONTAINS
           RETURN
        ELSE
           MSG = 'Container not found: ' // TRIM(DctName)
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
           RETURN
        ENDIF
     ENDIF
@@ -895,14 +895,14 @@ CONTAINS
     IF ( (Lct%Dct%Dta%SpaceDim/=2) .AND. &
          (Lct%Dct%Dta%SpaceDim/=1)        ) THEN
        MSG = 'Container is not 2D: ' // TRIM(DctName)
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+       CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
        RETURN
     ENDIF
 
     ! Check time dimension
     IF ( Lct%Dct%Dta%nt < T ) THEN
        MSG = 'not enough time slices: ' // TRIM(DctName)
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+       CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
        RETURN
     ENDIF
 
@@ -914,7 +914,7 @@ CONTAINS
           Ptr2D  => NULL()
        ELSE
           MSG = 'Container data not filled: ' // TRIM(DctName)
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
           RETURN
        ENDIF
     ENDIF

--- a/src/Core/hco_extlist_mod.F90
+++ b/src/Core/hco_extlist_mod.F90
@@ -184,7 +184,7 @@ CONTAINS
        IF ( OrigExtNr /= ExtNr ) THEN
           WRITE(MSG,*) 'Cannot create extension - extension already exists', &
                        TRIM(lcName), ExtNr, OrigExtNr
-          CALL HCO_ERROR(HcoConfig%Err,MSG,RC,THISLOC='AddExt (hco_extlist_mod.F90)')
+          CALL HCO_ERROR(MSG,RC,THISLOC='AddExt (hco_extlist_mod.F90)')
           RETURN
 
        ! Nothing to do otherwise
@@ -306,7 +306,7 @@ CONTAINS
     IF ( IDX <= 0 ) THEN
        MSG = 'Cannot extract option name/value pair - these must be ' // &
              'separated by a colon (:) character: ' // TRIM(Opt)
-       CALL HCO_ERROR(HcoConfig%Err,MSG,RC,THISLOC='AddExtOpt (hco_extlist_mod)')
+       CALL HCO_ERROR(MSG,RC,THISLOC='AddExtOpt (hco_extlist_mod)')
        RETURN
     ENDIF
 
@@ -414,7 +414,7 @@ CONTAINS
     ELSEIF ( .NOT. OptFound ) THEN
        WRITE(MSG,*) '(A) Cannot find option ', TRIM(OptName),  &
        ' in extension ', ExtNr
-       CALL HCO_ERROR(HcoConfig%Err,MSG,RC,THISLOC=LOC )
+       CALL HCO_ERROR(MSG,RC,THISLOC=LOC )
        RETURN
     ENDIF
 
@@ -605,7 +605,7 @@ CONTAINS
 
     IF ( .NOT. ASSOCIATED( ThisExt ) ) THEN
        WRITE(MSG,*) 'Cannot find extension Nr. ', ExtNr
-       CALL HCO_ERROR( HcoConfig%Err, MSG, RC, THISLOC=LOC )
+       CALL HCO_ERROR(  MSG, RC, THISLOC=LOC )
        RETURN
     ENDIF
 
@@ -1190,7 +1190,7 @@ CONTAINS
           IF ( TRIM(DUM) /= ADJUSTL(TRIM(OptValue)) ) THEN
              MSG = 'Cannot add option pair: '//TRIM(OptName)//': '//TRIM(OptValue) &
                 // ' - option already exists: '//TRIM(OptName)//': '//TRIM(DUM)
-             CALL HCO_ERROR ( HcoConfig%Err, MSG, RC, THISLOC=LOC )
+             CALL HCO_ERROR (  MSG, RC, THISLOC=LOC )
              RETURN
           ! Return with no error if values are the same
           ELSE
@@ -1210,7 +1210,7 @@ CONTAINS
     IF ( .NOT. ASSOCIATED( ThisExt ) ) THEN
        WRITE(MSG,*) 'Cannot add option to extension Nr. ', ExtNr
        MSG = TRIM(MSG) // '. Make sure this extension is activated!'
-       CALL HCO_ERROR(HcoConfig%Err,MSG,RC,THISLOC='AddOpt (hco_extlist_mod)')
+       CALL HCO_ERROR(MSG,RC,THISLOC='AddOpt (hco_extlist_mod)')
        RETURN
     ENDIF
 

--- a/src/Core/hco_filedata_mod.F90
+++ b/src/Core/hco_filedata_mod.F90
@@ -317,7 +317,7 @@ CONTAINS
             ( SIZE(FileDta%V2(1)%Val,1) /= nx ) .OR. &
             ( SIZE(FileDta%V2(1)%Val,2) /= ny )       ) THEN
           MSG = 'Wrong dimensions: ' // TRIM(FileDta%ncFile)
-          CALL HCO_ERROR ( HcoConfig%Err, MSG, RC )
+          CALL HCO_ERROR ( MSG, RC )
        ENDIF
        RETURN
     ENDIF
@@ -387,7 +387,7 @@ CONTAINS
             ( SIZE(FileDta%V3(1)%Val,2) /= ny ) .OR. &
             ( SIZE(FileDta%V3(1)%Val,3) /= nz )       ) THEN
           MSG = 'Wrong dimensions: ' // TRIM(FileDta%ncFile)
-          CALL HCO_ERROR ( HcoConfig%Err, MSG, RC )
+          CALL HCO_ERROR ( MSG, RC )
        ENDIF
        RETURN
     ENDIF

--- a/src/Core/hco_fluxarr_mod.F90
+++ b/src/Core/hco_fluxarr_mod.F90
@@ -213,7 +213,7 @@ CONTAINS
 
           ! Negative flag is 0: return w/ error
           ELSE
-             CALL HCO_ERROR ( HcoState%Config%Err, &
+             CALL HCO_ERROR ( &
                 'Negative values found!', &
                 RC, THISLOC = 'HCO_EmisAdd (HCO_FLUXARR_MOD.F90)' )
              RETURN
@@ -306,7 +306,7 @@ CONTAINS
 
           ! Negative flag is 0: return w/ error
           ELSE
-             CALL HCO_ERROR ( HcoState%Config%Err, &
+             CALL HCO_ERROR ( &
                'Negative values found!', &
                 RC, THISLOC = 'HCO_EmisAdd (HCO_FLUXARR_MOD.F90)' )
              RETURN
@@ -397,7 +397,7 @@ CONTAINS
 
           ! Negative flag is 0: return w/ error
           ELSE
-             CALL HCO_ERROR ( HcoState%Config%Err, &
+             CALL HCO_ERROR ( &
                'Negative values found!', &
                 RC, THISLOC = 'HCO_EmisAdd (HCO_FLUXARR_MOD.F90)' )
              RETURN
@@ -489,7 +489,7 @@ CONTAINS
 
           ! Negative flag is 0: return w/ error
           ELSE
-             CALL HCO_ERROR ( HcoState%Config%Err, &
+             CALL HCO_ERROR ( &
                'Negative values found!', &
                 RC, THISLOC = 'HCO_EmisAdd (HCO_FLUXARR_MOD.F90)' )
              RETURN
@@ -593,7 +593,7 @@ CONTAINS
 
           ! Negative flag is 0: return w/ error
           ELSE
-             CALL HCO_ERROR ( HcoState%Config%Err, &
+             CALL HCO_ERROR ( &
                'Negative values found!', &
                 RC, THISLOC = 'HCO_EmisAdd (HCO_FLUXARR_MOD.F90)' )
              RETURN
@@ -691,7 +691,7 @@ CONTAINS
 
           ! Negative flag is 0: return w/ error
           ELSE
-             CALL HCO_ERROR ( HcoState%Config%Err, &
+             CALL HCO_ERROR ( &
                'Negative values found!', &
                 RC, THISLOC = 'HCO_EmisAdd (HCO_FLUXARR_MOD.F90)' )
              RETURN
@@ -856,12 +856,12 @@ CONTAINS
     ! Check size dimensions
     IF ( I > HcoState%NX ) THEN
        MSG = 'Cannot add DP - i too high!'
-       CALL HCO_ERROR ( HcoState%Config%Err, MSG, RC )
+       CALL HCO_ERROR ( MSG, RC )
        RETURN
     ENDIF
     IF ( J > HcoState%NY ) THEN
        MSG = 'Cannot add DP - j too high!'
-       CALL HCO_ERROR ( HcoState%Config%Err, MSG, RC )
+       CALL HCO_ERROR ( MSG, RC )
        RETURN
     ENDIF
 
@@ -922,12 +922,12 @@ CONTAINS
     ! Check size dimensions
     IF ( I > HcoState%NX ) THEN
        MSG = 'Cannot add iVal - i too high!'
-       CALL HCO_ERROR ( HcoState%Config%Err, MSG, RC )
+       CALL HCO_ERROR ( MSG, RC )
        RETURN
     ENDIF
     IF ( J > HcoState%NY ) THEN
        MSG = 'Cannot add iVal - j too high!'
-       CALL HCO_ERROR ( HcoState%Config%Err, MSG, RC )
+       CALL HCO_ERROR ( MSG, RC )
        RETURN
     ENDIF
 

--- a/src/Core/hco_geotools_mod.F90
+++ b/src/Core/hco_geotools_mod.F90
@@ -248,7 +248,7 @@ CONTAINS
        ! Exit w/ error after 10 iterations
        CNT = CNT + 1
        IF ( CNT > MAXIT ) THEN
-          CALL HCO_ERROR ( HcoState%Config%Err, '>10 iterations', RC, &
+          CALL HCO_ERROR ( '>10 iterations', RC, &
                            THISLOC='HCO_ValidateLon (HCO_GEOTOOLS_MOD.F90)' )
           RETURN
        ENDIF
@@ -330,7 +330,7 @@ CONTAINS
        ! Exit w/ error after 10 iterations
        CNT = CNT + 1
        IF ( CNT > MAXIT ) THEN
-          CALL HCO_ERROR ( HcoState%Config%Err, '>10 iterations', RC, &
+          CALL HCO_ERROR ( '>10 iterations', RC, &
                            THISLOC='HCO_ValidateLon (HCO_GEOTOOLS_MOD.F90)' )
           RETURN
        ENDIF
@@ -524,7 +524,7 @@ CONTAINS
 
     ! Check error status
     IF ( ERR ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, &
+       CALL HCO_ERROR ( &
          'Cannot calculate SZA', RC, &
           THISLOC='HCO_GetSUNCOS (hco_geotools_mod.F90)' )
        RETURN
@@ -850,7 +850,7 @@ CONTAINS
             NZ /= HcoState%NZ ) THEN
           WRITE(MSG,*) 'Wrong TK array size: ', NX, NY, NZ, &
                        '; should be: ', HcoState%NX, HcoState%NY, HcoState%NZ
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
           RETURN
        ENDIF
 
@@ -904,7 +904,7 @@ CONTAINS
        IF ( NX /= HcoState%NX .OR. NY /= HcoState%NY ) THEN
           WRITE(MSG,*) 'Wrong PSFC array size: ', NX, NY, &
                        '; should be: ', HcoState%NX, HcoState%NY
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
           RETURN
        ENDIF
 
@@ -959,7 +959,7 @@ CONTAINS
        IF ( NX /= HcoState%NX .OR. NY /= HcoState%NY ) THEN
           WRITE(MSG,*) 'Wrong ZSFC array size: ', NX, NY, &
                        '; should be: ', HcoState%NX, HcoState%NY
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
           RETURN
        ENDIF
 
@@ -1007,7 +1007,7 @@ CONTAINS
             NZ /= (HcoState%NZ + 1) ) THEN
           WRITE(MSG,*) 'Wrong PEDGE array size: ', NX, NY, NZ, &
                        '; should be: ', HcoState%NX, HcoState%NY, HcoState%NZ+1
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
           RETURN
        ENDIF
 
@@ -1054,7 +1054,7 @@ CONTAINS
             NZ /= HcoState%NZ ) THEN
           WRITE(MSG,*) 'Wrong BXHEIGHT array size: ', NX, NY, NZ, &
                        '; should be: ', HcoState%NX, HcoState%NY, HcoState%NZ
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
           RETURN
        ENDIF
 
@@ -1221,7 +1221,7 @@ CONTAINS
                    'surface pressure value is zero! You can either provide an '    // &
                    'updated pressure edge field (PEDGE) or add a field with the '  // &
                    'surface geopotential height to your configuration file (ZSFC)'
-             CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+             CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
              RETURN
           ELSE
              FoundZSFC = .TRUE.
@@ -1239,7 +1239,7 @@ CONTAINS
                    'pressure value is zero! You can either provide an '    // &
                    'updated pressure edge field (PEDGE) or add a field with the '  // &
                    'grid box heights to your configuration file (BOXHEIGHT_M)'
-             CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+             CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
              RETURN
           ELSE
              FoundZSFC = .TRUE.
@@ -1377,7 +1377,7 @@ CONTAINS
              IF ( NX /= HcoState%NX .OR. NY /= HcoState%NY ) THEN
                 WRITE(MSG,*) 'Wrong PBLM array size: ', NX, NY, &
                              '; should be: ', HcoState%NX, HcoState%NY
-                CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+                CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
                 RETURN
              ENDIF
 
@@ -1419,7 +1419,7 @@ CONTAINS
     IF ( .NOT. FOUND ) THEN
        WRITE(MSG,*) 'Cannot set PBL height: a valid HEMCO data field, ', &
           'an explicit 2D field or a default value must be provided!'
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+       CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
        RETURN
     ENDIF
 
@@ -1479,7 +1479,7 @@ CONTAINS
 !         SIZE(PBLFRAC,3) /= HcoState%NZ        ) THEN
 !       WRITE(MSG,*) 'Input array PBLFRAC has wrong horiz. dimensions: ', &
 !                     SIZE(PBLFRAC,1),SIZE(PBLFRAC,2),SIZE(PBLFRAC,3)
-!       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+!       CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
 !       RETURN
 !    ENDIF
 !
@@ -1564,7 +1564,7 @@ CONTAINS
 !    IF ( SIZE(PBLlev,1) /= HcoState%NX .OR. SIZE(PBLlev,2) /= HcoState%NY ) THEN
 !       WRITE(MSG,*) 'Input array PBLlev has wrong horiz. dimensions: ', &
 !              SIZE(PBLlev,1),SIZE(PBLlev,2)
-!       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+!       CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
 !       RETURN
 !    ENDIF
 !

--- a/src/Core/hco_interp_mod.F90
+++ b/src/Core/hco_interp_mod.F90
@@ -680,13 +680,13 @@ CONTAINS
     IF ( SIZE(REGR_4D,1) /= nx ) THEN
        WRITE(MSG,*) 'x dimension mismatch ', TRIM(Lct%Dct%cName), &
           ': ', nx, SIZE(REGR_4D,1)
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+       CALL HCO_ERROR( MSG, RC )
        RETURN
     ENDIF
     IF ( SIZE(REGR_4D,2) /= ny ) THEN
        WRITE(MSG,*) 'y dimension mismatch ', TRIM(Lct%Dct%cName), &
           ': ', ny, SIZE(REGR_4D,2)
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+       CALL HCO_ERROR( MSG, RC )
        RETURN
     ENDIF
 
@@ -809,7 +809,7 @@ CONTAINS
           ELSEIF ( nlev > 47 ) THEN
              MSG = 'Can only remap from native onto reduced GEOS-5 if '// &
                    'input data has exactly 72 or 73 levels: '//TRIM(Lct%Dct%cName)
-             CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+             CALL HCO_ERROR( MSG, RC )
              RETURN
           ELSE
              nout = nlev
@@ -974,7 +974,7 @@ CONTAINS
        ENDIF
     ELSE
        WRITE(MSG,*) 'Vertical regridding failed: ',TRIM(Lct%Dct%cName)
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+       CALL HCO_ERROR( MSG, RC )
        RETURN
     ENDIF
 
@@ -1050,7 +1050,7 @@ CONTAINS
     ! Check number of levels to be used
     IF ( NZ /= 28 .AND. NZ /= 29 ) THEN
        MSG = 'Cannot map GEOS-5 onto GEOS-4 data, number of levels must be 28 or 29: '//TRIM(Lct%Dct%cName)
-       CALL HCO_ERROR ( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+       CALL HCO_ERROR ( MSG, RC, THISLOC=LOC )
        RETURN
     ENDIF
 
@@ -1058,7 +1058,7 @@ CONTAINS
     IF ( SIZE(REGR_4D,3) < NZ ) THEN
        WRITE(MSG,*) 'Cannot map GEOS-5 onto GEOS-4 data, original data has not enough levels: ', &
           TRIM(Lct%Dct%cName), ' --> ', SIZE(REGR_4D,3), ' smaller than ', NZ
-       CALL HCO_ERROR ( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+       CALL HCO_ERROR ( MSG, RC, THISLOC=LOC )
        RETURN
     ENDIF
 

--- a/src/Core/hco_readlist_mod.F90
+++ b/src/Core/hco_readlist_mod.F90
@@ -261,7 +261,7 @@ CONTAINS
                     'ReadList_Read (hco_readlist_mod.F90)', RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        MSG = 'Error in HCO_ENTER called from HEMCO ReadList_Read'
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC = LOC )
+       CALL HCO_ERROR( MSG, RC, THISLOC = LOC )
        RETURN
     ENDIF
 
@@ -285,7 +285,7 @@ CONTAINS
        CALL ReadList_Fill( HcoState, HcoState%ReadLists%Once, RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           MSG = 'Error in ReadList_Fill (1) called from HEMCO ReadList_Read'
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC = LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC = LOC )
           RETURN
        ENDIF
     ENDIF
@@ -299,7 +299,7 @@ CONTAINS
        CALL ReadList_Fill( HcoState, HcoState%ReadLists%Year, RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           MSG = 'Error in ReadList_Fill (2) called from HEMCO ReadList_Read'
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC = LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC = LOC )
           RETURN
        ENDIF
     ENDIF
@@ -313,7 +313,7 @@ CONTAINS
        CALL ReadList_Fill( HcoState, HcoState%ReadLists%Month, RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           MSG = 'Error in ReadList_Fill (3) called from HEMCO ReadList_Read'
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC = LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC = LOC )
           RETURN
        ENDIF
     ENDIF
@@ -327,7 +327,7 @@ CONTAINS
        CALL ReadList_Fill( HcoState, HcoState%ReadLists%Day, RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           MSG = 'Error in ReadList_Fill (4) called from HEMCO ReadList_Read'
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC = LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC = LOC )
           RETURN
        ENDIF
     ENDIF
@@ -341,7 +341,7 @@ CONTAINS
        CALL ReadList_Fill( HcoState, HcoState%ReadLists%Hour, RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           MSG = 'Error in ReadList_Fill (5) called from HEMCO ReadList_Read'
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC = LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC = LOC )
           RETURN
        ENDIF
     ENDIF
@@ -355,7 +355,7 @@ CONTAINS
        CALL ReadList_Fill( HcoState, HcoState%ReadLists%Hour3, RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           MSG = 'Error in ReadList_Fill (6) called from HEMCO ReadList_Read'
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC = LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC = LOC )
           RETURN
        ENDIF
     ENDIF
@@ -368,7 +368,7 @@ CONTAINS
     CALL ReadList_Fill( HcoState, HcoState%ReadLists%Always, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        MSG = 'Error in called ReadList_Fill (7) from HEMCO ReadList_Read'
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC = LOC )
+       CALL HCO_ERROR( MSG, RC, THISLOC = LOC )
        RETURN
     ENDIF
 
@@ -450,7 +450,7 @@ CONTAINS
                    'ReadList_Fill (hco_readlist_mod.F90)', RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        MSG = 'Error in HCO_ENTER called from HEMCO ReadList_Fill'
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC = LOC )
+       CALL HCO_ERROR( MSG, RC, THISLOC = LOC )
        RETURN
     ENDIF
 
@@ -489,7 +489,7 @@ CONTAINS
              CALL HCOIO_ReadOther( HcoState, Lct, RC )
              IF ( RC /= HCO_SUCCESS ) THEN
                 MSG = 'Error in HCOIO_ReadOther called from HEMCO ReadList_Fill: ' // TRIM(Lct%Dct%cname)
-                CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC = LOC )
+                CALL HCO_ERROR( MSG, RC, THISLOC = LOC )
                 RETURN
              ENDIF
 
@@ -500,7 +500,7 @@ CONTAINS
              CALL HCOIO_DATAREAD( HcoState, Lct, RC )
              IF ( RC /= HCO_SUCCESS ) THEN
                 MSG = 'Error in HCOIO_DATAREAD called from HEMCO ReadList_Fill: ' // TRIM(Lct%Dct%cname)
-                CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC = LOC )
+                CALL HCO_ERROR( MSG, RC, THISLOC = LOC )
                 RETURN
              ENDIF
           ENDIF
@@ -523,7 +523,7 @@ CONTAINS
           CALL tIDx_Assign ( HcoState, Lct%Dct, RC )
           IF ( RC /= HCO_SUCCESS ) THEN
              MSG = 'Error in tIDx_Assign called from HEMCO ReadList_Fill: ' // TRIM(Lct%Dct%cname)
-             CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC = LOC )
+             CALL HCO_ERROR( MSG, RC, THISLOC = LOC )
              RETURN
           ENDIF
 
@@ -531,7 +531,7 @@ CONTAINS
           CALL EmisList_Pass( HcoState, Lct, RC )
           IF ( RC /= HCO_SUCCESS ) THEN
              MSG = 'Error in EmisList_Pass called from HEMCO ReadList_Fill: ' // TRIM(Lct%Dct%cname)
-             CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC = LOC )
+             CALL HCO_ERROR( MSG, RC, THISLOC = LOC )
              RETURN
           ENDIF
 
@@ -545,7 +545,7 @@ CONTAINS
     CALL HCOIO_CloseAll ( HcoState, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        MSG = 'Error in HCOIO_CloseAll called from HEMCO ReadList_Fill: ' // TRIM(Lct%Dct%cname)
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC = LOC )
+       CALL HCO_ERROR( MSG, RC, THISLOC = LOC )
        RETURN
     ENDIF
 
@@ -912,7 +912,7 @@ CONTAINS
        IF ( This%Dct%DtaHome >= 0 ) THEN
           MSG = 'Cannot remove from ReadList. Data has already been read: ' // &
                 TRIM(This%Dct%cName)
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC = LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC = LOC )
        ENDIF
 
        ! Connect previous container to next container in list:

--- a/src/Core/hco_state_mod.F90
+++ b/src/Core/hco_state_mod.F90
@@ -211,7 +211,7 @@ CONTAINS
     IF ( nSpecies > 0 ) THEN
        ALLOCATE ( HcoState%Spc (nSpecies ), STAT=AS )
        IF ( AS /= 0 ) THEN
-          CALL HCO_ERROR( HcoConfig%Err, 'Species', RC )
+          CALL HCO_ERROR( 'Species', RC )
           RETURN
        ENDIF
     ENDIF
@@ -252,7 +252,7 @@ CONTAINS
     HcoState%NZ   = 0
     ALLOCATE ( HcoState%Grid, STAT = AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoConfig%Err, 'HEMCO grid', RC )
+       CALL HCO_ERROR( 'HEMCO grid', RC )
        RETURN
     ENDIF
 
@@ -292,7 +292,7 @@ CONTAINS
     ! Physical constants (Source: NIST, 2014)
     ALLOCATE ( HcoState%Phys, STAT = AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoConfig%Err, 'HEMCO physical constants', RC )
+       CALL HCO_ERROR( 'HEMCO physical constants', RC )
        RETURN
     ENDIF
     HcoState%Phys%Avgdr  = 6.022140857e23_dp
@@ -329,7 +329,7 @@ CONTAINS
     ! Aerosol options
     ALLOCATE ( HcoState%MicroPhys, STAT = AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoConfig%Err, 'HEMCO aerosol microphysics options', RC )
+       CALL HCO_ERROR( 'HEMCO aerosol microphysics options', RC )
        RETURN
     ENDIF
     HcoState%MicroPhys%nBins           = 0
@@ -738,7 +738,7 @@ CONTAINS
     HcoIDs(:)   = -1
 #endif
     IF ( AS/=0 ) THEN
-       CALL HCO_ERROR(HcoState%Config%Err,'HcoIDs allocation error', RC, THISLOC=LOC)
+       CALL HCO_ERROR('HcoIDs allocation error', RC, THISLOC=LOC)
        RETURN
     ENDIF
 

--- a/src/Core/hco_tidx_mod.F90
+++ b/src/Core/hco_tidx_mod.F90
@@ -532,7 +532,7 @@ CONTAINS
           IF ( dt /= 24 ) THEN
              MSG = '7 time slices but delta t is not 24 hours!' // &
                   TRIM(Dct%cName)
-             CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+             CALL HCO_ERROR( MSG, RC )
              RETURN
           ENDIF
 
@@ -545,7 +545,7 @@ CONTAINS
           IF ( .NOT. Dct%Dta%IsLocTime ) THEN
              MSG = 'Weekday data must be in local time!' // &
                   TRIM(Dct%cName)
-             CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+             CALL HCO_ERROR( MSG, RC )
              RETURN
 
           ELSE
@@ -564,7 +564,7 @@ CONTAINS
           ELSE
              MSG = 'Monthly data must not be gridded:' // &
                   TRIM(Dct%cName)
-             CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+             CALL HCO_ERROR( MSG, RC )
              RETURN
           ENDIF
 
@@ -581,7 +581,7 @@ CONTAINS
           IF ( MOD(24,dt) /= 0 ) THEN
              MSG = 'Cannot properly split up hourly data!' // &
                   TRIM(Dct%cName)
-             CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+             CALL HCO_ERROR( MSG, RC )
              RETURN
           ENDIF
 
@@ -590,7 +590,7 @@ CONTAINS
           IF ( ntexp /= nt ) THEN
              MSG = 'Wrong delta t and/or number of time slices!' // &
                   TRIM(Dct%cName)
-             CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+             CALL HCO_ERROR( MSG, RC )
              RETURN
           ENDIF
 
@@ -610,7 +610,7 @@ CONTAINS
        ELSE
           MSG = 'Invalid time slice for field ' // &
                TRIM(Dct%cName)
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+          CALL HCO_ERROR( MSG, RC )
           RETURN
        ENDIF
 
@@ -999,7 +999,7 @@ CONTAINS
     CALL STRSPLIT( CharStr, HCO_GetOpt(HcoConfig%ExtList,'Separator'), SUBSTR, N )
     IF ( N < 4 ) THEN
        MSG = 'Time stamp must have at least 4 elements: ' // TRIM(CharStr)
-       CALL HCO_ERROR( HcoConfig%Err, MSG, RC, THISLOC=LOC )
+       CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
        RETURN
     ENDIF
 
@@ -1061,7 +1061,7 @@ CONTAINS
              TimeVec(I1) = TimeVec(I0)
           ELSE
              MSG = 'Cannot extract time stamp: ' // TRIM(CharStr)
-             CALL HCO_ERROR( HcoConfig%Err, MSG, RC, THISLOC=LOC )
+             CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
              RETURN
           ENDIF
        ENDIF

--- a/src/Core/hco_timeshift_mod.F90
+++ b/src/Core/hco_timeshift_mod.F90
@@ -174,7 +174,7 @@ CONTAINS
             ( Dta%ncDys(1) == 1 .AND. Dta%ncDys(2) == 7 ) ) THEN
           WRITE(MSG,*) 'Time shift not supported for weekday data: ', &
              TRIM(Dta%ncFile)
-          CALL HCO_ERROR( HcoConfig%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
           RETURN
        ENDIF
     ENDIF

--- a/src/Core/hco_unit_mod.F90
+++ b/src/Core/hco_unit_mod.F90
@@ -418,7 +418,7 @@ CONTAINS
 
     IF ( Coef1 < 0.0_hp ) THEN
        MSG = 'cannot do unit conversion. Mass unit: ' // TRIM(unt)
-       CALL HCO_ERROR( HcoConfig%Err, MSG, RC, ThisLoc = LOC )
+       CALL HCO_ERROR( MSG, RC, ThisLoc = LOC )
        RETURN
     ENDIF
     Factor = Factor * Coef1

--- a/src/Core/hco_vertgrid_mod.F90
+++ b/src/Core/hco_vertgrid_mod.F90
@@ -220,7 +220,7 @@ CONTAINS
     ! Allocate AP and BP
     ALLOCATE(zGrid%Ap(nz+1), zGrid%Bp(nz+1), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoConfig%Err, 'Cannot allocate Ap / Bp', RC, THISLOC=LOC )
+       CALL HCO_ERROR( 'Cannot allocate Ap / Bp', RC, THISLOC=LOC )
        RETURN
     ENDIF
     zGrid%Ap = 0.0_hp
@@ -233,7 +233,7 @@ CONTAINS
        IF ( nz > 72 ) THEN
           WRITE(MSG,*) 'Vertical grid has more than 72 vertical levels', &
                        '- please provide Ap values in configuration file.'
-          CALL HCO_ERROR( HcoConfig%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
           RETURN
        ELSEIF ( nz > 47 ) THEN
           zGrid%Ap(:) = Ap72(1:(nz+1))
@@ -249,7 +249,7 @@ CONTAINS
        IF ( nz > 72 ) THEN
           WRITE(MSG,*) 'Vertical grid has more than 72 vertical levels', &
                        '- please provide Bp values in configuration file.'
-          CALL HCO_ERROR( HcoConfig%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
           RETURN
        ELSEIF ( nz > 47 ) THEN
           zGrid%Bp(:) = Bp72(1:(nz+1))

--- a/src/Core/hcoio_dataread_mod.F90
+++ b/src/Core/hcoio_dataread_mod.F90
@@ -204,7 +204,7 @@ CONTAINS
     ! Trap potential errors
     IF ( RC /= HCO_SUCCESS ) THEN
        MSG = 'Error encountered in routine HCOIO_Read!'
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+       CALL HCO_ERROR( MSG, RC )
        RETURN
     ENDIF
 

--- a/src/Core/hcoio_messy_mod.F90
+++ b/src/Core/hcoio_messy_mod.F90
@@ -192,7 +192,7 @@ MODULE HCOIO_MESSY_MOD
     IF ( Lct%Dct%Dta%SpaceDim /= 2 .AND. &
          Lct%Dct%Dta%SpaceDim /= 3         ) THEN
        MSG = 'Can only regrid 2D or 3D data: ' // TRIM(Lct%Dct%cName)
-       CALL HCO_ERROR ( HcoState%Config%Err, MSG, RC )
+       CALL HCO_ERROR ( MSG, RC )
        RETURN
     ENDIF
 
@@ -246,7 +246,7 @@ MODULE HCOIO_MESSY_MOD
        IF ( .NOT. ASSOCIATED(LevEdge) .AND. .NOT. IsModelLev ) THEN
           MSG = 'Cannot regrid '//TRIM(Lct%Dct%cName)//'. Either level '//&
                 'edges must be provided or data must be on model levels.'
-          CALL HCO_ERROR ( HcoState%Config%Err, MSG, RC )
+          CALL HCO_ERROR ( MSG, RC )
           RETURN
        ENDIF
     ENDIF
@@ -259,7 +259,7 @@ MODULE HCOIO_MESSY_MOD
        ! pressure @ i,j: sigma(i,j,l) = p(i,j,l) / ps(i,j)
        ALLOCATE(sigout(HcoState%NX,HcoState%NY,HcoState%NZ+1),STAT=AS)
        IF ( AS/= 0 ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, 'Cannot allocate sigout', RC )
+          CALL HCO_ERROR( 'Cannot allocate sigout', RC )
           RETURN
        ENDIF
        DO l = 1, HcoState%NZ+1
@@ -415,7 +415,7 @@ MODULE HCOIO_MESSY_MOD
        NCALLS = NZIN
        ALLOCATE(ArrOut(HcoState%NX,HcoState%NY,NZIN,NTIME),STAT=AS)
        IF ( AS /= 0 ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, 'Cannot allocate ArrOut', RC )
+          CALL HCO_ERROR( 'Cannot allocate ArrOut', RC )
           RETURN
        ENDIF
        ArrOut = 0.0_sp
@@ -470,7 +470,7 @@ MODULE HCOIO_MESSY_MOD
     !-----------------------------------------------------------------
     DEALLOCATE( sovl, dovl, rcnt, STAT=AS)
     IF(AS/=0) THEN
-       CALL HCO_ERROR(HcoState%Config%Err,'DEALLOCATION ERROR 1', RC )
+       CALL HCO_ERROR('DEALLOCATION ERROR 1', RC )
        RETURN
     ENDIF
     NULLIFY(sovl, dovl, rcnt)
@@ -480,7 +480,7 @@ MODULE HCOIO_MESSY_MOD
     ENDDO
     DEALLOCATE(narr_dst, STAT=AS)
     IF(AS/=0) THEN
-       CALL HCO_ERROR(HcoState%Config%Err,'DEALLOCATION ERROR 3', RC )
+       CALL HCO_ERROR('DEALLOCATION ERROR 3', RC )
        RETURN
     ENDIF
     NULLIFY(narr_dst)
@@ -490,7 +490,7 @@ MODULE HCOIO_MESSY_MOD
     ENDDO
     DEALLOCATE(narr_src, STAT=AS)
     IF(AS/=0) THEN
-       CALL HCO_ERROR(HcoState%Config%Err,'DEALLOCATION ERROR 2', RC )
+       CALL HCO_ERROR('DEALLOCATION ERROR 2', RC )
        RETURN
     ENDIF
     NULLIFY(narr_src)
@@ -587,7 +587,7 @@ MODULE HCOIO_MESSY_MOD
     ! ALLOCATE AXIS
     ALLOCATE(ax(N), STAT=status)
     IF ( status /= 0 ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, 'Cannot allocate axis', RC )
+       CALL HCO_ERROR ( 'Cannot allocate axis', RC )
        RETURN
     ENDIF
     DO I=1, N
@@ -612,7 +612,7 @@ MODULE HCOIO_MESSY_MOD
        ax(N)%ndp    = 1          ! LONGITUDE IS ...
        ALLOCATE(ax(N)%dep(1), STAT=status)
        IF ( status/= 0 ) THEN
-          CALL HCO_ERROR ( HcoState%Config%Err, 'Cannot allocate lon dependencies', RC )
+          CALL HCO_ERROR ( 'Cannot allocate lon dependencies', RC )
           RETURN
        ENDIF
        ax(N)%dep(1) = N          ! ... INDEPENDENT
@@ -621,14 +621,14 @@ MODULE HCOIO_MESSY_MOD
        ax(N)%dat%n = 1          ! 1 dimension
        ALLOCATE(ax(N)%dat%dim(ax(N)%dat%n), STAT=status)
        IF ( status/= 0 ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, 'Cannot allocate lon dimensions', RC )
+          CALL HCO_ERROR( 'Cannot allocate lon dimensions', RC )
           RETURN
        ENDIF
        ax(N)%dat%dim(:) = XLON
 
        ALLOCATE(ax(N)%dat%vd(XLON),STAT=status)
        IF ( status/= 0 ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, 'Cannot allocate lon axis', RC )
+          CALL HCO_ERROR( 'Cannot allocate lon axis', RC )
           RETURN
        ENDIF
        ax(N)%dat%vd(:) = lon
@@ -650,7 +650,7 @@ MODULE HCOIO_MESSY_MOD
        ax(N)%ndp    = 1          ! LATITUDE IS ...
        ALLOCATE(ax(N)%dep(1), STAT=status)
        IF ( status/= 0 ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, 'Cannot allocate lat dependencies', RC )
+          CALL HCO_ERROR( 'Cannot allocate lat dependencies', RC )
           RETURN
        ENDIF
        ax(N)%dep(1) = N          ! ... INDEPENDENT
@@ -659,14 +659,14 @@ MODULE HCOIO_MESSY_MOD
        ax(N)%dat%n = 1          ! 1 dimension
        ALLOCATE(ax(N)%dat%dim(ax(N)%dat%n), STAT=status)
        IF ( status/= 0 ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, 'Cannot allocate lat dimensions', RC )
+          CALL HCO_ERROR( 'Cannot allocate lat dimensions', RC )
           RETURN
        ENDIF
        ax(N)%dat%dim(:) = YLAT
 
        ALLOCATE(ax(N)%dat%vd(YLAT),STAT=status)
        IF ( status/= 0 ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, 'Cannot allocate lat axis', RC )
+          CALL HCO_ERROR( 'Cannot allocate lat axis', RC )
           RETURN
        ENDIF
        ax(N)%dat%vd(:) = lat
@@ -715,7 +715,7 @@ MODULE HCOIO_MESSY_MOD
        ax(N)%ndp = ndp
        ALLOCATE(ax(N)%dep(ax(N)%ndp), STAT=status)
        IF ( status /= 0 ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, 'Cannot allocate lev dependencies', RC )
+          CALL HCO_ERROR( 'Cannot allocate lev dependencies', RC )
           RETURN
        ENDIF
 
@@ -724,7 +724,7 @@ MODULE HCOIO_MESSY_MOD
        ax(N)%dat%n = ndp
        ALLOCATE(ax(N)%dat%dim(ax(N)%dat%n), STAT=status)
        IF ( status/= 0 ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, 'Cannot allocate lat dimensions', RC )
+          CALL HCO_ERROR( 'Cannot allocate lat dimensions', RC )
           RETURN
        ENDIF
 
@@ -751,7 +751,7 @@ MODULE HCOIO_MESSY_MOD
 
        ALLOCATE(ax(N)%dat%vd(nlev),STAT=status)
        IF ( status/= 0 ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, 'Cannot allocate lat axis', RC )
+          CALL HCO_ERROR( 'Cannot allocate lat axis', RC )
           RETURN
        ENDIF
 
@@ -888,7 +888,7 @@ MODULE HCOIO_MESSY_MOD
     ! create
     ALLOCATE(narr(NT),STAT=status)
     IF(status/=0) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'narr allocation error', RC, THISLOC=LOC )
+       CALL HCO_ERROR( 'narr allocation error', RC, THISLOC=LOC )
        RETURN
     ENDIF
 
@@ -899,7 +899,7 @@ MODULE HCOIO_MESSY_MOD
        narr(T)%n = size(ax)
        ALLOCATE(narr(T)%dim(narr(T)%n),STAT=status)
        IF(status/=0) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, 'Cannot allocate array dims', RC, THISLOC=LOC )
+          CALL HCO_ERROR( 'Cannot allocate array dims', RC, THISLOC=LOC )
           RETURN
        ENDIF
 
@@ -914,7 +914,7 @@ MODULE HCOIO_MESSY_MOD
 
        ALLOCATE(narr(T)%vd(NCELLS),STAT=status)
        IF(status/=0) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, 'Cannot allocate array', RC, THISLOC=LOC )
+          CALL HCO_ERROR( 'Cannot allocate array', RC, THISLOC=LOC )
           RETURN
        ENDIF
     ENDDO !T
@@ -1032,7 +1032,7 @@ MODULE HCOIO_MESSY_MOD
             ( SIZE(Ptr4D,4) /= NT )       ) THEN
           WRITE(MSG,*) 'Temporary pointer has wrong dimensions: ', &
                        TRIM(Lct%Dct%cName), NX, NY, NZ, NT, SIZE(Ptr4D,1), SIZE(Ptr4D,2), SIZE(Ptr4D,3), SIZE(Ptr4D,4)
-          CALL HCO_ERROR ( HcoState%Config%Err, MSG, RC, &
+          CALL HCO_ERROR ( MSG, RC, &
                            THISLOC='MESSY2HCO (hcoio_messy_mod.F90)' )
           RETURN
        ENDIF

--- a/src/Core/hcoio_read_mapl_mod.F90
+++ b/src/Core/hcoio_read_mapl_mod.F90
@@ -130,7 +130,7 @@ CONTAINS
        ! Check for MAPL error
        IF( STAT /= ESMF_SUCCESS ) THEN
           MSG = 'Cannot get xyz pointer: ' // TRIM(Lct%Dct%Dta%ncFile)
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+          CALL HCO_ERROR( MSG, RC )
           RETURN
        ENDIF
 
@@ -171,7 +171,7 @@ CONTAINS
        ! Check for MAPL error
        IF( STAT /= ESMF_SUCCESS ) THEN
           MSG = 'Cannot get xy pointer: ' // TRIM(Lct%Dct%Dta%ncFile)
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+          CALL HCO_ERROR( MSG, RC )
           RETURN
        ENDIF
 

--- a/src/Core/hcoio_read_std_mod.F90
+++ b/src/Core/hcoio_read_std_mod.F90
@@ -261,7 +261,7 @@ CONTAINS
     IF ( RC /= HCO_SUCCESS ) THEN
        MSG = 'Error encountered in routine "SrcFile_Parse", located '     // &
              'module src/Core/hcoio_read_std_mod.F90!'
-        CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+        CALL HCO_ERROR( MSG, RC )
         RETURN
     ENDIF
 
@@ -285,7 +285,7 @@ CONTAINS
                      TRIM(srcFile) // ' - Cannot get field ' // &
                      TRIM(Lct%Dct%cName) // '. Please check file name ' // &
                      'and time (incl. time range flag) in the config. file'
-                CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+                CALL HCO_ERROR( MSG, RC )
                 RETURN
 
              ! If MustFind flag is not enabled, ignore this field and return
@@ -304,7 +304,7 @@ CONTAINS
                   TRIM(srcFile) // ' - Cannot get field ' // &
                   TRIM(Lct%Dct%cName) // '. Please check file name ' // &
                   'and time (incl. time range flag) in the config. file'
-             CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+             CALL HCO_ERROR( MSG, RC )
              RETURN
           ENDIF
        ENDIF
@@ -466,7 +466,7 @@ CONTAINS
        DoReturn = .FALSE.
        IF ( Lct%Dct%Dta%CycleFlag == HCO_CFLAG_CYCLE ) THEN
           MSG = 'Invalid time index in ' // TRIM(srcFile)
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+          CALL HCO_ERROR( MSG, RC )
           DoReturn = .TRUE.
        ELSEIF ( ( Lct%Dct%Dta%CycleFlag == HCO_CFLAG_RANGE ) .OR.      &
                 ( Lct%Dct%Dta%CycleFlag == HCO_CFLAG_EXACT )     ) THEN
@@ -475,7 +475,7 @@ CONTAINS
                    TRIM(srcFile) // ' - Cannot get field ' // &
                    TRIM(Lct%Dct%cName) // '. Please check file name ' // &
                    'and time (incl. time range flag) in the config. file'
-             CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+             CALL HCO_ERROR( MSG, RC )
              DoReturn = .TRUE.
           ELSE
              CALL FileData_Cleanup( Lct%Dct%Dta, DeepClean=.FALSE.)
@@ -504,7 +504,7 @@ CONTAINS
        IF ( Lct%Dct%Dta%MustFind ) THEN
           MSG = 'Cannot find field ' // TRIM(Lct%Dct%cName) // &
                 '. Please check variable name in the config. file'
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+          CALL HCO_ERROR( MSG, RC )
           RETURN
 
        ! If MustFind flag is not enabled, ignore this field and return
@@ -549,7 +549,7 @@ CONTAINS
     IF ( nlon == 0 ) THEN
        MSG = 'Cannot find longitude variable in ' // TRIM(srcFile) // &
              ' - Must be one of `lon`, `longitude`, `Longitude`'
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+       CALL HCO_ERROR( MSG, RC )
        RETURN
     ENDIF
 
@@ -558,7 +558,7 @@ CONTAINS
     IF ( INDEX( thisUnit, 'degrees_east' ) == 0 ) THEN
        MSG = 'illegal longitude unit in ' // TRIM(srcFile) // &
              ' - Must be `degrees_east`.'
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+       CALL HCO_ERROR( MSG, RC )
        RETURN
     ENDIF
 
@@ -592,7 +592,7 @@ CONTAINS
     IF ( nlat == 0 ) THEN
        MSG = 'Cannot find latitude variable in ' // TRIM(srcFile) // &
              ' - Must be one of `lat`, `latitude`, `Latitude`'
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+       CALL HCO_ERROR( MSG, RC )
        RETURN
     ENDIF
 
@@ -601,7 +601,7 @@ CONTAINS
     IF ( INDEX( thisUnit, 'degrees_north' ) == 0 ) THEN
        MSG = 'illegal latitude unit in ' // TRIM(srcFile) // &
              ' - Must be `degrees_north`.'
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+       CALL HCO_ERROR( MSG, RC )
        RETURN
     ENDIF
 
@@ -636,7 +636,7 @@ CONTAINS
        IF ( nlev == 0 ) THEN
           MSG = 'Cannot find vertical coordinate variable in ' // &
                  TRIM(SrcFile) // ' - Must be one of `lev`, `level`, `height`.'
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+          CALL HCO_ERROR( MSG, RC )
           RETURN
        ENDIF
 
@@ -679,7 +679,7 @@ CONTAINS
           IF ( ABS(Lct%Dct%Dta%Levels) > nlev ) THEN
              WRITE(MSG,*) Lct%Dct%Dta%Levels, ' levels requested but file ', &
                 'has only ', nlev, ' levels: ', TRIM(Lct%Dct%cName)
-             CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+             CALL HCO_ERROR( MSG, RC )
              RETURN
           ENDIF
 
@@ -927,7 +927,7 @@ CONTAINS
              IF ( .NOT. FOUND ) THEN
                 WRITE(MSG,*) 'Cannot find file for year ', iYear, ' - needed ', &
                    'to perform time-averaging on file ', TRIM(Lct%Dct%Dta%ncFile)
-                CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+                CALL HCO_ERROR( MSG, RC )
                 RETURN
              ENDIF
 
@@ -1039,7 +1039,7 @@ CONTAINS
        IF ( Flag /= 0 .AND. UnitTolerance == 0 ) THEN
           MSG = 'Illegal unit: ' // TRIM(thisUnit) // '. File: ' // &
                 TRIM(srcFile)
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+          CALL HCO_ERROR( MSG, RC )
           RETURN
        ENDIF
 
@@ -1069,7 +1069,7 @@ CONTAINS
                 '. File: ' // TRIM(srcFile)
 
           IF ( UnitTolerance == 0 ) THEN
-             CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+             CALL HCO_ERROR( MSG, RC )
              RETURN
           ELSE
              CALL HCO_WARNING( HcoState%Config%Err, MSG, RC, WARNLEV=3 )
@@ -1119,7 +1119,7 @@ CONTAINS
             RC            = RC                )
        IF ( RC /= HCO_SUCCESS ) THEN
           MSG = 'Cannot convert units for ' // TRIM(Lct%Dct%cName)
-          CALL HCO_ERROR( HcoState%Config%Err, MSG , RC )
+          CALL HCO_ERROR( MSG , RC )
           RETURN
        ENDIF
 
@@ -1183,7 +1183,7 @@ CONTAINS
                                    LatEdge,  nlatEdge, NCRC   )
           IF ( NCRC /= 0 ) THEN
              MSG = 'Cannot read lat edge of ' // TRIM(srcFile)
-             CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+             CALL HCO_ERROR( MSG, RC )
              RETURN
           ENDIF
 
@@ -1196,7 +1196,7 @@ CONTAINS
        ELSE
           MSG = 'Unit must be unitless, emission or concentration: ' // &
                 TRIM(Lct%Dct%cName) // ': ' // TRIM(thisUnit)
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+          CALL HCO_ERROR( MSG, RC )
           RETURN
        ENDIF
     ENDIF ! Unit conversion
@@ -1210,7 +1210,7 @@ CONTAINS
                              LonEdge,  nlonEdge, NCRC   )
     IF ( NCRC /= 0 ) THEN
        MSG = 'Cannot read lon edge of ' // TRIM(srcFile)
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+       CALL HCO_ERROR( MSG, RC )
        RETURN
     ENDIF
     CALL HCO_ValidateLon( HcoState, nlonEdge, LonEdge, RC )
@@ -1223,7 +1223,7 @@ CONTAINS
                                 LatEdge,  nlatEdge, NCRC   )
        IF ( NCRC /= 0 ) THEN
           MSG = 'Cannot read lat edge of ' // TRIM(srcFile)
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+          CALL HCO_ERROR( MSG, RC )
           RETURN
        ENDIF
     ENDIF
@@ -1267,7 +1267,7 @@ CONTAINS
     IF ( HCO_IsIndexData(Lct%Dct%Dta%OrigUnit) .AND. UseMESSy ) THEN
        MSG = 'Cannot do MESSy regridding for index data: ' // &
              TRIM(srcFile)
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+       CALL HCO_ERROR( MSG, RC )
        RETURN
     ENDIF
 
@@ -1286,7 +1286,7 @@ CONTAINS
        IF ( tidx1 /= tidx2 ) THEN
           MSG = 'Cannot do MESSy regridding for more than one time step; ' &
                 // TRIM(srcFile)
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+          CALL HCO_ERROR( MSG, RC )
           RETURN
        ENDIF
 

--- a/src/Core/hcoio_util_mod.F90
+++ b/src/Core/hcoio_util_mod.F90
@@ -212,7 +212,7 @@ CONTAINS
     IF ( RC /= HCO_SUCCESS ) THEN
        MSG = &
          'Error encountered in HCO_GetPrefTimeAttr for ' // TRIM(Lct%Dct%cName)
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+       CALL HCO_ERROR( MSG, RC )
        IF ( ASSOCIATED(availYMDhm) ) THEN
           DEALLOCATE(availYMDhm)
           availYMDhm => NULL()
@@ -229,7 +229,7 @@ CONTAINS
        ! This should only happen for 'range' data
        IF ( Lct%Dct%Dta%CycleFlag /= HCO_CFLAG_RANGE ) THEN
           MSG = 'Cannot get preferred datetime for ' // TRIM(Lct%Dct%cName)
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+          CALL HCO_ERROR( MSG, RC )
           IF ( ASSOCIATED(availYMDhm) ) THEN
              DEALLOCATE(availYMDhm)
              availYMDhm => NULL()
@@ -446,7 +446,7 @@ CONTAINS
           IF ( nTime < 7 ) THEN
              MSG = 'Data must have exactly 7 time slices '// &
                    'if you set day attribute to WD: '//TRIM(Lct%Dct%cName)
-             CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+             CALL HCO_ERROR( MSG, RC )
              IF ( ASSOCIATED(availYMDhm) ) THEN
                 DEALLOCATE(availYMDhm)
                 availYMDhm => NULL()
@@ -469,7 +469,7 @@ CONTAINS
              IF ( tidx1 < 0 ) THEN
                 WRITE(MSG,*) 'Cannot get weekday slices for: ', &
                    TRIM(Lct%Dct%cName), '. Cannot find first time slice.'
-                CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+                CALL HCO_ERROR( MSG, RC )
                 IF ( ASSOCIATED(availYMDhm) ) THEN
                    DEALLOCATE(availYMDhm)
                    availYMDhm => NULL()
@@ -481,7 +481,7 @@ CONTAINS
                 WRITE(MSG,*) 'Cannot get weekday for: ',TRIM(Lct%Dct%cName), &
                    '. There are less than 6 additional time slices after ',  &
                    'selected start date ', availYMDhm(tidx1)
-                CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+                CALL HCO_ERROR( MSG, RC )
                 IF ( ASSOCIATED(availYMDhm) ) THEN
                    DEALLOCATE(availYMDhm)
                    availYMDhm => NULL()
@@ -523,7 +523,7 @@ CONTAINS
              IF ( RC /= HCO_SUCCESS ) THEN
                 MSG = 'Error encountered in GetIndex2Interp for: '        // &
                      TRIM(Lct%Dct%Cname)
-                CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+                CALL HCO_ERROR( MSG, RC )
                 IF ( ASSOCIATED(availYMDhm) ) THEN
                    DEALLOCATE(availYMDhm)
                    availYMDhm => NULL()
@@ -553,7 +553,7 @@ CONTAINS
           MSG = 'Field has no time/date variable - cycle flag must' // &
                 'be set to `C` in the HEMCO configuration file:'    // &
                 TRIM(Lct%Dct%cName)
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+          CALL HCO_ERROR( MSG, RC )
           IF ( ASSOCIATED(availYMDhm) ) THEN
              DEALLOCATE(availYMDhm)
              availYMDhm => NULL()
@@ -1441,12 +1441,12 @@ CONTAINS
 
     IF ( SIZE(Array,1) /= nlon ) THEN
        MSG = 'Array size does not agree with nlon: ' // TRIM(FN)
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+       CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
        RETURN
     ENDIF
     IF ( SIZE(Array,2) /= NLAT ) THEN
        MSG = 'Array size does not agree with nlat: ' // TRIM(FN)
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+       CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
        RETURN
     ENDIF
 
@@ -1618,7 +1618,7 @@ CONTAINS
                TRIM(srcFile) // ' - Cannot get field ' // &
                TRIM(Lct%Dct%cName) // '. Please check file name ' // &
                'and time (incl. time range flag) in the config. file'
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+          CALL HCO_ERROR( MSG, RC )
           RETURN
        ENDIF
 
@@ -1873,7 +1873,7 @@ CONTAINS
     IF ( ASSOCIATED(SigEdge) ) DEALLOCATE(SigEdge)
     ALLOCATE(SigEdge(nx,ny,nz+1),STAT=AS)
     IF ( AS/=0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'Allocate SigEdge', RC, &
+       CALL HCO_ERROR( 'Allocate SigEdge', RC, &
                        THISLOC=LOC )
        RETURN
     ENDIF
@@ -2007,7 +2007,7 @@ CONTAINS
        MSG = 'Cannot read dimension ' // TRIM(Lct%Dct%Dta%ArbDimName) &
              // ' from file ' // &
              TRIM(Lct%Dct%Dta%ncFile)
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+       CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
        RETURN
     ENDIF
 
@@ -2044,7 +2044,7 @@ CONTAINS
              'a HEMCO token/setting. This error happened when evaluating ', &
              'dimension ', TRIM(Lct%Dct%Dta%ArbDimName), ' belonging to ', &
              'file ', TRIM(Lct%Dct%Dta%ncFile)
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
           RETURN
        ENDIF
     ENDIF
@@ -2055,7 +2055,7 @@ CONTAINS
           'This error happened when evaluating ', &
           'dimension ', TRIM(Lct%Dct%Dta%ArbDimName), ' belonging to ', &
           'file ', TRIM(Lct%Dct%Dta%ncFile)
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+       CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
        RETURN
 
     ELSE
@@ -2128,7 +2128,7 @@ CONTAINS
     IF ( .NOT. Lct%Dct%Dta%IsLocTime ) THEN
        MSG = 'Cannot read data from file that is not in local time: ' // &
              TRIM(Lct%Dct%cName)
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC='HCOIO_ReadOther (hcoio_dataread_mod.F90)' )
+       CALL HCO_ERROR( MSG, RC, THISLOC='HCOIO_ReadOther (hcoio_dataread_mod.F90)' )
        RETURN
     ENDIF
 
@@ -2221,7 +2221,7 @@ CONTAINS
     OPEN ( IUFILE, FILE=TRIM( Lct%Dct%Dta%ncFile ), STATUS='OLD', IOSTAT=IOS )
     IF ( IOS /= 0 ) THEN
        MSG = 'Cannot open ' // TRIM(Lct%Dct%Dta%ncFile)
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+       CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
        RETURN
     ENDIF
 
@@ -2239,7 +2239,7 @@ CONTAINS
        IF ( IOS > 0 ) THEN
           MSG = 'Error reading ' // TRIM(Lct%Dct%Dta%ncFile)
           MSG = TRIM(MSG) // ' - last valid line: ' // TRIM(LINE)
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
           RETURN
        ENDIF
 
@@ -2286,7 +2286,7 @@ CONTAINS
 
        IF ( ID2 >= LEN(LINE) .OR. ID2 < 0 ) THEN
           MSG = 'Cannot extract country ID from: ' // TRIM(LINE)
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
           RETURN
        ENDIF
        DUM = LINE(ID1:ID2)
@@ -2572,7 +2572,7 @@ CONTAINS
        uppDt = Lct%Dct%Dta%ncDys(2)
     ELSE
        WRITE(MSG,*) "DtType must be one of 1, 2, 3: ", DtType
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+       CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
        RETURN
     ENDIF
 
@@ -2595,7 +2595,7 @@ CONTAINS
           ! the preferred date should always be restricted to the range
           ! of available time stamps.
           MSG = 'preferred date is outside of range: ' // TRIM(Lct%Dct%cName)
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
           RETURN
        ENDIF
     ENDIF
@@ -2710,7 +2710,7 @@ CONTAINS
     IF ( N == 0 ) THEN
        MSG = 'Cannot read data: ' // TRIM(Lct%Dct%cName) // &
              ': ' // TRIM(ValStr)
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC)
+       CALL HCO_ERROR( MSG, RC, THISLOC=LOC)
        RETURN
     ENDIF
 
@@ -2731,7 +2731,7 @@ CONTAINS
        IF ( N /= 4 ) THEN
           MSG = 'Mask values are not lon1/lat1/lon2/lat2: ' // &
                 TRIM(ValStr) // ' --> ' // TRIM(Lct%Dct%cName)
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
           RETURN
        ENDIF
 
@@ -2740,7 +2740,7 @@ CONTAINS
        ALLOCATE( FileArr(1,1,1,NUSE), STAT=AS )
        IF ( AS /= 0 ) THEN
           MSG = 'Cannot allocate FileArr'
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
           RETURN
        ENDIF
        FileArr(1,1,1,:) = FileVals(1:NUSE)
@@ -2781,7 +2781,7 @@ CONTAINS
                   Lct%Dct%Dta%ncHrs(1) /= Lct%Dct%Dta%ncHrs(2)       ) THEN
                 MSG = 'Data must not have more than one time dimension: ' // &
                        TRIM(Lct%Dct%cName)
-                CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+                CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
                 RETURN
              ENDIF
 
@@ -2797,7 +2797,7 @@ CONTAINS
                   Lct%Dct%Dta%ncHrs(1) /= Lct%Dct%Dta%ncHrs(2)       ) THEN
                 MSG = 'Data must only have one time dimension: ' // &
                       TRIM(Lct%Dct%cName)
-                CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+                CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
                 RETURN
              ENDIF
 
@@ -2812,7 +2812,7 @@ CONTAINS
              IF ( Lct%Dct%Dta%ncHrs(1) /= Lct%Dct%Dta%ncHrs(2) ) THEN
                 MSG = 'Data must only have one time dimension: ' // &
                       TRIM(Lct%Dct%cName)
-                CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+                CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
                 RETURN
              ENDIF
 
@@ -2835,14 +2835,14 @@ CONTAINS
        IF ( IDX2 > N ) THEN
           WRITE(MSG,*) 'Index ', IDX2, ' is larger than number of ', &
                        'values found: ', TRIM(Lct%Dct%cName)
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
           RETURN
        ENDIF
 
        ALLOCATE( FileArr(1,1,1,NUSE), STAT=AS )
        IF ( AS /= 0 ) THEN
           MSG = 'Cannot allocate FileArr'
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
           RETURN
        ENDIF
 
@@ -2956,7 +2956,7 @@ CONTAINS
        ELSE
           MSG = 'Unit must be unitless, emission or concentration: ' // &
                 TRIM(Lct%Dct%cName) // ': ' // TRIM(Lct%Dct%Dta%OrigUnit)
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
           RETURN
        ENDIF
 
@@ -2977,7 +2977,7 @@ CONTAINS
        ELSE
           MSG = 'Factor must be of length 1, 7, 12, or 24!' // &
                  TRIM(Lct%Dct%cName)
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC)
+          CALL HCO_ERROR( MSG, RC, THISLOC=LOC)
           RETURN
        ENDIF
 
@@ -2988,7 +2988,7 @@ CONTAINS
     ALLOCATE( Vals(NUSE), STAT=AS )
     IF ( AS /= 0 ) THEN
        MSG = 'Cannot allocate Vals'
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+       CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
        RETURN
     ENDIF
     Vals(:) = FileArr(1,1,1,:)
@@ -3071,7 +3071,7 @@ CONTAINS
                 'edges for this. This error occurs if a mask covers '// &
                 'a fixed grid point (e.g. lon1=lon2 and lat1=lat2) ' // &
                 'but HEMCO grid edges are not defined.'
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
           RETURN
        ENDIF
        GridPoint = .TRUE.
@@ -3215,7 +3215,7 @@ CONTAINS
     IF ( STRL < 6 ) THEN
        MSG = 'Math expression is too short - expected `MATH:<expr>`: ' &
              //TRIM(ValStr)
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+       CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
        RETURN
     ENDIF
     func = ValStr(6:STRL)
@@ -3329,7 +3329,7 @@ CONTAINS
     IF ( LHIDX > 0 .AND. LWDIDX > 0 ) THEN
        MSG = 'Cannot have local hour and local weekday in '//&
              'same expression: '//TRIM(func)
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+       CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
        RETURN
     ENDIF
 
@@ -3361,7 +3361,7 @@ CONTAINS
        ENDDO
     ELSE
        MSG = 'Error evaluation function: '//TRIM(func)
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC, THISLOC=LOC )
+       CALL HCO_ERROR( MSG, RC, THISLOC=LOC )
        RETURN
     ENDIF
     call destroyfunc()

--- a/src/Extensions/hcox_ch4wetland_mod.F90
+++ b/src/Extensions/hcox_ch4wetland_mod.F90
@@ -198,7 +198,7 @@ CONTAINS
     CALL InstGet ( ExtState%Wetland_CH4, Inst, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        WRITE(MSG,*) 'Cannot find CH4 wetland instance Nr. ', ExtState%Wetland_CH4
-       CALL HCO_ERROR(HcoState%Config%Err,MSG,RC)
+       CALL HCO_ERROR(MSG,RC)
        RETURN
     ENDIF
 
@@ -717,7 +717,7 @@ CONTAINS
     ! Create Instance
     CALL InstCreate ( ExtNr, ExtState%Wetland_CH4, Inst, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, 'Cannot create CH4WETLAND instance', RC )
+       CALL HCO_ERROR ( 'Cannot create CH4WETLAND instance', RC )
        RETURN
     ENDIF
 
@@ -729,7 +729,7 @@ CONTAINS
                Inst%SOIL_C(HcoState%NX, HcoState%NY), &
                Inst%MEAN_T(HcoState%NX, HcoState%NY), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, 'Allocation error', RC )
+       CALL HCO_ERROR ( 'Allocation error', RC )
        RETURN
     ENDIF
     Inst%RICE         = 0.0_hp
@@ -766,7 +766,7 @@ CONTAINS
     ! Make sure at least one source is used.
     IF ( .NOT. Inst%DoWetland .AND. .NOT. Inst%DoRice ) THEN
        MSG = 'Wetlands and rice emissions are both turned off!'
-       CALL HCO_ERROR(HcoState%Config%Err,MSG, RC )
+       CALL HCO_ERROR(MSG, RC )
        RETURN
     ENDIF
 

--- a/src/Extensions/hcox_custom_mod.F90
+++ b/src/Extensions/hcox_custom_mod.F90
@@ -127,7 +127,7 @@ CONTAINS
     CALL InstGet ( ExtState%Custom, Inst, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        WRITE(MSG,*) 'Cannot find custom instance Nr. ', ExtState%Custom
-       CALL HCO_ERROR(HcoState%Config%Err,MSG,RC)
+       CALL HCO_ERROR(MSG,RC)
        RETURN
     ENDIF
 
@@ -135,7 +135,7 @@ CONTAINS
     ALLOCATE ( FLUXICE( HcoState%NX,HcoState%NY),        &
                FLUXWIND(HcoState%NX,HcoState%NY), STAT=AS )
     IF ( AS/= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'ALLOCATION ERROR', RC )
+       CALL HCO_ERROR( 'ALLOCATION ERROR', RC )
        RETURN
     ENDIF
     FLUXICE  = 0.0_hp
@@ -268,7 +268,7 @@ CONTAINS
     Inst => NULL()
     CALL InstCreate ( ExtNr, ExtState%Custom, Inst, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, 'Cannot create custom instance', RC )
+       CALL HCO_ERROR (  'Cannot create custom instance', RC )
        RETURN
     ENDIF
 
@@ -279,7 +279,7 @@ CONTAINS
     ! Assume first half are 'wind species', second half are ice.
     IF ( MOD(nSpc,2) /= 0 ) THEN
        MSG = 'Cannot set species IDs for custom emission module!'
-       CALL HCO_ERROR(HcoState%Config%Err,MSG, RC )
+       CALL HCO_ERROR(MSG, RC )
        RETURN
     ENDIF
 

--- a/src/Extensions/hcox_driver_mod.F90
+++ b/src/Extensions/hcox_driver_mod.F90
@@ -162,7 +162,7 @@ CONTAINS
     CALL ExtStateInit( ExtState, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        ErrMsg = 'Error encountered in "ExtState_Init"!'
-       CALL HCO_ERROR( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+       CALL HCO_ERROR( ErrMsg, RC, ThisLoc )
        RETURN
     ENDIF
 
@@ -180,7 +180,7 @@ CONTAINS
     CALL HCOX_PARANOX_INIT( HcoState, 'ParaNOx', ExtState, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        ErrMsg = 'Error encountered in "HCOX_ParaNOx_Init"!'
-       CALL HCO_ERROR( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+       CALL HCO_ERROR( ErrMsg, RC, ThisLoc )
        RETURN
     ENDIF
 
@@ -190,7 +190,7 @@ CONTAINS
     CALL HCOX_LightNox_Init( HcoState, 'LightNOx', ExtState, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        ErrMsg = 'Error encountered in "HCOX_LightNox_Init"!'
-       CALL HCO_ERROR( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+       CALL HCO_ERROR( ErrMsg, RC, ThisLoc )
        RETURN
     ENDIF
 
@@ -200,7 +200,7 @@ CONTAINS
     CALL HCOX_Volcano_Init( HcoState, 'Volcano', ExtState,  RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        ErrMsg = 'Error encountered in "HCOX_Volcano_Init"!'
-       CALL HCO_ERROR( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+       CALL HCO_ERROR( ErrMsg, RC, ThisLoc )
        RETURN
     ENDIF
 
@@ -216,7 +216,7 @@ CONTAINS
        CALL HCOX_Custom_Init( HcoState, 'Custom', ExtState, RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Error encountered in "HCOX_Custom_Init"!'
-          CALL HCO_ERROR( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_ERROR( ErrMsg, RC, ThisLoc )
           RETURN
        ENDIF
 
@@ -226,7 +226,7 @@ CONTAINS
        CALL HCOX_SeaFlux_Init( HcoState, 'SeaFlux', ExtState, RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Error encountered in "HCOX_SeaFlux_Init"!'
-          CALL HCO_ERROR( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_ERROR( ErrMsg, RC, ThisLoc )
           RETURN
        ENDIF
 
@@ -236,7 +236,7 @@ CONTAINS
        CALL HCOX_SoilNox_Init( HcoState, 'SoilNOx', ExtState, RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Error encountered in "HCOX_SoilNox_Init"!'
-          CALL HCO_ERROR( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_ERROR( ErrMsg, RC, ThisLoc )
           RETURN
        ENDIF
 
@@ -246,7 +246,7 @@ CONTAINS
        CALL HCOX_DustDead_Init( HcoState, 'DustDead', ExtState,  RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Error encountered in "HCOX_DustDead_Init"!'
-          CALL HCO_ERROR( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_ERROR( ErrMsg, RC, ThisLoc )
           RETURN
        ENDIF
 #if defined( TOMAS )
@@ -254,7 +254,7 @@ CONTAINS
                                       ExtState, RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Error encountered in "HCOX_TOMAS_DustDead_Init"!'
-          CALL HCO_ERROR( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_ERROR( ErrMsg, RC, ThisLoc )
           RETURN
        ENDIF
 #endif
@@ -265,7 +265,7 @@ CONTAINS
        CALL HCOX_DustGinoux_Init( HcoState, 'DustGinoux', ExtState, RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Error encountered in "HCOX_DustGinoux_Init"!'
-          CALL HCO_ERROR( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_ERROR( ErrMsg, RC, ThisLoc )
           RETURN
        ENDIF
 
@@ -275,7 +275,7 @@ CONTAINS
        CALL HCOX_SeaSalt_Init( HcoState, 'SeaSalt', ExtState, RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Error encountered in "HCOX_SeaSalt_Init"!'
-          CALL HCO_ERROR( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_ERROR( ErrMsg, RC, ThisLoc )
           RETURN
        ENDIF
 
@@ -285,7 +285,7 @@ CONTAINS
        CALL HCOX_Megan_Init( HcoState, 'MEGAN', ExtState, RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Error encountered in "HCOX_Megan_Init"!'
-          CALL HCO_ERROR( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_ERROR( ErrMsg, RC, ThisLoc )
           RETURN
        ENDIF
 
@@ -295,7 +295,7 @@ CONTAINS
        CALL HCOX_GFED_Init( HcoState, 'GFED', ExtState, RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Error encountered in "HCOX_GFED_Init"!'
-          CALL HCO_ERROR( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_ERROR( ErrMsg, RC, ThisLoc )
           RETURN
        ENDIF
 
@@ -305,7 +305,7 @@ CONTAINS
        CALL HCOX_FINN_Init( HcoState, 'FINN', ExtState, RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Error encountered in "HCOX_FINN_Init"!'
-          CALL HCO_ERROR( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_ERROR( ErrMsg, RC, ThisLoc )
           RETURN
        ENDIF
 
@@ -315,7 +315,7 @@ CONTAINS
        CALL HCOX_GC_RnPbBe_Init( HcoState, 'GC_Rn-Pb-Be', ExtState,  RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Error encountered in "HCOX_GC_RnPbBe_Init"!'
-          CALL HCO_ERROR( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_ERROR( ErrMsg, RC, ThisLoc )
           RETURN
        ENDIF
 
@@ -325,7 +325,7 @@ CONTAINS
        CALL HCOX_GC_POPs_Init( HcoState, 'GC_POPs', ExtState,  RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Error encountered in "HCOX_GC_POPs_Init"!'
-          CALL HCO_ERROR( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_ERROR( ErrMsg, RC, ThisLoc )
           RETURN
        ENDIF
 
@@ -335,7 +335,7 @@ CONTAINS
        CALL HCOX_CH4Wetland_Init( HcoState, 'CH4_WETLANDS', ExtState,  RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Error encountered in "HCOX_CH4Wetland_Init"!'
-          CALL HCO_ERROR( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_ERROR( ErrMsg, RC, ThisLoc )
           RETURN
        ENDIF
 
@@ -345,7 +345,7 @@ CONTAINS
        CALL HCOX_Iodine_Init( HcoState, 'Inorg_Iodine', ExtState,  RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Error encountered in "HCOX_Iodine_Init"!'
-          CALL HCO_ERROR( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_ERROR( ErrMsg, RC, ThisLoc )
           RETURN
        ENDIF
 
@@ -356,7 +356,7 @@ CONTAINS
        CALL HCOX_TOMAS_Jeagle_Init( HcoState, 'TOMAS_Jeagle', ExtState,  RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Error encountered in "HCOX_TOMAS_Jeagle_Init"!'
-          CALL HCO_ERROR( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_ERROR( ErrMsg, RC, ThisLoc )
           RETURN
        ENDIF
 #endif
@@ -373,7 +373,7 @@ CONTAINS
     ! Cannot have both DustDead and DustGinoux turned on!
     IF ( ExtState%DustDead > 0 .AND. ExtState%DustGinoux > 0 ) THEN
        ErrMsg = 'Ginoux and DEAD dust emissions switched on!'
-       CALL HCO_ERROR( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+       CALL HCO_ERROR( ErrMsg, RC, ThisLoc )
        RETURN
     ENDIF
 
@@ -384,7 +384,7 @@ CONTAINS
        CALL HCOX_DiagnDefine( HcoState, ExtState, RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Error encountered in "ExtState_Init"!'
-          CALL HCO_ERROR( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_ERROR( ErrMsg, RC, ThisLoc )
           RETURN
        ENDIF
     ENDIF
@@ -498,7 +498,7 @@ CONTAINS
        CALL HCOX_Volcano_Run( ExtState, HcoState, RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Error encountered in "HCOX_Volcano_Run"!'
-          CALL HCO_ERROR( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_ERROR( ErrMsg, RC, ThisLoc )
           RETURN
        ENDIF
     ENDIF
@@ -519,7 +519,7 @@ CONTAINS
           CALL HCOX_Custom_Run( ExtState, HcoState, RC)
           IF ( RC /= HCO_SUCCESS ) THEN
              ErrMsg = 'Error encountered in "HCOX_Custom_Run"!'
-             CALL HCO_ERROR( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+             CALL HCO_ERROR( ErrMsg, RC, ThisLoc )
              RETURN
           ENDIF
        ENDIF
@@ -531,7 +531,7 @@ CONTAINS
           CALL HCOX_SeaFlux_Run( ExtState, HcoState, RC)
           IF ( RC /= HCO_SUCCESS ) THEN
              ErrMsg = 'Error encountered in "HCOX_SeaFlux_Run"!'
-             CALL HCO_ERROR( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+             CALL HCO_ERROR( ErrMsg, RC, ThisLoc )
              RETURN
           ENDIF
        ENDIF
@@ -543,7 +543,7 @@ CONTAINS
           CALL HCOX_ParaNox_Run( ExtState, HcoState, RC )
           IF ( RC /= HCO_SUCCESS ) THEN
              ErrMsg = 'Error encountered in "HCOX_ParaNOx_Run"!'
-             CALL HCO_ERROR( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+             CALL HCO_ERROR( ErrMsg, RC, ThisLoc )
              RETURN
           ENDIF
        ENDIF
@@ -555,7 +555,7 @@ CONTAINS
           CALL HCOX_LightNox_Run( ExtState, HcoState, RC )
           IF ( RC /= HCO_SUCCESS ) THEN
              ErrMsg = 'Error encountered in "HCOX_LightNox_Run"!'
-             CALL HCO_ERROR( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+             CALL HCO_ERROR( ErrMsg, RC, ThisLoc )
              RETURN
           ENDIF
        ENDIF
@@ -567,7 +567,7 @@ CONTAINS
           CALL HCOX_SoilNox_Run( ExtState, HcoState, RC )
           IF ( RC /= HCO_SUCCESS ) THEN
              ErrMsg = 'Error encountered in "HCOX_SoilNOx_Run"!'
-             CALL HCO_ERROR( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+             CALL HCO_ERROR( ErrMsg, RC, ThisLoc )
              RETURN
           ENDIF
        ENDIF
@@ -579,7 +579,7 @@ CONTAINS
           CALL HCOX_DustDead_Run( ExtState, HcoState, RC )
           IF ( RC /= HCO_SUCCESS ) THEN
              ErrMsg = 'Error encountered in "HCOX_DustDead_Run"!'
-             CALL HCO_ERROR( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+             CALL HCO_ERROR( ErrMsg, RC, ThisLoc )
              RETURN
           ENDIF
        ENDIF
@@ -590,7 +590,7 @@ CONTAINS
           CALL HCOX_TOMAS_DustDead_Run( ExtState, HcoState, RC )
           IF ( RC /= HCO_SUCCESS ) THEN
              ErrMsg = 'Error encountered in "HCOX_TOMAS_DustDead_Run"!'
-             CALL HCO_ERROR( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+             CALL HCO_ERROR( ErrMsg, RC, ThisLoc )
              RETURN
           ENDIF
        ENDIF
@@ -603,7 +603,7 @@ CONTAINS
           CALL HCOX_DustGinoux_Run( ExtState, HcoState, RC )
           IF ( RC /= HCO_SUCCESS ) THEN
              ErrMsg = 'Error encountered in "HCOX_DustGinoux_Run"!'
-             CALL HCO_ERROR( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+             CALL HCO_ERROR( ErrMsg, RC, ThisLoc )
              RETURN
           ENDIF
        ENDIF
@@ -615,7 +615,7 @@ CONTAINS
           CALL HCOX_SeaSalt_Run( ExtState, HcoState, RC )
           IF ( RC /= HCO_SUCCESS ) THEN
              ErrMsg = 'Error encountered in "HCOX_SeaSalt_Run"!'
-             CALL HCO_ERROR( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+             CALL HCO_ERROR( ErrMsg, RC, ThisLoc )
              RETURN
           ENDIF
        ENDIF
@@ -627,7 +627,7 @@ CONTAINS
           CALL HCOX_Megan_Run( ExtState, HcoState, RC )
           IF ( RC /= HCO_SUCCESS ) THEN
              ErrMsg = 'Error encountered in "HCOX__Run"!'
-             CALL HCO_ERROR( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+             CALL HCO_ERROR( ErrMsg, RC, ThisLoc )
              RETURN
           ENDIF
        ENDIF
@@ -639,7 +639,7 @@ CONTAINS
           CALL HCOX_GFED_Run( ExtState, HcoState, RC )
           IF ( RC /= HCO_SUCCESS ) THEN
              ErrMsg = 'Error encountered in "HCOX_GFED_Run"!'
-             CALL HCO_ERROR( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+             CALL HCO_ERROR( ErrMsg, RC, ThisLoc )
              RETURN
           ENDIF
        ENDIF
@@ -651,7 +651,7 @@ CONTAINS
           CALL HcoX_FINN_Run( ExtState, HcoState, RC )
           IF ( RC /= HCO_SUCCESS ) THEN
              ErrMsg = 'Error encountered in "HCOX_FINN_Run"!'
-             CALL HCO_ERROR( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+             CALL HCO_ERROR( ErrMsg, RC, ThisLoc )
              RETURN
           ENDIF
        ENDIF
@@ -663,7 +663,7 @@ CONTAINS
           CALL HCOX_GC_RnPbBe_Run( ExtState, HcoState, RC )
           IF ( RC /= HCO_SUCCESS ) THEN
              ErrMsg = 'Error encountered in "HCOX_GC_RnPbBe_Run"!'
-             CALL HCO_ERROR( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+             CALL HCO_ERROR( ErrMsg, RC, ThisLoc )
              RETURN
           ENDIF
        ENDIF
@@ -675,7 +675,7 @@ CONTAINS
           CALL HCOX_GC_POPs_Run( ExtState, HcoState, RC )
           IF ( RC /= HCO_SUCCESS ) THEN
              ErrMsg = 'Error encountered in "HCOX_GC_POPs_Run"!'
-             CALL HCO_ERROR( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+             CALL HCO_ERROR( ErrMsg, RC, ThisLoc )
              RETURN
           ENDIF
        ENDIF
@@ -687,7 +687,7 @@ CONTAINS
           CALL HCOX_CH4Wetland_Run( ExtState, HcoState, RC )
           IF ( RC /= HCO_SUCCESS ) THEN
              ErrMsg = 'Error encountered in "HCOX_CH4Wetland_Run"!'
-             CALL HCO_ERROR( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+             CALL HCO_ERROR( ErrMsg, RC, ThisLoc )
              RETURN
           ENDIF
        ENDIF
@@ -700,7 +700,7 @@ CONTAINS
           CALL HCOX_TOMAS_Jeagle_Run( ExtState, HcoState, RC )
           IF ( RC /= HCO_SUCCESS ) THEN
              ErrMsg = 'Error encountered in "HCOX_TOMAS_Jeagle_Run"!'
-             CALL HCO_ERROR( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+             CALL HCO_ERROR( ErrMsg, RC, ThisLoc )
              RETURN
           ENDIF
        ENDIF
@@ -713,7 +713,7 @@ CONTAINS
           CALL HCOX_Iodine_Run( ExtState, HcoState, RC )
           IF ( RC /= HCO_SUCCESS ) THEN
              ErrMsg = 'Error encountered in "HCOX_Iodine_Run"!'
-             CALL HCO_ERROR( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+             CALL HCO_ERROR( ErrMsg, RC, ThisLoc )
              RETURN
           ENDIF
        ENDIF
@@ -735,7 +735,7 @@ CONTAINS
        CALL HCOX_DiagnFill( HcoState, ExtState, RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Error encountered in "HCOX_DiagnFill_Run"!'
-          CALL HCO_ERROR( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_ERROR( ErrMsg, RC, ThisLoc )
           RETURN
        ENDIF
 
@@ -968,38 +968,38 @@ CONTAINS
 
        ALLOCATE( DGN_LAI(I,J), STAT=AS )
        IF ( AS /= 0 ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, 'Diagnostics allocation error 1', RC, THISLOC=LOC )
+          CALL HCO_ERROR( 'Diagnostics allocation error 1', RC, THISLOC=LOC )
           RETURN
        ENDIF
 !       ALLOCATE( DGN_GWET(I,J), STAT=AS )
 !       IF ( AS /= 0 ) THEN
-!          CALL HCO_ERROR( HcoState%Config%Err, 'Diagnostics allocation error 1', RC, THISLOC=LOC )
+!          CALL HCO_ERROR( 'Diagnostics allocation error 1', RC, THISLOC=LOC )
 !          RETURN
 !       ENDIF
 !       ALLOCATE( DGN_T2M(I,J), DGN_V10M(I,J), DGN_U10M(I,J), STAT=AS )
 !       IF ( AS /= 0 ) THEN
-!          CALL HCO_ERROR( HcoState%Config%Err, 'Diagnostics allocation error 2', RC, THISLOC=LOC )
+!          CALL HCO_ERROR( 'Diagnostics allocation error 2', RC, THISLOC=LOC )
 !          RETURN
 !       ENDIF
 !       ALLOCATE( DGN_PARDR(I,J), DGN_PARDF(I,J), DGN_SZAFACT(I,J), STAT=AS )
 !       IF ( AS /= 0 ) THEN
-!          CALL HCO_ERROR( HcoState%Config%Err, 'Diagnostics allocation error 3', RC, THISLOC=LOC )
+!          CALL HCO_ERROR( 'Diagnostics allocation error 3', RC, THISLOC=LOC )
 !          RETURN
 !       ENDIF
 !       ALLOCATE( DGN_CLDFRC(I,J), DGN_ALBD(I,J), DGN_WLI(I,J), STAT=AS )
 !       IF ( AS /= 0 ) THEN
-!          CALL HCO_ERROR( HcoState%Config%Err, 'Diagnostics allocation error 4', RC, THISLOC=LOC )
+!          CALL HCO_ERROR( 'Diagnostics allocation error 4', RC, THISLOC=LOC )
 !          RETURN
 !       ENDIF
 !       ALLOCATE( DGN_TROPP(I,J), STAT=AS )
 !       IF ( AS /= 0 ) THEN
-!          CALL HCO_ERROR( HcoState%Config%Err, 'Diagnostics allocation error 5', RC, THISLOC=LOC )
+!          CALL HCO_ERROR( 'Diagnostics allocation error 5', RC, THISLOC=LOC )
 !          RETURN
 !       ENDIF
 
        ALLOCATE( DGN_SUNCOS(I,J), DGN_DRYTOTN(I,J), DGN_WETTOTN(I,J), STAT=AS )
        IF ( AS /= 0 ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, 'Diagnostics allocation error 6', RC, THISLOC=LOC )
+          CALL HCO_ERROR( 'Diagnostics allocation error 6', RC, THISLOC=LOC )
           RETURN
        ENDIF
 

--- a/src/Extensions/hcox_dustdead_mod.F
+++ b/src/Extensions/hcox_dustdead_mod.F
@@ -280,7 +280,7 @@
       CALL InstGet ( ExtState%DustDead, Inst, RC )
       IF ( RC /= HCO_SUCCESS ) THEN
        WRITE(MSG,*) 'Cannot find DEAD instance Nr. ', ExtState%DustDead
-       CALL HCO_ERROR(HcoState%Config%Err,MSG,RC)
+       CALL HCO_ERROR(MSG,RC)
        RETURN
       ENDIF
 
@@ -491,7 +491,7 @@
      &                        Inst%HcoIDs(N), RC,  ExtNr=Inst%ExtNr )
             IF ( RC /= HCO_SUCCESS ) THEN
                WRITE(MSG,*) 'HCO_EmisAdd error: dust bin ', N
-               CALL HCO_ERROR(HcoState%Config%Err,MSG, RC )
+               CALL HCO_ERROR(MSG, RC )
                RETURN
             ENDIF
 
@@ -506,7 +506,7 @@
      &                           ExtNr=Inst%ExtNrAlk )
                IF ( RC /= HCO_SUCCESS ) THEN
                   WRITE(MSG,*) 'HCO_EmisAdd error: dust alk bin ', N
-                  CALL HCO_ERROR(HcoState%Config%Err,MSG, RC )
+                  CALL HCO_ERROR(MSG, RC )
                   RETURN
                ENDIF
 
@@ -588,7 +588,7 @@
       Inst => NULL()
       CALL InstCreate ( ExtNr, ExtState%DustDead, Inst, RC )
       IF ( RC /= HCO_SUCCESS ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err,
+       CALL HCO_ERROR ( 
      &                 'Cannot create DEAD instance', RC )
        RETURN
       ENDIF
@@ -619,7 +619,7 @@
       ! Sanity check
       IF ( nSpc /= NBINS ) THEN
          MSG = 'Dust DEAD model does not have four species!'
-         CALL HCO_ERROR(HcoState%Config%Err,MSG, RC )
+         CALL HCO_ERROR(MSG, RC )
          RETURN
       ENDIF
 
@@ -644,7 +644,7 @@
          MSG = 'Mass flux tuning factor not defined. ' //
      &         'Please explicitly set it by modifying the line ' //
      &         '` --> Mass tuning factor: XX.X` in HEMCO_Config.rc. '
-            CALL HCO_ERROR(HcoState%Config%Err, MSG,
+            CALL HCO_ERROR(MSG,
      &                     RC, THISLOC='HCOX_DustDead_Init')
          RETURN
       ENDIF
@@ -692,7 +692,7 @@
      &           Inst%VAI_DST       ( HcoState%NX, HcoState%NY),
      &           STAT=AS )
       IF ( AS /= 0 ) THEN
-        CALL HCO_ERROR ( HcoState%Config%Err, 'Allocation error', RC )
+        CALL HCO_ERROR ( 'Allocation error', RC )
         RETURN
       ENDIF
       Inst%ERD_FCT_GEO    = 0.0_hp
@@ -707,98 +707,98 @@
 !      ! Allocate arrays
 !      ALLOCATE( Inst%FLX_LW_DWN_SFC( I, J ), STAT=AS )
 !      IF ( AS /= 0 ) THEN
-!        CALL HCO_ERROR ( HcoState%Config%Err, 'FLX_LW_DWN_SFC', RC )
+!        CALL HCO_ERROR ( 'FLX_LW_DWN_SFC', RC )
 !        RETURN
 !      ENDIF
 !      Inst%FLX_LW_DWN_SFC = 0d0
 
 !      ALLOCATE( Inst%FLX_SW_ABS_SFC( I, J ), STAT=AS )
 !      IF ( AS /= 0 ) THEN
-!        CALL HCO_ERROR ( HcoState%Config%Err, 'FLX_SW_ABS_SFC', RC )
+!        CALL HCO_ERROR ( 'FLX_SW_ABS_SFC', RC )
 !        RETURN
 !      ENDIF
 !      Inst%FLX_SW_ABS_SFC = 0d0
 
 !      ALLOCATE( Inst%TPT_GND( I, J ), STAT=AS )
 !      IF ( AS /= 0 ) THEN
-!        CALL HCO_ERROR ( HcoState%Config%Err, 'TPT_GND', RC )
+!        CALL HCO_ERROR ( 'TPT_GND', RC )
 !        RETURN
 !      ENDIF
 !      Inst%TPT_GND = 0d0
 
 !      ALLOCATE( Inst%TPT_SOI( I, J ), STAT=AS )
 !      IF ( AS /= 0 ) THEN
-!        CALL HCO_ERROR ( HcoState%Config%Err, 'TPT_SOI', RC )
+!        CALL HCO_ERROR ( 'TPT_SOI', RC )
 !        RETURN
 !      ENDIF
 !      Inst%TPT_SOI = 0d0
 
 !      ALLOCATE( Inst%VWC_SFC( I, J ), STAT=AS )
 !      IF ( AS /= 0 ) THEN
-!        CALL HCO_ERROR ( HcoState%Config%Err, 'VWC_SFC', RC )
+!        CALL HCO_ERROR ( 'VWC_SFC', RC )
 !        RETURN
 !      ENDIF
 !      Inst%VWC_SFC = 0d0
 
 !      ALLOCATE( Inst%SRC_STR( I, J ), STAT=AS )
 !      IF ( AS /= 0 ) THEN
-!        CALL HCO_ERROR ( HcoState%Config%Err, 'SRC_STR', RC )
+!        CALL HCO_ERROR ( 'SRC_STR', RC )
 !        RETURN
 !      ENDIF
 !      Inst%SRC_STR = 0d0
 
       ALLOCATE( Inst%PLN_TYP( 0:28, 3 ), STAT=AS )
       IF ( AS /= 0 ) THEN
-        CALL HCO_ERROR ( HcoState%Config%Err, 'PLN_TYP', RC )
+        CALL HCO_ERROR ( 'PLN_TYP', RC )
         RETURN
       ENDIF
       Inst%PLN_TYP = 0
 
       ALLOCATE( Inst%PLN_FRC( 0:28, 3 ), STAT=AS )
       IF ( AS /= 0 ) THEN
-        CALL HCO_ERROR ( HcoState%Config%Err, 'PLN_FRC', RC )
+        CALL HCO_ERROR ( 'PLN_FRC', RC )
         RETURN
       ENDIF
       Inst%PLN_FRC = 0d0
 
       ALLOCATE( Inst%TAI( MVT, 12 ), STAT=AS )
       IF ( AS /= 0 ) THEN
-        CALL HCO_ERROR ( HcoState%Config%Err, 'TAI', RC )
+        CALL HCO_ERROR ( 'TAI', RC )
         RETURN
       ENDIF
       Inst%TAI = 0d0
 
       ALLOCATE( Inst%DMT_VWR( NBINS ), STAT=AS )
       IF ( AS /= 0 ) THEN
-        CALL HCO_ERROR ( HcoState%Config%Err, 'DMT_VWR', RC )
+        CALL HCO_ERROR ( 'DMT_VWR', RC )
         RETURN
       ENDIF
       Inst%DMT_VWR = 0d0
 
 !      ALLOCATE( Inst%DNS_AER( NBINS ), STAT=AS )
 !      IF ( AS /= 0 ) THEN
-!        CALL HCO_ERROR ( HcoState%Config%Err, 'DNS_AER', RC )
+!        CALL HCO_ERROR ( 'DNS_AER', RC )
 !        RETURN
 !      ENDIF
 !      Inst%DNS_AER = 0d0
 
       ALLOCATE( Inst%OVR_SRC_SNK_FRC( DST_SRC_NBR, NBINS ), STAT=AS )
       IF ( AS /= 0 ) THEN
-        CALL HCO_ERROR ( HcoState%Config%Err, 'OVR_SRC_SNK_FRC', RC )
+        CALL HCO_ERROR ( 'OVR_SRC_SNK_FRC', RC )
         RETURN
       ENDIF
       Inst%OVR_SRC_SNK_FRC = 0d0
 
       ALLOCATE( Inst%OVR_SRC_SNK_MSS( DST_SRC_NBR, NBINS ), STAT=AS )
       IF ( AS /= 0 ) THEN
-        CALL HCO_ERROR ( HcoState%Config%Err, 'OVR_SRC_SNK_MSS', RC )
+        CALL HCO_ERROR ( 'OVR_SRC_SNK_MSS', RC )
         RETURN
       ENDIF
       Inst%OVR_SRC_SNK_MSS = 0d0
 
 !      ALLOCATE( Inst%OROGRAPHY( I, J ), STAT=AS )
 !      IF ( AS /= 0 ) THEN
-!        CALL HCO_ERROR ( HcoState%Config%Err, 'OROGRAPHY', RC )
+!        CALL HCO_ERROR ( 'OROGRAPHY', RC )
 !        RETURN
 !      ENDIF
 !      Inst%OROGRAPHY = 0
@@ -806,7 +806,7 @@
       ! Bin size min diameter [m]
       ALLOCATE( Inst%DMT_MIN( NBINS ), STAT=AS )
       IF ( AS /= 0 ) THEN
-        CALL HCO_ERROR ( HcoState%Config%Err, 'DMT_MIN', RC )
+        CALL HCO_ERROR ( 'DMT_MIN', RC )
         RETURN
       ENDIF
       Inst%DMT_MIN(1) = 0.2d-6
@@ -817,7 +817,7 @@
       ! Bin size max diameter [m]
       ALLOCATE( Inst%DMT_MAX( NBINS ), STAT=AS )
       IF ( AS /= 0 ) THEN
-        CALL HCO_ERROR ( HcoState%Config%Err, 'DMT_MAX', RC )
+        CALL HCO_ERROR ( 'DMT_MAX', RC )
         RETURN
       ENDIF
       Inst%DMT_MAX(1) = 2.0d-6
@@ -831,7 +831,7 @@
       ! Mass median diameter BSM96 p. 73 Table 2
       ALLOCATE( Inst%DMT_VMA_SRC( DST_SRC_NBR ), STAT=AS )
       IF ( AS /= 0 ) THEN
-        CALL HCO_ERROR ( HcoState%Config%Err, 'DMT_VMA_SRC', RC )
+        CALL HCO_ERROR ( 'DMT_VMA_SRC', RC )
         RETURN
       ENDIF
       Inst%DMT_VMA_SRC(1) = 0.832d-6
@@ -842,7 +842,7 @@
       ! BSM96 p. 73 Table 2
       ALLOCATE( Inst%GSD_ANL_SRC( DST_SRC_NBR ), STAT=AS )
       IF ( AS /= 0 ) THEN
-        CALL HCO_ERROR ( HcoState%Config%Err, 'GSD_ANL_SRC', RC )
+        CALL HCO_ERROR ( 'GSD_ANL_SRC', RC )
         RETURN
       ENDIF
       Inst%GSD_ANL_SRC(1) = 2.10d0
@@ -852,7 +852,7 @@
       ! MSS_FRC_SRC:  Mass fraction BSM96 p. 73 Table 2
       ALLOCATE( Inst%MSS_FRC_SRC( DST_SRC_NBR ), STAT=AS )
       IF ( AS /= 0 ) THEN
-        CALL HCO_ERROR ( HcoState%Config%Err, 'MSS_FRC_SRC', RC )
+        CALL HCO_ERROR ( 'MSS_FRC_SRC', RC )
         RETURN
       ENDIF
       Inst%MSS_FRC_SRC(1) = 0.036d0
@@ -1175,7 +1175,7 @@
          ! Stop occasional haywire model runs
 !         IF ( TPT_MDP(I) > 350.0d0 ) THEN
 !            MSG = 'TPT_MDP(i) > 350.0'
-!            CALL HCO_ERROR(HcoState%Config%Err,MSG, RC, THISLOC='DST_MBL' )
+!            CALL HCO_ERROR(MSG, RC, THISLOC='DST_MBL' )
 !            RETURN
 !         ENDIF
          ! Now simply restrict to 350K, rather than crashing
@@ -2606,7 +2606,7 @@
          ! tdf 10/27/2K3 -- Sanity check
          IF ( RGH_MMN(LON_IDX) <= 0.0 ) THEN
             MSG = 'RGH_MMN <= 0.0'
-            CALL HCO_ERROR(HcoState%Config%Err,MSG,RC,THISLOC='BLM_MBL')
+            CALL HCO_ERROR(MSG,RC,THISLOC='BLM_MBL')
             RETURN
          ENDIF
 
@@ -2620,7 +2620,7 @@
          ! Sanity check
          IF ( WND_FRC_DENOM <= 0.0 ) THEN
             MSG = 'WND_FRC_DENOM <= 0.0'
-            CALL HCO_ERROR(HcoState%Config%Err,MSG,RC,THISLOC='BLM_MBL')
+            CALL HCO_ERROR(MSG,RC,THISLOC='BLM_MBL')
             RETURN
          ENDIF
 
@@ -3061,7 +3061,7 @@
 
               ! Presumably ocean snuck through
               ELSE
-                 CALL HCO_ERROR( HcoState%Config%Err,
+                 CALL HCO_ERROR( 
      &                          'pln_typ_idx == 0', RC,
      &                           THISLOC='RGH_MMN_GET' )
                  RETURN
@@ -3413,7 +3413,7 @@
 
       ! Error check
       IF ( RYN_NBR < 0.03D0 ) THEN
-         CALL HCO_ERROR ( HcoState%Config%Err, 'RYN_NBR < 0.03', RC,
+         CALL HCO_ERROR ( 'RYN_NBR < 0.03', RC,
      &      THISLOC='WND_FRC_THR_SLT_GET' )
          RETURN
 
@@ -3737,7 +3737,7 @@
       ! Error check
       if ( FEFF <= 0.0D0 .OR. FEFF > 1.0D0 ) THEN
          MSG = 'Feff out of range!'
-         CALL HCO_ERROR(HcoState%Config%Err,MSG, RC,
+         CALL HCO_ERROR(MSG, RC,
      &      THISLOC='FRC_THR_NC_DRG_GET' )
          RETURN
       ENDIF
@@ -4042,7 +4042,7 @@
                IF ( MSS_FRC_CACO3_SZ_CRR < 0.0D0  .OR.
      &              MSS_FRC_CACO3_SZ_CRR > 1.0D0 ) THEN
                   MSG = 'mss_frc_CaC_s < 0.0.or.mss_frc_CaC_s > 1.0!'
-                  CALL HCO_ERROR(HcoState%Config%Err,MSG, RC,
+                  CALL HCO_ERROR(MSG, RC,
      &               THISLOC='FLX_MSS_CACO3_MSK' )
                   RETURN
                ENDIF
@@ -4050,7 +4050,7 @@
                IF ( MSS_FRC_CACO3_SLC(LON_IDX) < 0.0D0  .OR.
      &              MSS_FRC_CACO3_SLC(LON_IDX) > 1.0D0 ) THEN
                   MSG = 'mss_frc_CaCO3_s < 0.0.or.mss_frc_CaCO3 > 1.0!'
-                  CALL HCO_ERROR(HcoState%Config%Err,MSG, RC,
+                  CALL HCO_ERROR(MSG, RC,
      &               THISLOC='FLX_MSS_CACO3_MSK' )
                   RETURN
                ENDIF
@@ -4557,7 +4557,7 @@
       ! Error check
       IF ( VAI_MBL_THR <= 0.0d0 ) THEN
          MSG = 'VAI_MBL_THR <= 0.0'
-         CALL HCO_ERROR(HcoState%Config%Err,MSG, RC,
+         CALL HCO_ERROR(MSG, RC,
      &        THISLOC='LND_FRC_MBL_GET' )
          RETURN
       ENDIF
@@ -4684,14 +4684,14 @@
          ! Error check
          IF ( LND_FRC_MBL(lon_idx) > 1.0D0 ) THEN
             MSG = 'LND_FRC_MBL > 1'
-            CALL HCO_ERROR(HcoState%Config%Err,MSG, RC,
+            CALL HCO_ERROR(MSG, RC,
      &         THISLOC='LND_FRC_MBL_GET' )
             RETURN
          ENDIF
 
          IF ( LND_FRC_MBL(LON_IDX) < 0.0D0 )   then
             MSG = 'LND_FRC_MBL < 0'
-            CALL HCO_ERROR(HcoState%Config%Err,MSG, RC,
+            CALL HCO_ERROR(MSG, RC,
      &         THISLOC='LND_FRC_MBL_GET' )
             RETURN
          ENDIF
@@ -4881,7 +4881,7 @@
          ! 19990913: erf() in SGI /usr/lib64/mips4/libftn.so is bogus
          IF ( ABS( 0.8427d0 - ERF(1.0d0) ) / 0.8427d0 > 0.001d0 ) THEN
             MSG = 'ERF error 1 in OVR_SRC_SNK_FRC_GET!'
-            CALL HCO_ERROR(HcoState%Config%Err,MSG, RC,
+            CALL HCO_ERROR(MSG, RC,
      &         THISLOC='OVR_SRC_SNK_FRC_GET' )
             RETURN
          ENDIF
@@ -4889,7 +4889,7 @@
          ! Another ERF check
          IF ( ERF( 0.0D0 ) /= 0.0D0 ) THEN
             MSG = 'ERF error 2 in OVR_SRC_SNK_FRC_GET!'
-            CALL HCO_ERROR(HcoState%Config%Err,MSG, RC,
+            CALL HCO_ERROR(MSG, RC,
      &         THISLOC='OVR_SRC_SNK_FRC_GET' )
             RETURN
          ENDIF

--- a/src/Extensions/hcox_dustginoux_mod.F90
+++ b/src/Extensions/hcox_dustginoux_mod.F90
@@ -195,7 +195,7 @@ CONTAINS
     CALL InstGet ( ExtState%DustGinoux, Inst, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        WRITE(MSG,*) 'Cannot find DustGinoux instance Nr. ', ExtState%DustGinoux
-       CALL HCO_ERROR(HcoState%Config%Err,MSG,RC)
+       CALL HCO_ERROR(MSG,RC)
        RETURN
     ENDIF
 
@@ -375,7 +375,7 @@ CONTAINS
                             Inst%HcoIDs(N), RC,       ExtNr=Inst%ExtNr   )
           IF ( RC /= HCO_SUCCESS ) THEN
              WRITE(MSG,*) 'HCO_EmisAdd error: dust bin ', N
-             CALL HCO_ERROR(HcoState%Config%Err,MSG, RC )
+             CALL HCO_ERROR(MSG, RC )
              RETURN
           ENDIF
 
@@ -391,7 +391,7 @@ CONTAINS
                                Inst%HcoIDsAlk(N), RC, ExtNr=Inst%ExtNrAlk)
              IF ( RC /= HCO_SUCCESS ) THEN
                 WRITE(MSG,*) 'HCO_EmisAdd error: dust alkalinity bin ', N
-                CALL HCO_ERROR(HcoState%Config%Err,MSG, RC )
+                CALL HCO_ERROR(MSG, RC )
                 RETURN
              ENDIF
           ENDIF
@@ -475,7 +475,7 @@ CONTAINS
     Inst => NULL()
     CALL InstCreate ( ExtNr, ExtState%DustGinoux, Inst, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, 'Cannot create DustGinoux instance', RC )
+       CALL HCO_ERROR ( 'Cannot create DustGinoux instance', RC )
        RETURN
     ENDIF
     ! Also fill Inst%ExtNr
@@ -508,7 +508,7 @@ CONTAINS
        WRITE( MSG, 100 ) Inst%NBINS, nSpc
  100   FORMAT( 'Expected ', i3, ' DustGinoux species but only found ', i3, &
                ' in the HEMCO configuration file!  Exiting...' )
-       CALL HCO_ERROR(HcoState%Config%Err,MSG, RC )
+       CALL HCO_ERROR(MSG, RC )
        RETURN
     ENDIF
 
@@ -573,7 +573,7 @@ CONTAINS
                Inst%SRCE_CLAY ( HcoState%NX, HcoState%NY ), &
                STAT = AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR(HcoState%Config%Err,'Allocation error', RC )
+       CALL HCO_ERROR('Allocation error', RC )
        RETURN
     ENDIF
 
@@ -601,7 +601,7 @@ CONTAINS
 
 #if !defined( TOMAS )
        MSG = 'Cannot have > 4 GINOUX dust bins unless you are using TOMAS!'
-       CALL HCO_ERROR(HcoState%Config%Err,MSG, RC )
+       CALL HCO_ERROR(MSG, RC )
        RETURN
 #endif
 
@@ -731,7 +731,7 @@ CONTAINS
     ELSE
 
        ! Stop w/ error message
-       CALL HCO_ERROR( HcoState%Config%Err, 'Wrong number of TOMAS dust bins!', RC )
+       CALL HCO_ERROR( 'Wrong number of TOMAS dust bins!', RC )
 
     ENDIF
 

--- a/src/Extensions/hcox_finn_mod.F90
+++ b/src/Extensions/hcox_finn_mod.F90
@@ -266,7 +266,7 @@ CONTAINS
     CALL InstGet ( ExtState%FINN, Inst, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        WRITE(MSG,*) 'Cannot find FINN instance Nr. ', ExtState%FINN
-       CALL HCO_ERROR(HcoState%Config%Err,MSG,RC)
+       CALL HCO_ERROR(MSG,RC)
        RETURN
     ENDIF
 
@@ -384,7 +384,7 @@ CONTAINS
           ELSEIF ( NF == 6 ) THEN
              THISTYP => Inst%VEGTYP9
           ELSE
-             CALL HCO_ERROR ( HcoState%Config%Err, 'Undefined emission factor', RC )
+             CALL HCO_ERROR ( 'Undefined emission factor', RC )
              RETURN
           ENDIF
 
@@ -495,7 +495,7 @@ CONTAINS
                          RC,       ExtNr=Inst%ExtNr, Cat=-1, Hier=-1 )
        IF ( RC /= HCO_SUCCESS ) THEN
           MSG = 'HCO_EmisAdd error: ' // TRIM(HcoState%Spc(HcoID)%SpcName)
-          CALL HCO_ERROR(HcoState%Config%Err,MSG, RC )
+          CALL HCO_ERROR(MSG, RC )
           RETURN
        ENDIF
 
@@ -624,7 +624,7 @@ CONTAINS
     Inst => NULL()
     CALL InstCreate ( ExtNr, ExtState%FINN, Inst, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, 'Cannot create FINN instance', RC )
+       CALL HCO_ERROR ( 'Cannot create FINN instance', RC )
        RETURN
     ENDIF
 
@@ -669,7 +669,7 @@ CONTAINS
          Inst%BCPIfrac < 0.0_sp .OR. Inst%BCPIfrac > 1.0_sp     ) THEN
        WRITE(MSG,*) 'hydrophilic fractions must be between 0-1: ', &
           Inst%OCPIfrac, Inst%BCPIfrac
-       CALL HCO_ERROR(HcoState%Config%Err,MSG, RC )
+       CALL HCO_ERROR(MSG, RC )
        RETURN
     ENDIF
 
@@ -688,7 +688,7 @@ CONTAINS
     ! FINN species names
     ALLOCATE ( Inst%FINN_SPEC_NAME ( N_SPEC ), STAT=AS )
     IF ( AS/=0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'Cannot allocate FINN_SPEC_NAME', RC )
+       CALL HCO_ERROR( 'Cannot allocate FINN_SPEC_NAME', RC )
        RETURN
     ENDIF
     Inst%FINN_SPEC_NAME = ''
@@ -697,7 +697,7 @@ CONTAINS
     ! scale factors for all FINN species.
     ALLOCATE ( Inst%FINN_EMFAC ( N_SPEC, N_EMFAC ), STAT=AS )
     IF ( AS/=0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'Cannot allocate FINN_EMFAC', RC )
+       CALL HCO_ERROR( 'Cannot allocate FINN_EMFAC', RC )
        RETURN
     ENDIF
     Inst%FINN_EMFAC = 0.0_dp
@@ -708,7 +708,7 @@ CONTAINS
                Inst%SpcScal(nSpcMax), Inst%SpcScalFldNme(nSpcMax), STAT=AS )
 
     IF ( AS/=0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'Cannot allocate FinnIDs', RC )
+       CALL HCO_ERROR( 'Cannot allocate FinnIDs', RC )
        RETURN
     ENDIF
     Inst%nSpc             = 0
@@ -725,7 +725,7 @@ CONTAINS
                Inst%VEGTYP5(HcoState%NX,HcoState%NY), &
                Inst%VEGTYP9(HcoState%NX,HcoState%NY), STAT=AS )
     IF ( AS/=0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'Cannot allocate VEGTYP', RC )
+       CALL HCO_ERROR( 'Cannot allocate VEGTYP', RC )
        RETURN
     ENDIF
     Inst%VEGTYP1 = 0.0_hp
@@ -847,7 +847,7 @@ CONTAINS
     IF ( RC /= HCO_SUCCESS ) RETURN
     IF ( tnSpc == 0 ) THEN
        MSG = 'No FINN species specified'
-       CALL HCO_ERROR(HcoState%Config%Err,MSG, RC )
+       CALL HCO_ERROR(MSG, RC )
        RETURN
     ENDIF
 
@@ -878,7 +878,7 @@ CONTAINS
              'This version of HEMCO expects species scale factors to be ' // &
              'set as `Scaling_XX` instead of `XX scale factor`. '         // &
              'Please update the FINN settings section accordingly.'
-       CALL HCO_ERROR(HcoState%Config%Err,MSG, RC )
+       CALL HCO_ERROR(MSG, RC )
        RETURN
     ENDIF
 
@@ -942,7 +942,7 @@ CONTAINS
                 IF ( Inst%nSpc > nSpcMax ) THEN
                    MSG = 'nSpc greater than nSpcMax, please increase ' // &
                          'parameter `nSpcMax` in hcox_finn_mod.F90'
-                   CALL HCO_ERROR ( HcoState%Config%Err, MSG, RC )
+                   CALL HCO_ERROR ( MSG, RC )
                    RETURN
                 ENDIF
 
@@ -1099,7 +1099,7 @@ CONTAINS
        ! in FINN.
        IF ( .NOT. Matched ) THEN
           MSG = 'Species '// TRIM(SpcName) //' not found in FINN'
-          CALL HCO_ERROR(HcoState%Config%Err,MSG, RC )
+          CALL HCO_ERROR(MSG, RC )
           RETURN
        ENDIF
     ENDDO !L

--- a/src/Extensions/hcox_finn_mod.FINNv16
+++ b/src/Extensions/hcox_finn_mod.FINNv16
@@ -371,7 +371,7 @@ CONTAINS
           ELSEIF ( NF == 7 ) THEN
              THISTYP => VEGTYP9
           ELSE
-             CALL HCO_ERROR ( HcoState%Config%Err, 'Undefined emission factor', RC )
+             CALL HCO_ERROR ( 'Undefined emission factor', RC )
              RETURN
           ENDIF
 
@@ -482,7 +482,7 @@ CONTAINS
                          RC,       ExtNr=ExtNr, Cat=-1, Hier=-1 )
        IF ( RC /= HCO_SUCCESS ) THEN
           MSG = 'HCO_EmisAdd error: ' // TRIM(HcoState%Spc(HcoID)%SpcName)
-          CALL HCO_ERROR(HcoState%Config%Err,MSG, RC )
+          CALL HCO_ERROR(MSG, RC )
           RETURN
        ENDIF
 
@@ -643,7 +643,7 @@ CONTAINS
          BCPIfrac < 0.0_sp .OR. BCPIfrac > 1.0_sp     ) THEN
        WRITE(MSG,*) 'hydrophilic fractions must be between 0-1: ', &
           OCPIfrac, BCPIfrac
-       CALL HCO_ERROR(HcoState%Config%Err,MSG, RC )
+       CALL HCO_ERROR(MSG, RC )
        RETURN
     ENDIF
 
@@ -662,7 +662,7 @@ CONTAINS
     ! FINN species names
     ALLOCATE ( FINN_SPEC_NAME ( N_SPEC ), STAT=AS )
     IF ( AS/=0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'Cannot allocate FINN_SPEC_NAME', RC )
+       CALL HCO_ERROR( 'Cannot allocate FINN_SPEC_NAME', RC )
        RETURN
     ENDIF
     FINN_SPEC_NAME = ''
@@ -671,7 +671,7 @@ CONTAINS
     ! scale factors for all FINN species.
     ALLOCATE ( FINN_EMFAC ( N_SPEC, N_EMFAC ), STAT=AS )
     IF ( AS/=0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'Cannot allocate FINN_EMFAC', RC )
+       CALL HCO_ERROR( 'Cannot allocate FINN_EMFAC', RC )
        RETURN
     ENDIF
     FINN_EMFAC = 0.0_dp
@@ -682,7 +682,7 @@ CONTAINS
                SpcScal(nSpcMax), SpcScalFldNme(nSpcMax), STAT=AS )
 
     IF ( AS/=0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'Cannot allocate FinnIDs', RC )
+       CALL HCO_ERROR( 'Cannot allocate FinnIDs', RC )
        RETURN
     ENDIF
     nSpc             = 0
@@ -700,7 +700,7 @@ CONTAINS
                VEGTYP6(HcoState%NX,HcoState%NY), &
                VEGTYP9(HcoState%NX,HcoState%NY), STAT=AS )
     IF ( AS/=0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'Cannot allocate VEGTYP', RC )
+       CALL HCO_ERROR( 'Cannot allocate VEGTYP', RC )
        RETURN
     ENDIF
     VEGTYP1 = 0.0_hp
@@ -823,7 +823,7 @@ CONTAINS
     IF ( RC /= HCO_SUCCESS ) RETURN
     IF ( tnSpc == 0 ) THEN
        MSG = 'No FINN species specified'
-       CALL HCO_ERROR(HcoState%Config%Err,MSG, RC )
+       CALL HCO_ERROR(MSG, RC )
        RETURN
     ENDIF
 
@@ -854,7 +854,7 @@ CONTAINS
              'This version of HEMCO expects species scale factors to be ' // &
              'set as `Scaling_XX` instead of `XX scale factor`. '         // &
              'Please update the FINN settings section accordingly.'
-       CALL HCO_ERROR(HcoState%Config%Err,MSG, RC )
+       CALL HCO_ERROR(MSG, RC )
        RETURN
     ENDIF
 
@@ -918,7 +918,7 @@ CONTAINS
                 IF ( nSpc > nSpcMax ) THEN
                    MSG = 'nSpc greater than nSpcMax, please increase ' // &
                          'parameter `nSpcMax` in hcox_finn_mod.F90'
-                   CALL HCO_ERROR ( HcoState%Config%Err, MSG, RC )
+                   CALL HCO_ERROR ( MSG, RC )
                    RETURN
                 ENDIF
 
@@ -1075,7 +1075,7 @@ CONTAINS
        ! in FINN.
        IF ( .NOT. Matched ) THEN
           MSG = 'Species '// TRIM(SpcName) //' not found in FINN'
-          CALL HCO_ERROR(HcoState%Config%Err,MSG, RC )
+          CALL HCO_ERROR(MSG, RC )
           RETURN
        ENDIF
     ENDDO !L

--- a/src/Extensions/hcox_gc_POPs_mod.F90
+++ b/src/Extensions/hcox_gc_POPs_mod.F90
@@ -249,7 +249,7 @@ CONTAINS
     CALL InstGet ( ExtState%GC_POPs, Inst, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        WRITE(MSG,*) 'Cannot find GC_POPs instance Nr. ', ExtState%GC_POPs
-       CALL HCO_ERROR(HcoState%Config%Err,MSG,RC)
+       CALL HCO_ERROR(MSG,RC)
        RETURN
     ENDIF
 
@@ -297,7 +297,7 @@ CONTAINS
 
     ! Maximum extent of the PBL [model level]
     IF ( .NOT. ASSOCIATED(ExtState%PBL_MAX) ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, 'PBL_MAX not defined in ExtState!', RC )
+       CALL HCO_ERROR ( 'PBL_MAX not defined in ExtState!', RC )
        RETURN
     ELSE
        PBL_MAX = DBLE( ExtState%PBL_MAX )
@@ -458,7 +458,7 @@ CONTAINS
                          RC, ExtNr=Inst%ExtNr )
        Arr3D => NULL()
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, 'HCO_EmisAdd error: EmisPOPPOCPO', RC )
+          CALL HCO_ERROR( 'HCO_EmisAdd error: EmisPOPPOCPO', RC )
           RETURN
        ENDIF
     ENDIF
@@ -474,7 +474,7 @@ CONTAINS
                          RC, ExtNr=Inst%ExtNr )
        Arr3D => NULL()
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, 'HCO_EmisAdd error: EmisPOPPBCPO', RC )
+          CALL HCO_ERROR( 'HCO_EmisAdd error: EmisPOPPBCPO', RC )
           RETURN
        ENDIF
     ENDIF
@@ -490,7 +490,7 @@ CONTAINS
                          RC, ExtNr=Inst%ExtNr )
        Arr3D => NULL()
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, 'HCO_EmisAdd error: EmisPOPG', RC )
+          CALL HCO_ERROR( 'HCO_EmisAdd error: EmisPOPG', RC )
           RETURN
        ENDIF
 
@@ -1630,7 +1630,7 @@ CONTAINS
     Inst => NULL()
     CALL InstCreate ( ExtNr, ExtState%GC_POPs, Inst, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, 'Cannot create GC_POPs instance', RC )
+       CALL HCO_ERROR ( 'Cannot create GC_POPs instance', RC )
        RETURN
     ENDIF
     ! Also fill ExtNrSS - this is the same as the parent ExtNr
@@ -1670,21 +1670,21 @@ CONTAINS
     ! ERROR: POPG tracer is not found!
     IF ( Inst%IDTPOPG <= 0 ) THEN
        RC = HCO_FAIL
-       CALL HCO_ERROR( HcoState%Config%Err, 'Cannot find POPG tracer in list of species!', RC )
+       CALL HCO_ERROR( 'Cannot find POPG tracer in list of species!', RC )
        RETURN
     ENDIF
 
     ! ERROR! POPPOCPO tracer is not found
     IF ( Inst%IDTPOPPOCPO <= 0 ) THEN
        RC = HCO_FAIL
-       CALL HCO_ERROR( HcoState%Config%Err, 'Cannot find POPPOCPO tracer in list of species!', RC )
+       CALL HCO_ERROR( 'Cannot find POPPOCPO tracer in list of species!', RC )
        RETURN
     ENDIF
 
     ! ERROR! POPPBCPO tracer is not found
     IF ( Inst%IDTPOPPBCPO <= 0 ) THEN
        RC = HCO_FAIL
-       CALL HCO_ERROR( HcoState%Config%Err, 'Cannot find POPPBCPO tracer in list of species!', RC )
+       CALL HCO_ERROR( 'Cannot find POPPBCPO tracer in list of species!', RC )
        RETURN
     ENDIF
 
@@ -1714,119 +1714,119 @@ CONTAINS
 
     ALLOCATE( Inst%EmisPOPG( HcoState%NX, HcoState%NY, HcoState%NZ ), STAT=RC )
     IF ( RC /= 0 ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, 'Cannot allocate EmisPOPG', RC )
+       CALL HCO_ERROR ( 'Cannot allocate EmisPOPG', RC )
        RETURN
     ENDIF
     Inst%EmisPOPG = 0.0e0_hp
 
     ALLOCATE( Inst%EmisPOPPOCPO( HcoState%NX, HcoState%NY, HcoState%NZ ), STAT=RC )
     IF ( RC /= 0 ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, 'Cannot allocate EmisPOPPOCPO', RC )
+       CALL HCO_ERROR ( 'Cannot allocate EmisPOPPOCPO', RC )
        RETURN
     ENDIF
     Inst%EmisPOPPOCPO = 0.0e0_hp
 
     ALLOCATE( Inst%EmisPOPPBCPO( HcoState%NX, HcoState%NY, HcoState%NZ ), STAT=RC )
     IF ( RC /= 0 ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, 'Cannot allocate EmisPOPPBCPO', RC )
+       CALL HCO_ERROR ( 'Cannot allocate EmisPOPPBCPO', RC )
        RETURN
     ENDIF
     Inst%EmisPOPPBCPO = 0.0e0_hp
 
     ALLOCATE( Inst%EmisPOPGfromSoil( HcoState%NX, HcoState%NY ), STAT=RC )
     IF ( RC /= 0 ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, 'Cannot allocate EmisPOPGfromSoil', RC )
+       CALL HCO_ERROR ( 'Cannot allocate EmisPOPGfromSoil', RC )
        RETURN
     ENDIF
     Inst%EmisPOPGfromSoil = 0.0e0_hp
 
     ALLOCATE( Inst%EmisPOPGfromLake( HcoState%NX, HcoState%NY ), STAT=RC )
     IF ( RC /= 0 ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, 'Cannot allocate EmisPOPGfromLake', RC )
+       CALL HCO_ERROR ( 'Cannot allocate EmisPOPGfromLake', RC )
        RETURN
     ENDIF
     Inst%EmisPOPGfromLake = 0.0e0_hp
 
     ALLOCATE( Inst%EmisPOPGfromLeaf( HcoState%NX, HcoState%NY ), STAT=RC )
     IF ( RC /= 0 ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, 'Cannot allocate EmisPOPGfromLeaf', RC )
+       CALL HCO_ERROR ( 'Cannot allocate EmisPOPGfromLeaf', RC )
        RETURN
     ENDIF
     Inst%EmisPOPGfromLeaf = 0.0e0_hp
 
     ALLOCATE( Inst%EmisPOPGfromSnow( HcoState%NX, HcoState%NY ), STAT=RC )
     IF ( RC /= 0 ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, 'Cannot allocate EmisPOPGfromSnow', RC )
+       CALL HCO_ERROR ( 'Cannot allocate EmisPOPGfromSnow', RC )
        RETURN
     ENDIF
     Inst%EmisPOPGfromSnow = 0.0e0_hp
 
     ALLOCATE( Inst%EmisPOPGfromOcean( HcoState%NX, HcoState%NY ), STAT=RC )
     IF ( RC /= 0 ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, 'Cannot allocate EmisPOPGfromOcean', RC )
+       CALL HCO_ERROR ( 'Cannot allocate EmisPOPGfromOcean', RC )
        RETURN
     ENDIF
     Inst%EmisPOPGfromOcean = 0.0e0_hp
 
     ALLOCATE( Inst%FluxPOPGfromSoilToAir( HcoState%NX, HcoState%NY ), STAT=RC )
     IF ( RC /= 0 ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, 'Cannot allocate FluxPOPGfromSoilToAir', RC )
+       CALL HCO_ERROR ( 'Cannot allocate FluxPOPGfromSoilToAir', RC )
        RETURN
     ENDIF
     Inst%FluxPOPGfromSoilToAir = 0.0e0_hp
 
     ALLOCATE( Inst%FluxPOPGfromAirToSoil( HcoState%NX, HcoState%NY ), STAT=RC )
     IF ( RC /= 0 ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, 'Cannot allocate FluxPOPGfromAirToSoil', RC )
+       CALL HCO_ERROR ( 'Cannot allocate FluxPOPGfromAirToSoil', RC )
        RETURN
     ENDIF
     Inst%FluxPOPGfromAirToSoil = 0.0e0_hp
 
     ALLOCATE( Inst%FluxPOPGfromLakeToAir( HcoState%NX, HcoState%NY ), STAT=RC )
     IF ( RC /= 0 ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, 'Cannot allocate FluxPOPGfromLakeToAir', RC )
+       CALL HCO_ERROR ( 'Cannot allocate FluxPOPGfromLakeToAir', RC )
        RETURN
     ENDIF
     Inst%FluxPOPGfromLakeToAir = 0.0e0_hp
 
     ALLOCATE( Inst%FluxPOPGfromAirToLake( HcoState%NX, HcoState%NY ), STAT=RC )
     IF ( RC /= 0 ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, 'Cannot allocate FluxPOPGfromAirToLake', RC )
+       CALL HCO_ERROR ( 'Cannot allocate FluxPOPGfromAirToLake', RC )
        RETURN
     ENDIF
     Inst%FluxPOPGfromAirToLake = 0.0e0_hp
 
     ALLOCATE( Inst%FluxPOPGfromLeafToAir( HcoState%NX, HcoState%NY ), STAT=RC )
     IF ( RC /= 0 ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, 'Cannot allocate FluxPOPGfromLeafToAir', RC )
+       CALL HCO_ERROR ( 'Cannot allocate FluxPOPGfromLeafToAir', RC )
        RETURN
     ENDIF
     Inst%FluxPOPGfromLeafToAir = 0.0e0_hp
 
     ALLOCATE( Inst%FluxPOPGfromAirToLeaf( HcoState%NX, HcoState%NY ), STAT=RC )
     IF ( RC /= 0 ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, 'Cannot allocate FluxPOPGfromAirToLeaf', RC )
+       CALL HCO_ERROR ( 'Cannot allocate FluxPOPGfromAirToLeaf', RC )
        RETURN
     ENDIF
     Inst%FluxPOPGfromAirToLeaf = 0.0e0_hp
 
     ALLOCATE( Inst%FugacitySoilToAir( HcoState%NX, HcoState%NY ), STAT=RC )
     IF ( RC /= 0 ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, 'Cannot allocate FugacitySoilToAir', RC )
+       CALL HCO_ERROR ( 'Cannot allocate FugacitySoilToAir', RC )
        RETURN
     ENDIF
     Inst%FugacitySoilToAir = 0.0e0_hp
 
     ALLOCATE( Inst%FugacityLakeToAir( HcoState%NX, HcoState%NY ), STAT=RC )
     IF ( RC /= 0 ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, 'Cannot allocate FugacityLakeToAir', RC )
+       CALL HCO_ERROR ( 'Cannot allocate FugacityLakeToAir', RC )
        RETURN
     ENDIF
     Inst%FugacityLakeToAir = 0.0e0_hp
 
     ALLOCATE( Inst%FugacityLeafToAir( HcoState%NX, HcoState%NY ), STAT=RC )
     IF ( RC /= 0 ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, 'Cannot allocate FugacityLeafToAir', RC )
+       CALL HCO_ERROR ( 'Cannot allocate FugacityLeafToAir', RC )
        RETURN
     ENDIF
     Inst%FugacityLeafToAir = 0.0e0_hp

--- a/src/Extensions/hcox_gc_RnPbBe_mod.F90
+++ b/src/Extensions/hcox_gc_RnPbBe_mod.F90
@@ -182,7 +182,7 @@ CONTAINS
     CALL InstGet ( ExtState%GC_RnPbBe, Inst, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        WRITE(MSG,*) 'Cannot find GC_RnPbBe instance Nr. ', ExtState%GC_RnPbBe
-       CALL HCO_ERROR(HcoState%Config%Err,MSG,RC)
+       CALL HCO_ERROR(MSG,RC)
        RETURN
     ENDIF
 
@@ -343,7 +343,7 @@ CONTAINS
                          RC,       ExtNr=Inst%ExtNr )
        Arr2D => NULL()
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, &
+          CALL HCO_ERROR( &
                           'HCO_EmisAdd error: EmissRn222', RC )
           RETURN
        ENDIF
@@ -425,7 +425,7 @@ CONTAINS
                             RC,       ExtNr=Inst%ExtNr )
           Arr3D => NULL()
           IF ( RC /= HCO_SUCCESS ) THEN
-             CALL HCO_ERROR( HcoState%Config%Err, &
+             CALL HCO_ERROR( &
                              'HCO_EmisAdd error: EmissBe7', RC )
              RETURN
           ENDIF
@@ -438,7 +438,7 @@ CONTAINS
                             RC,       ExtNr=Inst%ExtNr )
           Arr3D => NULL()
           IF ( RC /= HCO_SUCCESS ) THEN
-             CALL HCO_ERROR( HcoState%Config%Err, &
+             CALL HCO_ERROR( &
                              'HCO_EmisAdd error: EmissBe7Strat', RC )
              RETURN
           ENDIF
@@ -451,7 +451,7 @@ CONTAINS
                             RC,       ExtNr=Inst%ExtNr )
           Arr3D => NULL()
           IF ( RC /= HCO_SUCCESS ) THEN
-             CALL HCO_ERROR( HcoState%Config%Err, &
+             CALL HCO_ERROR( &
                              'HCO_EmisAdd error: EmissBe10', RC )
              RETURN
           ENDIF
@@ -464,7 +464,7 @@ CONTAINS
                             RC,       ExtNr=Inst%ExtNr )
           Arr3D => NULL()
           IF ( RC /= HCO_SUCCESS ) THEN
-             CALL HCO_ERROR( HcoState%Config%Err, &
+             CALL HCO_ERROR( &
                              'HCO_EmisAdd error: EmissBe10Strat', RC )
              RETURN
           ENDIF
@@ -550,7 +550,7 @@ CONTAINS
     Inst => NULL()
     CALL InstCreate ( ExtNr, ExtState%GC_RnPbBe, Inst, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, 'Cannot create GC_RnPbBe instance', RC )
+       CALL HCO_ERROR ( 'Cannot create GC_RnPbBe instance', RC )
        RETURN
     ENDIF
     ! Also fill Inst%ExtNr
@@ -611,7 +611,7 @@ CONTAINS
 
     ! ERROR: No tracer defined
     IF ( Inst%IDTRn222 <= 0 .AND. Inst%IDTBe7 <= 0 .AND. Inst%IDTBe10 <= 0) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, &
+       CALL HCO_ERROR( &
                        'Cannot use RnPbBe extension: no valid species!', RC )
     ENDIF
 
@@ -628,7 +628,7 @@ CONTAINS
     IF ( Inst%IDTRn222 > 0 ) THEN
        ALLOCATE( Inst%EmissRn222( HcoState%Nx, HcoState%NY ), STAT=RC )
        IF ( RC /= 0 ) THEN
-          CALL HCO_ERROR ( HcoState%Config%Err, &
+          CALL HCO_ERROR ( &
                            'Cannot allocate EmissRn222', RC )
           RETURN
        ENDIF
@@ -638,7 +638,7 @@ CONTAINS
        ALLOCATE( Inst%EmissBe7( HcoState%Nx, HcoState%NY, HcoState%NZ ), &
                  STAT=RC )
        IF ( RC /= 0 ) THEN
-          CALL HCO_ERROR ( HcoState%Config%Err, &
+          CALL HCO_ERROR ( &
                            'Cannot allocate EmissBe7', RC )
           RETURN
        ENDIF
@@ -647,7 +647,7 @@ CONTAINS
        ! Array for latitudes (Lal & Peters data)
        ALLOCATE( Inst%LATSOU( 10 ), STAT=RC )
        IF ( RC /= 0 ) THEN
-          CALL HCO_ERROR ( HcoState%Config%Err, &
+          CALL HCO_ERROR ( &
                            'Cannot allocate LATSOU', RC )
           RETURN
        ENDIF
@@ -655,7 +655,7 @@ CONTAINS
        ! Array for pressures (Lal & Peters data)
        ALLOCATE( Inst%PRESOU( 33 ), STAT=RC )
        IF ( RC /= 0 ) THEN
-          CALL HCO_ERROR ( HcoState%Config%Err, &
+          CALL HCO_ERROR ( &
                            'Cannot allocate PRESOU', RC )
           RETURN
        ENDIF
@@ -663,7 +663,7 @@ CONTAINS
        ! Array for 7Be emissions ( Lal & Peters data)
        ALLOCATE( Inst%BESOU( 10, 33 ), STAT=RC )
        IF ( RC /= 0 ) THEN
-          CALL HCO_ERROR ( HcoState%Config%Err, &
+          CALL HCO_ERROR ( &
                            'Cannot allocate BESOU', RC )
           RETURN
        ENDIF
@@ -676,7 +676,7 @@ CONTAINS
        ALLOCATE( Inst%EmissBe7Strat( HcoState%Nx, HcoState%NY, HcoState%NZ ), &
                  STAT=RC )
        IF ( RC /= 0 ) THEN
-          CALL HCO_ERROR ( HcoState%Config%Err, &
+          CALL HCO_ERROR ( &
                            'Cannot allocate EmissBe7Strat', RC )
           RETURN
        ENDIF
@@ -687,7 +687,7 @@ CONTAINS
        ALLOCATE( Inst%EmissBe10( HcoState%Nx, HcoState%NY, HcoState%NZ ), &
                  STAT=RC )
        IF ( RC /= 0 ) THEN
-          CALL HCO_ERROR ( HcoState%Config%Err, &
+          CALL HCO_ERROR ( &
                            'Cannot allocate EmissBe10', RC )
           RETURN
        ENDIF
@@ -697,7 +697,7 @@ CONTAINS
        ALLOCATE( Inst%EmissBe10Strat( HcoState%Nx, HcoState%NY, HcoState%NZ ), &
                  STAT=RC )
        IF ( RC /= 0 ) THEN
-          CALL HCO_ERROR ( HcoState%Config%Err, &
+          CALL HCO_ERROR ( &
                            'Cannot allocate EmissBe10Strat', RC )
           RETURN
        ENDIF

--- a/src/Extensions/hcox_gfed_mod.F90
+++ b/src/Extensions/hcox_gfed_mod.F90
@@ -244,7 +244,7 @@ CONTAINS
     CALL InstGet ( ExtState%GFED, Inst, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        WRITE(MSG,*) 'Cannot find GFED instance Nr. ', ExtState%GFED
-       CALL HCO_ERROR(HcoState%Config%Err,MSG,RC)
+       CALL HCO_ERROR(MSG,RC)
        RETURN
     ENDIF
 
@@ -327,7 +327,7 @@ CONTAINS
              CASE( 6 )
                 TMPPTR => Inst%GFED_AGRI
              CASE DEFAULT
-                CALL HCO_ERROR ( HcoState%Config%Err, 'Undefined emission factor', RC )
+                CALL HCO_ERROR ( 'Undefined emission factor', RC )
                 RETURN
           END SELECT
 
@@ -480,7 +480,7 @@ CONTAINS
        CALL HCO_EmisAdd( HcoState, SpcArr, Inst%HcoIDs(N), RC, ExtNr=Inst%ExtNr )
        IF ( RC /= HCO_SUCCESS ) THEN
           MSG = 'HCO_EmisAdd error: ' // TRIM(HcoState%Spc(Inst%HcoIDs(N))%SpcName)
-          CALL HCO_ERROR(HcoState%Config%Err,MSG, RC )
+          CALL HCO_ERROR(MSG, RC )
           RETURN
        ENDIF
 
@@ -571,7 +571,7 @@ CONTAINS
     Inst => NULL()
     CALL InstCreate ( ExtNr, ExtState%GFED, Inst, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, 'Cannot create GFED instance', RC )
+       CALL HCO_ERROR ( 'Cannot create GFED instance', RC )
        RETURN
     ENDIF
 
@@ -586,7 +586,7 @@ CONTAINS
     IF ( .NOT. Inst%IsGFED4  ) THEN
        MSG = 'GFED is enabled but no GFED version is selected. ' // &
              'Please set GFED4 in HEMCO configuration file.'
-       CALL HCO_ERROR(HcoState%Config%Err,MSG, RC )
+       CALL HCO_ERROR(MSG, RC )
        RETURN
     ENDIF
 
@@ -650,7 +650,7 @@ CONTAINS
          Inst%POG1frac < 0.0_sp .OR. Inst%POG1frac > 1.0_sp     ) THEN
        WRITE(MSG,*) 'fractions must be between 0-1: ', &
           Inst%OCPIfrac, Inst%BCPIfrac, Inst%POG1frac, Inst%SOAPfrac
-       CALL HCO_ERROR(HcoState%Config%Err,MSG, RC )
+       CALL HCO_ERROR(MSG, RC )
        RETURN
     ENDIF
 
@@ -677,7 +677,7 @@ CONTAINS
     ! Allocate scale factors table
     ALLOCATE ( Inst%GFED4_EMFAC ( N_SPEC, N_EMFAC ), STAT=AS )
     IF ( AS/=0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'Cannot allocate GFED_EMFAC', RC )
+       CALL HCO_ERROR( 'Cannot allocate GFED_EMFAC', RC )
        RETURN
     ENDIF
     Inst%GFED4_EMFAC = 0.0_hp
@@ -735,7 +735,7 @@ CONTAINS
     IF ( RC /= HCO_SUCCESS ) RETURN
     IF ( Inst%nSpc == 0 ) THEN
        MSG = 'No GFED species specified'
-       CALL HCO_ERROR(HcoState%Config%Err,MSG, RC )
+       CALL HCO_ERROR(MSG, RC )
        RETURN
     ENDIF
     ALLOCATE(Inst%HcoIDs(Inst%nSpc),Inst%SpcNames(Inst%nSpc))
@@ -777,14 +777,14 @@ CONTAINS
              'This version of HEMCO expects species scale factors to be ' // &
              'set as `Scaling_XX` instead of `XX scale factor`. '         // &
              'Please update the GFED settings section accordingly.'
-       CALL HCO_ERROR(HcoState%Config%Err,MSG, RC )
+       CALL HCO_ERROR(MSG, RC )
        RETURN
     ENDIF
 
     ! GFEDIDS are the matching indeces of the HEMCO species in GFED_EMFAC.
     ALLOCATE ( Inst%GfedIDs(Inst%nSpc), STAT=AS )
     IF ( AS/=0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'Cannot allocate GfedIDs', RC )
+       CALL HCO_ERROR( 'Cannot allocate GfedIDs', RC )
        RETURN
     ENDIF
     Inst%GfedIDs = -1
@@ -849,7 +849,7 @@ CONTAINS
        ENDDO
        IF ( .NOT. Matched ) THEN
           MSG = 'Species '// TRIM(SpcName) //' not found in GFED'
-          CALL HCO_ERROR(HcoState%Config%Err,MSG, RC )
+          CALL HCO_ERROR(MSG, RC )
           RETURN
        ENDIF
     ENDDO !N

--- a/src/Extensions/hcox_iodine_mod.F90
+++ b/src/Extensions/hcox_iodine_mod.F90
@@ -152,7 +152,7 @@ CONTAINS
     CALL InstGet ( ExtState%Inorg_Iodine, Inst, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        WRITE(MSG,*) 'Cannot find iodine instance Nr. ', ExtState%Inorg_Iodine
-       CALL HCO_ERROR(HcoState%Config%Err,MSG,RC)
+       CALL HCO_ERROR(MSG,RC)
        RETURN
     ENDIF
 
@@ -382,7 +382,7 @@ CONTAINS
     ! Create Instance
     CALL InstCreate ( ExtNr, ExtState%Inorg_Iodine, Inst, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, 'Cannot create InorgIodine instance', RC )
+       CALL HCO_ERROR ( 'Cannot create InorgIodine instance', RC )
        RETURN
     ENDIF
 

--- a/src/Extensions/hcox_lightnox_mod.F90
+++ b/src/Extensions/hcox_lightnox_mod.F90
@@ -192,7 +192,7 @@ CONTAINS
     CALL InstGet ( ExtState%LightNOx, Inst, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        WRITE(MSG,*) 'Cannot find lightning NOx instance Nr. ', ExtState%LightNOx
-       CALL HCO_ERROR(HcoState%Config%Err,MSG,RC)
+       CALL HCO_ERROR(MSG,RC)
        RETURN
     ENDIF
 
@@ -209,7 +209,7 @@ CONTAINS
        CALL HCO_EmisAdd( HcoState, Inst%SLBASE, Inst%IDTNO, &
                          RC, ExtNr=Inst%ExtNr)
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, 'HCO_EmisAdd error: SLBASE', RC )
+          CALL HCO_ERROR( 'HCO_EmisAdd error: SLBASE', RC )
           RETURN
        ENDIF
 
@@ -799,7 +799,7 @@ CONTAINS
     Inst => NULL()
     CALL InstCreate ( ExtNr, ExtState%LightNOx, Inst, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, 'Cannot create LightNOx instance', RC )
+       CALL HCO_ERROR ( 'Cannot create LightNOx instance', RC )
        RETURN
     ENDIF
 
@@ -851,7 +851,7 @@ CONTAINS
     ELSE
        IF ( .not. FileExists ) THEN
           WRITE( MSG, 300 ) TRIM( FileMsg ), TRIM( FileName )
-          CALL HCO_ERROR(HcoState%Config%Err, MSG, RC )
+          CALL HCO_ERROR(MSG, RC )
           RETURN
        ENDIF
     ENDIF
@@ -889,7 +889,7 @@ CONTAINS
     IF ( RC /= HCO_SUCCESS ) RETURN
     IF ( nSpc /= 1 ) THEN
        MSG = 'Lightning NOx module must have exactly one species!'
-       CALL HCO_ERROR(HcoState%Config%Err,MSG, RC )
+       CALL HCO_ERROR(MSG, RC )
        RETURN
     ENDIF
     Inst%IDTNO = HcoIDs(1)
@@ -923,42 +923,42 @@ CONTAINS
 
     ALLOCATE( Inst%PROFILE( NNLIGHT, NLTYPE ), STAT=AS )
     IF( AS /= 0 ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, 'PROFILE', RC )
+       CALL HCO_ERROR ( 'PROFILE', RC )
        RETURN
     ENDIF
     Inst%PROFILE = 0.0_hp
 
     ALLOCATE( Inst%SLBASE(HcoState%NX,HcoState%NY,HcoState%NZ), STAT=AS )
     IF( AS /= 0 ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, 'SLBASE', RC )
+       CALL HCO_ERROR ( 'SLBASE', RC )
        RETURN
     ENDIF
     Inst%SLBASE = 0.0_hp
 
     ALLOCATE ( Inst%FLASH_DENS_TOT( HcoState%NX, HcoState%NY), STAT=AS )
     IF ( AS/=0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'FLASH_DENS_TOT', RC )
+       CALL HCO_ERROR( 'FLASH_DENS_TOT', RC )
        RETURN
     ENDIF
     Inst%FLASH_DENS_TOT = 0.0_sp
 
     !ALLOCATE ( Inst%FLASH_DENS_IC( HcoState%NX, HcoState%NY), STAT=AS )
     !IF ( AS/=0 ) THEN
-    !   CALL HCO_ERROR( HcoState%Config%Err, 'FLASH_DENS_IC', RC )
+    !   CALL HCO_ERROR( 'FLASH_DENS_IC', RC )
     !   RETURN
     !ENDIF
     !Inst%FLASH_DENS_IC = 0.0_sp
 
     !ALLOCATE ( Inst%FLASH_DENS_CG( HcoState%NX, HcoState%NY), STAT=AS )
     !IF ( AS/=0 ) THEN
-    !   CALL HCO_ERROR( HcoState%Config%Err, 'FLASH_DENS_CG', RC )
+    !   CALL HCO_ERROR( 'FLASH_DENS_CG', RC )
     !   RETURN
     !ENDIF
     !Inst%FLASH_DENS_CG = 0.0_sp
 
     ALLOCATE ( Inst%CONV_DEPTH( HcoState%NX, HcoState%NY), STAT=AS )
     IF ( AS/=0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'CONV_DEPTH', RC )
+       CALL HCO_ERROR( 'CONV_DEPTH', RC )
        RETURN
     ENDIF
     Inst%CONV_DEPTH = 0.0_sp
@@ -976,7 +976,7 @@ CONTAINS
     OPEN( IU_FILE, FILE=TRIM( FILENAME ), STATUS='OLD', IOSTAT=IOS )
     IF ( IOS /= 0 ) THEN
        MSG = 'IOERROR: LightDist: 1'
-       CALL HCO_ERROR(HcoState%Config%Err,MSG, RC )
+       CALL HCO_ERROR(MSG, RC )
        RETURN
     ENDIF
 
@@ -985,7 +985,7 @@ CONTAINS
        READ( IU_FILE, '(a)', IOSTAT=IOS )
        IF ( IOS /= 0 ) THEN
           MSG = 'IOERROR: LightDist: 2'
-          CALL HCO_ERROR(HcoState%Config%Err,MSG, RC )
+          CALL HCO_ERROR(MSG, RC )
           RETURN
        ENDIF
     ENDDO
@@ -995,7 +995,7 @@ CONTAINS
        READ( IU_FILE,*,IOSTAT=IOS) (Inst%PROFILE(III,JJJ),JJJ=1,NLTYPE)
        IF ( IOS /= 0 ) THEN
           MSG = 'IOERROR: LightDist: 3'
-          CALL HCO_ERROR(HcoState%Config%Err,MSG, RC )
+          CALL HCO_ERROR(MSG, RC )
           RETURN
        ENDIF
     ENDDO

--- a/src/Extensions/hcox_megan_mod.F90
+++ b/src/Extensions/hcox_megan_mod.F90
@@ -366,7 +366,7 @@ CONTAINS
     CALL InstGet ( ExtState%Megan, Inst, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        WRITE(MSG,*) 'Cannot find Megan instance Nr. ', ExtState%Megan
-       CALL HCO_ERROR(HcoState%Config%Err,MSG,RC)
+       CALL HCO_ERROR(MSG,RC)
        RETURN
     ENDIF
 
@@ -417,7 +417,7 @@ CONTAINS
     CALL CALC_AEF( HcoState, ExtState, Inst, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        MSG = 'Error encountered in MEGAN routine CALC_AEF!'
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+       CALL HCO_ERROR( MSG, RC )
        RETURN
     ENDIF
 
@@ -425,7 +425,7 @@ CONTAINS
     CALL CALC_NORM_FAC( Inst, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        MSG = 'Error encountered in MEGAN routine CALC_NORM_FAC!'
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+       CALL HCO_ERROR( MSG, RC )
        RETURN
     ENDIF
 
@@ -433,7 +433,7 @@ CONTAINS
     CALL FILL_RESTART_VARS( HcoState, ExtState, Inst, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        MSG = 'Error encountered in MEGAN routine FILL_RESTART_VARS!'
-       CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+       CALL HCO_ERROR( MSG, RC )
        RETURN
     ENDIF
 
@@ -449,7 +449,7 @@ CONTAINS
        CALL CALC_AEF( HcoState, ExtState, Inst, RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           MSG = 'Error encountered in MEGAN routine CALC_AEF!'
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+          CALL HCO_ERROR( MSG, RC )
           RETURN
        ENDIF
 
@@ -457,7 +457,7 @@ CONTAINS
        CALL CALC_NORM_FAC( Inst, RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           MSG = 'Error encountered in MEGAN routine CALC_NORM_FAC!'
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+          CALL HCO_ERROR( MSG, RC )
           RETURN
        ENDIF
 
@@ -465,7 +465,7 @@ CONTAINS
        CALL FILL_RESTART_VARS( HcoState, ExtState, Inst, RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           MSG = 'Error encountered in MEGAN routine FILL_RESTART_VARS!'
-          CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+          CALL HCO_ERROR( MSG, RC )
           RETURN
        ENDIF
     ENDIF
@@ -544,7 +544,7 @@ CONTAINS
        CALL GET_MEGAN_EMISSIONS( HcoState, ExtState, Inst, &
                                  I, J, 'ISOP', EMIS_ISOP, RC )
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, &
+          CALL HCO_ERROR( &
                           'GET_MEGAN_EMISSIONS_ISOP', RC )
           ERR = .TRUE.
           EXIT
@@ -579,7 +579,7 @@ CONTAINS
        CALL GET_MEGAN_EMISSIONS( HcoState, ExtState, &
                                  Inst, I, J, 'APIN', EMIS_APIN, RC)
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, &
+          CALL HCO_ERROR( &
                           'GET_MEGAN_EMISSIONS_APIN', RC )
           ERR = .TRUE.
           EXIT
@@ -591,7 +591,7 @@ CONTAINS
        CALL GET_MEGAN_EMISSIONS( HcoState, ExtState, &
                                  Inst, I, J, 'BPIN', EMIS_BPIN, RC)
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, &
+          CALL HCO_ERROR( &
                           'GET_MEGAN_EMISSIONS_BPIN', RC )
           ERR = .TRUE.
           EXIT
@@ -603,7 +603,7 @@ CONTAINS
        CALL GET_MEGAN_EMISSIONS( HcoState, ExtState, &
                                  Inst, I, J, 'LIMO', EMIS_LIMO, RC)
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, &
+          CALL HCO_ERROR( &
                           'GET_MEGAN_EMISSIONS_LIMO', RC )
           ERR = .TRUE.
           EXIT
@@ -615,7 +615,7 @@ CONTAINS
        CALL GET_MEGAN_EMISSIONS( HcoState, ExtState, &
                                  Inst, I, J, 'SABI', EMIS_SABI, RC)
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, &
+          CALL HCO_ERROR( &
                           'GET_MEGAN_EMISSIONS_SABI', RC )
           ERR = .TRUE.
           EXIT
@@ -627,7 +627,7 @@ CONTAINS
        CALL GET_MEGAN_EMISSIONS( HcoState, ExtState, &
                                  Inst, I, J, 'MYRC', EMIS_MYRC, RC)
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, &
+          CALL HCO_ERROR( &
                           'GET_MEGAN_EMISSIONS_MYRC', RC )
           ERR = .TRUE.
           EXIT
@@ -639,7 +639,7 @@ CONTAINS
        CALL GET_MEGAN_EMISSIONS( HcoState, ExtState, &
                                  Inst, I, J, 'CARE', EMIS_CARE, RC)
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, &
+          CALL HCO_ERROR( &
                           'GET_MEGAN_EMISSIONS_CARE', RC )
           ERR = .TRUE.
           EXIT
@@ -651,7 +651,7 @@ CONTAINS
        CALL GET_MEGAN_EMISSIONS( HcoState, ExtState, &
                                  Inst, I, J, 'OCIM', EMIS_OCIM, RC)
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, &
+          CALL HCO_ERROR( &
                           'GET_MEGAN_EMISSIONS_OCIM', RC )
           ERR = .TRUE.
           EXIT
@@ -664,7 +664,7 @@ CONTAINS
        CALL GET_MEGAN_EMISSIONS( HcoState, ExtState, &
                                  Inst, I, J, 'OMON', EMIS_OMON, RC)
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, &
+          CALL HCO_ERROR( &
                           'GET_MEGAN_EMISSIONS_OMON', RC )
           ERR = .TRUE.
           EXIT
@@ -687,7 +687,7 @@ CONTAINS
           CALL GET_MEGAN_EMISSIONS( HcoState, ExtState, &
                                     Inst, I, J, 'ALD2', EMIS_ALD2, RC)
           IF ( RC /= HCO_SUCCESS ) THEN
-             CALL HCO_ERROR( HcoState%Config%Err, &
+             CALL HCO_ERROR( &
                              'GET_MEGAN_EMISSIONS_ALD2', RC )
              ERR = .TRUE.
              EXIT
@@ -703,7 +703,7 @@ CONTAINS
           CALL GET_MEGAN_EMISSIONS( HcoState, ExtState, &
                                     Inst, I, J, 'MOH', EMIS_MOH, RC)
           IF ( RC /= HCO_SUCCESS ) THEN 
-             CALL HCO_ERROR( HcoState%Config%Err,  &
+             CALL HCO_ERROR(  &
                              'GET_MEGAN_EMISSIONS_MOH', RC )
              ERR = .TRUE.
              EXIT
@@ -719,7 +719,7 @@ CONTAINS
           CALL GET_MEGAN_EMISSIONS( HcoState, ExtState, &
                                     Inst, I, J, 'EOH', EMIS_EOH, RC)
           IF ( RC /= HCO_SUCCESS ) THEN
-             CALL HCO_ERROR( HcoState%Config%Err, &
+             CALL HCO_ERROR( &
                              'GET_MEGAN_EMISSIONS_EOH', RC )
              ERR = .TRUE.
              EXIT
@@ -740,7 +740,7 @@ CONTAINS
        CALL GET_MEGAN_EMISSIONS( HcoState, ExtState, &
                                  Inst, I, J, 'MBOX', EMIS_MBOX, RC)
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, &
+          CALL HCO_ERROR( &
                           'GET_MEGAN_EMISSIONS_MBOX', RC )
           ERR = .TRUE.
           EXIT
@@ -752,7 +752,7 @@ CONTAINS
        CALL GET_MEGAN_EMISSIONS( HcoState, ExtState, &
                                  Inst, I, J, 'FAXX', EMIS_FAXX, RC )
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, &
+          CALL HCO_ERROR( &
                           'GET_MEGAN_EMISSIONS_FAXX', RC )
           ERR = .TRUE.
           EXIT
@@ -764,7 +764,7 @@ CONTAINS
        CALL GET_MEGAN_EMISSIONS( HcoState, ExtState, &
                                  Inst, I, J, 'AAXX', EMIS_AAXX, RC )
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, &
+          CALL HCO_ERROR( &
                           'GET_MEGAN_EMISSIONS_AAXX', RC )
           ERR = .TRUE.
           EXIT
@@ -811,7 +811,7 @@ CONTAINS
           CALL GET_MEGAN_EMISSIONS( HcoState, ExtState, &
                                     Inst, I, J, 'ACET', EMIS_ACET, RC)
           IF ( RC /= HCO_SUCCESS ) THEN
-             CALL HCO_ERROR( HcoState%Config%Err, &
+             CALL HCO_ERROR( &
                              'GET_MEGAN_EMISSIONS_ACET', RC )
              ERR = .TRUE.
              EXIT
@@ -846,7 +846,7 @@ CONTAINS
           CALL GET_MEGAN_EMISSIONS( HcoState, ExtState, &
                                     Inst, I, J, 'PRPE', EMIS_PRPE, RC)
           IF ( RC /= HCO_SUCCESS ) THEN
-             CALL HCO_ERROR( HcoState%Config%Err, &
+             CALL HCO_ERROR( &
                              'GET_MEGAN_EMISSIONS_PRPE', RC )
              ERR = .TRUE.
              EXIT
@@ -866,7 +866,7 @@ CONTAINS
           CALL GET_MEGAN_EMISSIONS( HcoState, ExtState, &
                                     Inst, I, J, 'C2H4', EMIS_C2H4, RC)
           IF ( RC /= HCO_SUCCESS ) THEN
-             CALL HCO_ERROR( HcoState%Config%Err, &
+             CALL HCO_ERROR( &
                              'GET_MEGAN_EMISSIONS_C2H4', RC )
              ERR = .TRUE.
              EXIT
@@ -940,7 +940,7 @@ CONTAINS
        CALL GET_MEGAN_EMISSIONS( HcoState, ExtState, &
                                  Inst, I, J, 'FARN', EMIS_FARN, RC )
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, &
+          CALL HCO_ERROR( &
                           'GET_MEGAN_EMISSIONS_FARN', RC )
           ERR = .TRUE.
           EXIT
@@ -952,7 +952,7 @@ CONTAINS
        CALL GET_MEGAN_EMISSIONS( HcoState, ExtState, &
                                  Inst, I, J, 'BCAR', EMIS_BCAR, RC )
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, &
+          CALL HCO_ERROR( &
                           'GET_MEGAN_EMISSIONS_BCAR', RC )
           ERR = .TRUE.
           EXIT
@@ -964,7 +964,7 @@ CONTAINS
        CALL GET_MEGAN_EMISSIONS( HcoState, ExtState, &
                                  Inst, I, J, 'OSQT', EMIS_OSQT, RC )
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, &
+          CALL HCO_ERROR( &
                           'GET_MEGAN_EMISSIONS_OSQT', RC )
           ERR = .TRUE.
           EXIT
@@ -1049,7 +1049,7 @@ CONTAINS
        CALL HCO_EmisAdd( HcoState, Inst%FLUXISOP, Inst%IDTISOP, &
                          RC, ExtNr=Inst%ExtNr )
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, &
+          CALL HCO_ERROR( &
                           'HCO_EmisAdd error: FLUXISOP', RC )
           RETURN
        ENDIF
@@ -1063,7 +1063,7 @@ CONTAINS
        CALL HCO_EmisAdd( HcoState, Inst%FLUXALD2, Inst%IDTALD2, &
                          RC, ExtNr=Inst%ExtNr )
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, &
+          CALL HCO_ERROR( &
                           'HCO_EmisAdd error: FLUXALD2', RC )
           RETURN
        ENDIF
@@ -1077,7 +1077,7 @@ CONTAINS
        CALL HCO_EmisAdd( HcoState, Inst%FLUXMOH, Inst%IDTMOH, &
                          RC, ExtNr=Inst%ExtNr )
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, &
+          CALL HCO_ERROR( &
                           'HCO_EmisAdd error: FLUXMOH', RC )
           RETURN 
        ENDIF
@@ -1091,7 +1091,7 @@ CONTAINS
        CALL HCO_EmisAdd( HcoState, Inst%FLUXEOH, Inst%IDTEOH, &
                          RC, ExtNr=Inst%ExtNr )
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, &
+          CALL HCO_ERROR( &
                           'HCO_EmisAdd error: FLUXEOH', RC )
           RETURN
        ENDIF
@@ -1106,7 +1106,7 @@ CONTAINS
        CALL HCO_EmisAdd( HcoState, Inst%FLUXACET, Inst%IDTACET, &
                          RC, ExtNr=Inst%ExtNr )
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, &
+          CALL HCO_ERROR( &
                           'HCO_EmisAdd error: FLUXACET', RC )
           RETURN
        ENDIF
@@ -1120,7 +1120,7 @@ CONTAINS
        CALL HCO_EmisAdd( HcoState, Inst%FLUXSOAP, Inst%IDTSOAP, &
                          RC, ExtNr=Inst%ExtNr )
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, &
+          CALL HCO_ERROR( &
                           'HCO_EmisAdd error: FLUXSOAP', RC )
           RETURN
        ENDIF
@@ -1135,7 +1135,7 @@ CONTAINS
        CALL HCO_EmisAdd( HcoState, Inst%FLUXSOAS, Inst%IDTSOAS, &
                          RC, ExtNr=Inst%ExtNr )
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, &
+          CALL HCO_ERROR( &
                           'HCO_EmisAdd error: FLUXSOAS', RC )
           RETURN
        ENDIF
@@ -1150,7 +1150,7 @@ CONTAINS
        CALL HCO_EmisAdd( HcoState, Inst%FLUXPRPE, Inst%IDTPRPE, &
                          RC, ExtNr=Inst%ExtNr )
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, &
+          CALL HCO_ERROR( &
                           'HCO_EmisAdd error: FLUXPRPE', RC )
           RETURN
        ENDIF
@@ -1165,7 +1165,7 @@ CONTAINS
        CALL HCO_EmisAdd( HcoState, Inst%FLUXC2H4, Inst%IDTC2H4, &
                          RC, ExtNr=Inst%ExtNr )
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, &
+          CALL HCO_ERROR( &
                           'HCO_EmisAdd error: FLUXC2H4', RC )
           RETURN
        ENDIF
@@ -1180,7 +1180,7 @@ CONTAINS
        CALL HCO_EmisAdd( HcoState, Inst%FLUXMTPA, Inst%IDTMTPA, &
                          RC, ExtNr=Inst%ExtNr )
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, &
+          CALL HCO_ERROR( &
                           'HCO_EmisAdd error: FLUXMTPA', RC )
           RETURN
        ENDIF
@@ -1195,7 +1195,7 @@ CONTAINS
        CALL HCO_EmisAdd( HcoState, Inst%FLUXMTPO, Inst%IDTMTPO, &
                          RC, ExtNr=Inst%ExtNr )
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, &
+          CALL HCO_ERROR( &
                           'HCO_EmisAdd error: FLUXMTPO', RC )
           RETURN
        ENDIF
@@ -1210,7 +1210,7 @@ CONTAINS
        CALL HCO_EmisAdd( HcoState, Inst%FLUXLIMO, Inst%IDTLIMO, &
                          RC, ExtNr=Inst%ExtNr )
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, &
+          CALL HCO_ERROR( &
                           'HCO_EmisAdd error: FLUXLIMO', RC )
           RETURN
        ENDIF
@@ -1225,7 +1225,7 @@ CONTAINS
        CALL HCO_EmisAdd( HcoState, Inst%FLUXSESQ, Inst%IDTSESQ, &
                          RC, ExtNr=Inst%ExtNr )
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, &
+          CALL HCO_ERROR( &
                           'HCO_EmisAdd error: FLUXSESQ', RC )
           RETURN
        ENDIF
@@ -1745,7 +1745,7 @@ CONTAINS
     ELSE
 
        MSG = 'Invalid compound name'
-       CALL HCO_ERROR(HcoState%Config%Err,MSG, RC, &
+       CALL HCO_ERROR(MSG, RC, &
                       THISLOC='GET_MEGAN_PARAMS' )
        RETURN
 
@@ -1859,7 +1859,7 @@ CONTAINS
        EMFAC = Inst%AEF_OSQT(I,J)
     CASE DEFAULT
        MSG = 'Invalid compound name'
-       CALL HCO_ERROR(HcoState%Config%Err, MSG, &
+       CALL HCO_ERROR(MSG, &
                       RC, THISLOC='GET_MEGAN_AEF' )
        RETURN
     END SELECT
@@ -3412,7 +3412,7 @@ CONTAINS
     ! Create an instance for this extension
     CALL InstCreate ( ExtNr, ExtState%Megan, Inst, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, &
+       CALL HCO_ERROR ( &
                        'Cannot create MEGAN instance', RC )
        RETURN
     ENDIF
@@ -3465,7 +3465,7 @@ CONTAINS
        IF ( Inst%GLOBCO2 <  150.0_hp .OR. &
             Inst%GLOBCO2 > 1250.0_hp     ) THEN
           MSG = 'Global CO2 outside valid range of 150-1250 ppmv!'
-          CALL HCO_ERROR(HcoState%Config%Err,MSG, RC )
+          CALL HCO_ERROR(MSG, RC )
           RETURN
        ENDIF
     ENDIF
@@ -3679,7 +3679,7 @@ CONTAINS
           ENDIF
        CASE DEFAULT
           MSG = 'Invalid species names: ' // TRIM(SpcNames(I))
-          CALL HCO_ERROR(HcoState%Config%Err,MSG, RC )
+          CALL HCO_ERROR(MSG, RC )
           RETURN
        END SELECT
 
@@ -3741,42 +3741,42 @@ CONTAINS
 
     ALLOCATE( Inst%T_LAST24H( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'T_LAST24H', RC )
+       CALL HCO_ERROR( 'T_LAST24H', RC )
        RETURN
     ENDIF
     Inst%T_LAST24H = 0.0_hp
 
     ALLOCATE( Inst%T_LASTXDAYS( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'T_LASTXDAYS', RC )
+       CALL HCO_ERROR( 'T_LASTXDAYS', RC )
        RETURN
     ENDIF
     Inst%T_LASTXDAYS = 0.0_hp
 
     ALLOCATE( Inst%PARDR_LASTXDAYS( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'PARDR_LASTXDAYS', RC )
+       CALL HCO_ERROR( 'PARDR_LASTXDAYS', RC )
        RETURN
     ENDIF
     Inst%PARDR_LASTXDAYS = 0.0_hp
 
     ALLOCATE( Inst%PARDF_LASTXDAYS( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'PARDF_LASTXDAYS', RC )
+       CALL HCO_ERROR( 'PARDF_LASTXDAYS', RC )
        RETURN
     ENDIF
     Inst%PARDF_LASTXDAYS = 0.0_hp
 
     ALLOCATE( Inst%LAI_PREVDAY( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-      CALL HCO_ERROR( HcoState%Config%Err, 'LAI_PREVDAY', RC )
+      CALL HCO_ERROR( 'LAI_PREVDAY', RC )
       RETURN
     ENDIF
     Inst%LAI_PREVDAY = 0.0_sp
 
     ALLOCATE( Inst%ARRAY_16( NX, NY, 16 ), STAT=AS )
     IF ( AS /= 0 ) THEN
-      CALL HCO_ERROR( HcoState%Config%Err, 'ARRAY_16', RC )
+      CALL HCO_ERROR( 'ARRAY_16', RC )
       RETURN
     ENDIF
     Inst%ARRAY_16 = 0.0_hp
@@ -3786,336 +3786,336 @@ CONTAINS
     ! we calculate only 1 normalization factor for all compounds (dbm 11/2012)
     ALLOCATE( Inst%NORM_FAC( 1 ), STAT=AS )
     IF ( AS /= 0 ) THEN
-      CALL HCO_ERROR( HcoState%Config%Err, 'NORM_FAC', RC )
+      CALL HCO_ERROR( 'NORM_FAC', RC )
       RETURN
     ENDIF
     Inst%NORM_FAC = -99d0
 
     ALLOCATE( Inst%AEF_APIN( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'AEF_APIN', RC )
+       CALL HCO_ERROR( 'AEF_APIN', RC )
        RETURN
     ENDIF
     Inst%AEF_APIN = 0.0_hp
 
     ALLOCATE( Inst%AEF_MYRC( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'AEF_MYRC', RC )
+       CALL HCO_ERROR( 'AEF_MYRC', RC )
        RETURN
     ENDIF
     Inst%AEF_MYRC = 0.0_hp
 
     ALLOCATE( Inst%AEF_OMON( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'AEF_OMON', RC )
+       CALL HCO_ERROR( 'AEF_OMON', RC )
        RETURN
     ENDIF
     Inst%AEF_OMON = 0.0_hp
 
     ALLOCATE( Inst%AEF_FARN( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'AEF_FARN', RC )
+       CALL HCO_ERROR( 'AEF_FARN', RC )
        RETURN
     ENDIF
     Inst%AEF_FARN = 0.0_hp
 
     ALLOCATE( Inst%AEF_BCAR( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'AEF_BCAR', RC )
+       CALL HCO_ERROR( 'AEF_BCAR', RC )
        RETURN
     ENDIF
     Inst%AEF_BCAR = 0.0_hp
 
     ALLOCATE( Inst%AEF_OSQT( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'AEF_OSQT', RC )
+       CALL HCO_ERROR( 'AEF_OSQT', RC )
        RETURN
     ENDIF
     Inst%AEF_OSQT = 0.0_hp
 
     ALLOCATE( Inst%AEF_MOH( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'AEF_MOH', RC )
+       CALL HCO_ERROR( 'AEF_MOH', RC )
        RETURN
     ENDIF
     Inst%AEF_MOH = 0.0_hp
 
     ALLOCATE( Inst%AEF_ACET( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'AEF_ACET', RC )
+       CALL HCO_ERROR( 'AEF_ACET', RC )
        RETURN
     ENDIF
     Inst%AEF_ACET = 0.0_hp
 
     ALLOCATE( Inst%AEF_EOH( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'AEF_EOH', RC )
+       CALL HCO_ERROR( 'AEF_EOH', RC )
        RETURN
     ENDIF
     Inst%AEF_EOH = 0.0_hp
 
     ALLOCATE( Inst%AEF_CH2O( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'AEF_CH2O', RC )
+       CALL HCO_ERROR( 'AEF_CH2O', RC )
        RETURN
     ENDIF
     Inst%AEF_CH2O = 0.0_hp
 
     ALLOCATE( Inst%AEF_ALD2( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'AEF_ALD2', RC )
+       CALL HCO_ERROR( 'AEF_ALD2', RC )
        RETURN
     ENDIF
     Inst%AEF_ALD2 = 0.0_hp
 
     ALLOCATE( Inst%AEF_FAXX( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'AEF_FAXX', RC )
+       CALL HCO_ERROR( 'AEF_FAXX', RC )
        RETURN
     ENDIF
     Inst%AEF_FAXX = 0.0_hp
 
     ALLOCATE( Inst%AEF_AAXX( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'AEF_AAXX', RC )
+       CALL HCO_ERROR( 'AEF_AAXX', RC )
        RETURN
     ENDIF
     Inst%AEF_AAXX = 0.0_hp
 
     ALLOCATE( Inst%AEF_C2H4( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err,'AEF_C2H4', RC )
+       CALL HCO_ERROR( 'AEF_C2H4', RC )
        RETURN
     ENDIF
     Inst%AEF_C2H4 = 0.0_hp
 
     ALLOCATE( Inst%AEF_TOLU( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'AEF_TOLU', RC )
+       CALL HCO_ERROR( 'AEF_TOLU', RC )
        RETURN
     ENDIF
     Inst%AEF_TOLU = 0.0_hp
 
     ALLOCATE( Inst%AEF_HCNX( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'AEF_HCNX', RC )
+       CALL HCO_ERROR( 'AEF_HCNX', RC )
        RETURN
     ENDIF
     Inst%AEF_HCNX = 0.0_hp
 
     ALLOCATE( Inst%AEF_PRPE( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'AEF_PRPE', RC )
+       CALL HCO_ERROR( 'AEF_PRPE', RC )
        RETURN
     ENDIF
     Inst%AEF_PRPE = 0.0_hp
 
     ALLOCATE( Inst%FLUXISOP( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'FLUXISOP', RC )
+       CALL HCO_ERROR( 'FLUXISOP', RC )
        RETURN
     ENDIF
     Inst%FLUXISOP = 0.0_hp
 
     ALLOCATE( Inst%FLUXMONO( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'FLUXMONO', RC )
+       CALL HCO_ERROR( 'FLUXMONO', RC )
        RETURN
     ENDIF
     Inst%FLUXMONO = 0.0_hp
 
     ALLOCATE( Inst%FLUXACET( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'FLUXACET', RC )
+       CALL HCO_ERROR( 'FLUXACET', RC )
        RETURN
     ENDIF
     Inst%FLUXACET = 0.0_hp
 
     ALLOCATE( Inst%FLUXACETmb( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err,'FLUXACETmb', RC )
+       CALL HCO_ERROR( 'FLUXACETmb', RC )
        RETURN
     ENDIF
     Inst%FLUXACETmb = 0.0_sp
 
     ALLOCATE( Inst%FLUXACETbg( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err,'FLUXACETbg', RC )
+       CALL HCO_ERROR( 'FLUXACETbg', RC )
        RETURN
     ENDIF
     Inst%FLUXACETbg = 0.0_sp
 
     ALLOCATE( Inst%FLUXPRPE( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'FLUXPRPE', RC )
+       CALL HCO_ERROR( 'FLUXPRPE', RC )
        RETURN
     ENDIF
     Inst%FLUXPRPE = 0.0_hp
 
     ALLOCATE( Inst%FLUXC2H4( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'FLUXC2H4', RC )
+       CALL HCO_ERROR( 'FLUXC2H4', RC )
        RETURN
     ENDIF
     Inst%FLUXC2H4 = 0.0_hp
 
     ALLOCATE( Inst%FLUXLIMO( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'FLUXLIMO', RC )
+       CALL HCO_ERROR( 'FLUXLIMO', RC )
        RETURN
     ENDIF
     Inst%FLUXLIMO = 0.0_hp
 
     ALLOCATE( Inst%FLUXMTPA( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'FLUXMTPA', RC )
+       CALL HCO_ERROR( 'FLUXMTPA', RC )
        RETURN
     ENDIF
     Inst%FLUXMTPA = 0.0_hp
 
     ALLOCATE( Inst%FLUXMTPO( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'FLUXMTPO', RC )
+       CALL HCO_ERROR( 'FLUXMTPO', RC )
        RETURN
     ENDIF
     Inst%FLUXMTPO = 0.0_hp
 
     ALLOCATE( Inst%FLUXSESQ( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'FLUXSESQ', RC )
+       CALL HCO_ERROR( 'FLUXSESQ', RC )
        RETURN
     ENDIF
     Inst%FLUXSESQ = 0.0_hp
 
     ALLOCATE( Inst%FLUXSOAP( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'FLUXSOAP', RC )
+       CALL HCO_ERROR( 'FLUXSOAP', RC )
        RETURN
     ENDIF
     Inst%FLUXSOAP = 0.0_hp
 
     ALLOCATE( Inst%FLUXSOAS( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'FLUXSOAS', RC )
+       CALL HCO_ERROR( 'FLUXSOAS', RC )
        RETURN
     ENDIF
     Inst%FLUXSOAS = 0.0_hp
 
     ALLOCATE( Inst%FLUXALD2( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'FLUXALD2', RC )
+       CALL HCO_ERROR( 'FLUXALD2', RC )
        RETURN
     ENDIF
     Inst%FLUXALD2 = 0.0_hp
 
     ALLOCATE( Inst%FLUXMOH( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'FLUXMOH', RC )
+       CALL HCO_ERROR( 'FLUXMOH', RC )
        RETURN
     ENDIF
     Inst%FLUXMOH = 0.0_hp
 
     ALLOCATE( Inst%FLUXEOH( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'FLUXEOH', RC )
+       CALL HCO_ERROR( 'FLUXEOH', RC )
        RETURN
     ENDIF
     Inst%FLUXEOH = 0.0_hp
 
     ALLOCATE( Inst%FLUXAPIN( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'FLUXAPIN', RC )
+       CALL HCO_ERROR( 'FLUXAPIN', RC )
        RETURN
     ENDIF
     Inst%FLUXAPIN = 0.0_sp
 
     ALLOCATE( Inst%FLUXBPIN( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'FLUXBPIN', RC )
+       CALL HCO_ERROR( 'FLUXBPIN', RC )
        RETURN
     ENDIF
     Inst%FLUXBPIN = 0.0_sp
 
     ALLOCATE( Inst%FLUXSABI( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'FLUXSABI', RC )
+       CALL HCO_ERROR( 'FLUXSABI', RC )
        RETURN
     ENDIF
     Inst%FLUXSABI = 0.0_sp
 
     ALLOCATE( Inst%FLUXMYRC( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'FLUXMYRC', RC )
+       CALL HCO_ERROR( 'FLUXMYRC', RC )
        RETURN
     ENDIF
     Inst%FLUXMYRC = 0.0_sp
 
     ALLOCATE( Inst%FLUXCARE( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'FLUXCARE', RC )
+       CALL HCO_ERROR( 'FLUXCARE', RC )
        RETURN
     ENDIF
     Inst%FLUXCARE = 0.0_sp
 
     ALLOCATE( Inst%FLUXOCIM( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'FLUXOCIM', RC )
+       CALL HCO_ERROR( 'FLUXOCIM', RC )
        RETURN
     ENDIF
     Inst%FLUXOCIM = 0.0_sp
 
     ALLOCATE( Inst%FLUXOMON( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err,  'FLUXOMON', RC )
+       CALL HCO_ERROR(  'FLUXOMON', RC )
        RETURN
     ENDIF
     Inst%FLUXOMON = 0.0_sp
 
     ALLOCATE( Inst%FLUXFARN( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'FLUXFARN', RC )
+       CALL HCO_ERROR( 'FLUXFARN', RC )
        RETURN
     ENDIF
     Inst%FLUXFARN = 0.0_sp
 
     ALLOCATE( Inst%FLUXBCAR( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'FLUXBCAR', RC )
+       CALL HCO_ERROR( 'FLUXBCAR', RC )
        RETURN
     ENDIF
     Inst%FLUXBCAR = 0.0_sp
 
     ALLOCATE( Inst%FLUXOSQT( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'FLUXOSQT', RC )
+       CALL HCO_ERROR( 'FLUXOSQT', RC )
        RETURN
     ENDIF
     Inst%FLUXOSQT = 0.0_sp
 
     ALLOCATE( Inst%FLUXMBOX( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'FLUXMBOX', RC )
+       CALL HCO_ERROR( 'FLUXMBOX', RC )
        RETURN
     ENDIF
     Inst%FLUXMBOX = 0.0_sp
 
     ALLOCATE( Inst%FLUXFAXX( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'FLUXFAXX', RC )
+       CALL HCO_ERROR( 'FLUXFAXX', RC )
        RETURN
     ENDIF
     Inst%FLUXFAXX = 0.0_sp
 
     ALLOCATE( Inst%FLUXAAXX( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'FLUXAAXX', RC )
+       CALL HCO_ERROR( 'FLUXAAXX', RC )
        RETURN
     ENDIF
     Inst%FLUXAAXX = 0.0_sp
 
     ALLOCATE( Inst%ARRAY_16( NX, NY, 16 ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'ARRAY_16', RC )
+       CALL HCO_ERROR( 'ARRAY_16', RC )
        RETURN
     ENDIF
     Inst%ARRAY_16 = 0.0_hp
@@ -4128,7 +4128,7 @@ CONTAINS
                Inst%AEF_OCIM ( NX, NY ), &
                Inst%AEF_SABI ( NX, NY ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'AEF allocation error', RC )
+       CALL HCO_ERROR( 'AEF allocation error', RC )
        RETURN
     ENDIF
     Inst%AEF_ISOP  = 0.0_hp

--- a/src/Extensions/hcox_paranox_mod.F90
+++ b/src/Extensions/hcox_paranox_mod.F90
@@ -236,7 +236,7 @@ CONTAINS
     CALL InstGet ( ExtState%ParaNOx, Inst, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        WRITE(MSG,*) 'Cannot find ParaNOx instance Nr. ', ExtState%ParaNOx
-       CALL HCO_ERROR(HcoState%Config%Err,MSG,RC)
+       CALL HCO_ERROR(MSG,RC)
        RETURN
     ENDIF
 
@@ -717,7 +717,7 @@ CONTAINS
        CALL HCO_EmisAdd( HcoState, FLUXNO, Inst%IDTNO, &
                          RC,       ExtNr=Inst%ExtNr )
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, 'HCO_EmisAdd error: FLUXNO', RC )
+          CALL HCO_ERROR( 'HCO_EmisAdd error: FLUXNO', RC )
           RETURN
        ENDIF
     ENDIF
@@ -866,7 +866,7 @@ CONTAINS
    Inst => NULL()
    CALL InstCreate( ExtNr, ExtState%ParaNOx, Inst, RC                       )
    IF ( RC /= HCO_SUCCESS ) THEN
-      CALL HCO_ERROR( HcoState%Config%Err,                                   &
+      CALL HCO_ERROR(                                   &
                       'Cannot create ParaNOx instance', RC                  )
       RETURN
    ENDIF
@@ -1036,35 +1036,35 @@ CONTAINS
       ! FNOX
       ALLOCATE( Inst%FRACNOX_LUT02(nT,nJ,nO3,nSEA,nSEA,nJ,nNOx), STAT=RC )
       IF ( RC /= HCO_SUCCESS ) THEN
-         CALL HCO_ERROR ( HcoState%Config%Err, 'FRACNOX_LUT02', RC )
+         CALL HCO_ERROR ( 'FRACNOX_LUT02', RC )
          RETURN
       ENDIF
       Inst%FRACNOX_LUT02 = 0.0_sp
 
       ALLOCATE( Inst%FRACNOX_LUT06(nT,nJ,nO3,nSEA,nSEA,nJ,nNOx), STAT=RC )
       IF ( RC /= HCO_SUCCESS ) THEN
-         CALL HCO_ERROR ( HcoState%Config%Err, 'FRACNOX_LUT06', RC )
+         CALL HCO_ERROR ( 'FRACNOX_LUT06', RC )
          RETURN
       ENDIF
       Inst%FRACNOX_LUT06 = 0.0_sp
 
       ALLOCATE( Inst%FRACNOX_LUT10(nT,nJ,nO3,nSEA,nSEA,nJ,nNOx), STAT=RC )
       IF ( RC /= HCO_SUCCESS ) THEN
-         CALL HCO_ERROR ( HcoState%Config%Err, 'FRACNOX_LUT10', RC )
+         CALL HCO_ERROR ( 'FRACNOX_LUT10', RC )
          RETURN
       ENDIF
       Inst%FRACNOX_LUT10 = 0.0_sp
 
       ALLOCATE( Inst%FRACNOX_LUT14(nT,nJ,nO3,nSEA,nSEA,nJ,nNOx), STAT=RC )
       IF ( RC /= HCO_SUCCESS ) THEN
-         CALL HCO_ERROR ( HcoState%Config%Err, 'FRACNOX_LUT014', RC )
+         CALL HCO_ERROR ( 'FRACNOX_LUT014', RC )
          RETURN
       ENDIF
       Inst%FRACNOX_LUT14 = 0.0_sp
 
       ALLOCATE( Inst%FRACNOX_LUT18(nT,nJ,nO3,nSEA,nSEA,nJ,nNOx), STAT=RC )
       IF ( RC /= HCO_SUCCESS ) THEN
-         CALL HCO_ERROR ( HcoState%Config%Err, 'FRACNOX_LUT18', RC )
+         CALL HCO_ERROR ( 'FRACNOX_LUT18', RC )
          RETURN
       ENDIF
       Inst%FRACNOX_LUT18 = 0.0_sp
@@ -1072,35 +1072,35 @@ CONTAINS
       ! OPE
       ALLOCATE( Inst%OPE_LUT02(nT,nJ,nO3,nSEA,nSEA,nJ,nNOx), STAT=RC )
       IF ( RC /= HCO_SUCCESS ) THEN
-         CALL HCO_ERROR ( HcoState%Config%Err, 'OPE_LUT02', RC )
+         CALL HCO_ERROR ( 'OPE_LUT02', RC )
          RETURN
       ENDIF
       Inst%OPE_LUT02 = 0.0_sp
 
       ALLOCATE( Inst%OPE_LUT06(nT,nJ,nO3,nSEA,nSEA,nJ,nNOx), STAT=RC )
       IF ( RC /= HCO_SUCCESS ) THEN
-         CALL HCO_ERROR ( HcoState%Config%Err, 'OPE_LUT06', RC )
+         CALL HCO_ERROR ( 'OPE_LUT06', RC )
          RETURN
       ENDIF
       Inst%OPE_LUT06 = 0.0_sp
 
       ALLOCATE( Inst%OPE_LUT10(nT,nJ,nO3,nSEA,nSEA,nJ,nNOx), STAT=RC )
       IF ( RC /= 0 ) THEN
-         CALL HCO_ERROR ( HcoState%Config%Err, 'OPE_LUT10', RC )
+         CALL HCO_ERROR ( 'OPE_LUT10', RC )
          RETURN
       ENDIF
       Inst%OPE_LUT10 = 0.0_sp
 
       ALLOCATE( Inst%OPE_LUT14(nT,nJ,nO3,nSEA,nSEA,nJ,nNOx), STAT=RC )
       IF ( RC /= 0 ) THEN
-         CALL HCO_ERROR ( HcoState%Config%Err, 'OPE_LUT014', RC )
+         CALL HCO_ERROR ( 'OPE_LUT014', RC )
          RETURN
       ENDIF
       Inst%OPE_LUT14 = 0.0_sp
 
       ALLOCATE( Inst%OPE_LUT18(nT,nJ,nO3,nSEA,nSEA,nJ,nNOx), STAT=RC )
       IF ( RC /= HCO_SUCCESS ) THEN
-         CALL HCO_ERROR ( HcoState%Config%Err, 'OPE_LUT18', RC )
+         CALL HCO_ERROR ( 'OPE_LUT18', RC )
          RETURN
       ENDIF
       Inst%OPE_LUT18 = 0.0_sp
@@ -1108,35 +1108,35 @@ CONTAINS
       ! MOE
       ALLOCATE( Inst%MOE_LUT02(nT,nJ,nO3,nSEA,nSEA,nJ,nNOx), STAT=RC )
       IF ( RC /= HCO_SUCCESS ) THEN
-         CALL HCO_ERROR ( HcoState%Config%Err, 'MOE_LUT02', RC )
+         CALL HCO_ERROR ( 'MOE_LUT02', RC )
          RETURN
       ENDIF
       Inst%MOE_LUT02 = 0.0_sp
 
       ALLOCATE( Inst%MOE_LUT06(nT,nJ,nO3,nSEA,nSEA,nJ,nNOx), STAT=RC )
       IF ( RC /= HCO_SUCCESS ) THEN
-         CALL HCO_ERROR ( HcoState%Config%Err, 'MOE_LUT06', RC )
+         CALL HCO_ERROR ( 'MOE_LUT06', RC )
          RETURN
       ENDIF
       Inst%MOE_LUT06 = 0.0_sp
 
       ALLOCATE( Inst%MOE_LUT10(nT,nJ,nO3,nSEA,nSEA,nJ,nNOx), STAT=RC )
       IF ( RC /= HCO_SUCCESS ) THEN
-         CALL HCO_ERROR ( HcoState%Config%Err, 'MOE_LUT10', RC )
+         CALL HCO_ERROR ( 'MOE_LUT10', RC )
          RETURN
       ENDIF
       Inst%MOE_LUT10 = 0.0_sp
 
       ALLOCATE( Inst%MOE_LUT14(nT,nJ,nO3,nSEA,nSEA,nJ,nNOx), STAT=RC )
       IF ( RC /= HCO_SUCCESS ) THEN
-         CALL HCO_ERROR ( HcoState%Config%Err, 'MOE_LUT014', RC )
+         CALL HCO_ERROR ( 'MOE_LUT014', RC )
          RETURN
       ENDIF
       Inst%MOE_LUT14 = 0.0_sp
 
       ALLOCATE( Inst%MOE_LUT18(nT,nJ,nO3,nSEA,nSEA,nJ,nNOx), STAT=RC )
       IF ( RC /= HCO_SUCCESS ) THEN
-         CALL HCO_ERROR ( HcoState%Config%Err, 'MOE_LUT18', RC )
+         CALL HCO_ERROR ( 'MOE_LUT18', RC )
          RETURN
       ENDIF
       Inst%MOE_LUT18 = 0.0_sp
@@ -1144,35 +1144,35 @@ CONTAINS
       ! DNOx
       ALLOCATE( Inst%DNOx_LUT02(nT,nJ,nO3,nSEA,nSEA,nJ,nNOx), STAT=RC )
       IF ( RC /= HCO_SUCCESS ) THEN
-         CALL HCO_ERROR ( HcoState%Config%Err, 'DNOx_LUT02', RC )
+         CALL HCO_ERROR ( 'DNOx_LUT02', RC )
          RETURN
       ENDIF
       Inst%DNOx_LUT02 = 0.0_sp
 
       ALLOCATE( Inst%DNOx_LUT06(nT,nJ,nO3,nSEA,nSEA,nJ,nNOx), STAT=RC )
       IF ( RC /= HCO_SUCCESS ) THEN
-         CALL HCO_ERROR ( HcoState%Config%Err, 'DNOx_LUT06', RC )
+         CALL HCO_ERROR ( 'DNOx_LUT06', RC )
          RETURN
       ENDIF
       Inst%DNOx_LUT06 = 0.0_sp
 
       ALLOCATE( Inst%DNOx_LUT10(nT,nJ,nO3,nSEA,nSEA,nJ,nNOx), STAT=RC )
       IF ( RC /= HCO_SUCCESS ) THEN
-         CALL HCO_ERROR ( HcoState%Config%Err, 'DNOx_LUT10', RC )
+         CALL HCO_ERROR ( 'DNOx_LUT10', RC )
          RETURN
       ENDIF
       Inst%DNOx_LUT10 = 0.0_sp
 
       ALLOCATE( Inst%DNOx_LUT14(nT,nJ,nO3,nSEA,nSEA,nJ,nNOx), STAT=RC )
       IF ( RC /= HCO_SUCCESS ) THEN
-         CALL HCO_ERROR ( HcoState%Config%Err, 'DNOx_LUT014', RC )
+         CALL HCO_ERROR ( 'DNOx_LUT014', RC )
          RETURN
       ENDIF
       Inst%DNOx_LUT14 = 0.0_sp
 
       ALLOCATE( Inst%DNOx_LUT18(nT,nJ,nO3,nSEA,nSEA,nJ,nNOx), STAT=RC )
       IF ( RC /= HCO_SUCCESS ) THEN
-         CALL HCO_ERROR ( HcoState%Config%Err, 'DNOx_LUT18', RC )
+         CALL HCO_ERROR ( 'DNOx_LUT18', RC )
          RETURN
       ENDIF
       Inst%DNOx_LUT18 = 0.0_sp
@@ -1180,7 +1180,7 @@ CONTAINS
       ALLOCATE(Inst%DEPO3  (HcoState%NX,HcoState%NY),        &
                Inst%DEPHNO3(HcoState%NX,HcoState%NY), STAT=RC )
       IF ( RC /= HCO_SUCCESS ) THEN
-         CALL HCO_ERROR ( HcoState%Config%Err, 'Deposition arrays', RC )
+         CALL HCO_ERROR ( 'Deposition arrays', RC )
          RETURN
       ENDIF
       Inst%DEPO3   = 0.0_sp
@@ -1189,14 +1189,14 @@ CONTAINS
    !   ! O3 loss and HNO3 deposition
    !   ALLOCATE( Inst%SHIPO3LOSS(HcoState%NX,HcoState%NY), STAT=RC )
    !   IF ( RC /= HCO_SUCCESS ) THEN
-   !      CALL HCO_ERROR ( HcoState%Config%Err, 'SHIPO3LOSS', RC )
+   !      CALL HCO_ERROR ( 'SHIPO3LOSS', RC )
    !      RETURN
    !   ENDIF
    !   Inst%SHIPO3LOSS = 0d0
 
    !   ALLOCATE( Inst%SHIPHNO3DEP(HcoState%NX,HcoState%NY), STAT=RC )
    !   IF ( RC /= HCO_SUCCESS ) THEN
-   !        CALL HCO_ERROR ( HcoState%Config%Err, 'SHIPHNO3DEP', RC ); RETURN
+   !        CALL HCO_ERROR ( 'SHIPHNO3DEP', RC ); RETURN
    !   ENDIF
    !   Inst%SHIPHNO3DEP = 0d0
 
@@ -1256,7 +1256,7 @@ CONTAINS
    !------------------------------------------------------------------------
    ALLOCATE ( Inst%ShipNO(HcoState%NX,HcoState%NY,HcoState%NZ), STAT=RC )
    IF ( RC /= HCO_SUCCESS ) THEN
-      CALL HCO_ERROR ( HcoState%Config%Err, 'ShipNO', RC )
+      CALL HCO_ERROR ( 'ShipNO', RC )
       RETURN
    ENDIF
    Inst%ShipNO = 0.0_hp
@@ -1264,7 +1264,7 @@ CONTAINS
    ! Allocate variables for SunCosMid from 5 hours ago.
    ALLOCATE ( Inst%SC5(HcoState%NX,HcoState%NY), STAT=RC )
    IF ( RC /= HCO_SUCCESS ) THEN
-      CALL HCO_ERROR ( HcoState%Config%Err, 'SC5', RC )
+      CALL HCO_ERROR ( 'SC5', RC )
       RETURN
    ENDIF
    Inst%SC5 = 0.0_hp
@@ -1429,7 +1429,7 @@ CONTAINS
    MSG = 'In ESMF, cannot read PARANOX look-up-table in netCDF ' // &
          'format. Please set `LUT data format` to `txt` in the ' // &
          'HEMCO configuration file.'
-   CALL HCO_ERROR(HcoState%Config%Err,MSG, RC, &
+   CALL HCO_ERROR(MSG, RC, &
            THISLOC = 'READ_PARANOX_LUT_NC (hcox_paranox_mod.F90)' )
    RETURN
 #else
@@ -1605,7 +1605,7 @@ CONTAINS
    ELSE
       IF ( .not. FileExists ) THEN
          WRITE( MSG, 300 ) TRIM( FileMsg ), TRIM( FileName )
-         CALL HCO_ERROR(HcoState%Config%Err, MSG, HMRC )
+         CALL HCO_ERROR(MSG, HMRC )
          IF ( PRESENT( RC ) ) RC = HMRC
          RETURN
       ENDIF
@@ -1902,7 +1902,7 @@ CONTAINS
    ELSE
       IF ( .not. FileExists ) THEN
          WRITE( MSG, 300 ) TRIM( FileMsg ), TRIM( FileName )
-         CALL HCO_ERROR(HcoState%Config%Err, MSG, RC )
+         CALL HCO_ERROR(MSG, RC )
          RETURN
       ENDIF
    ENDIF
@@ -1917,35 +1917,35 @@ CONTAINS
    ! Open file for reading
    OPEN ( fID, FILE=TRIM(FILENAME), FORM="FORMATTED", IOSTAT=IOS )
    IF ( IOS /= 0 ) THEN
-      CALL HCO_ERROR( HcoState%Config%Err, 'read_lut_txtfile:1', RC, THISLOC=LOC )
+      CALL HCO_ERROR( 'read_lut_txtfile:1', RC, THISLOC=LOC )
       RETURN
    ENDIF
 
    ! Read FNOx
    READ( fId, FMT=FMAT, IOSTAT=IOS ) FNOx
    IF ( IOS /= 0 ) THEN
-      CALL HCO_ERROR( HcoState%Config%Err, 'read_lut_txtfile: FNOx', RC, THISLOC=LOC )
+      CALL HCO_ERROR( 'read_lut_txtfile: FNOx', RC, THISLOC=LOC )
       RETURN
    ENDIF
 
    ! Read OPE
    READ( fId, FMT=FMAT, IOSTAT=IOS ) OPE
    IF ( IOS /= 0 ) THEN
-      CALL HCO_ERROR( HcoState%Config%Err, 'read_lut_txtfile: OPE', RC, THISLOC=LOC )
+      CALL HCO_ERROR( 'read_lut_txtfile: OPE', RC, THISLOC=LOC )
       RETURN
    ENDIF
 
    ! Read MOE
    READ( fId, FMT=FMAT, IOSTAT=IOS ) MOE
    IF ( IOS /= 0 ) THEN
-      CALL HCO_ERROR( HcoState%Config%Err, 'read_lut_txtfile: MOE', RC, THISLOC=LOC )
+      CALL HCO_ERROR( 'read_lut_txtfile: MOE', RC, THISLOC=LOC )
       RETURN
    ENDIF
 
    ! Read DNOx
    READ( fId, FMT=FMAT, IOSTAT=IOS ) DNOx
    IF ( IOS /= 0 ) THEN
-      CALL HCO_ERROR( HcoState%Config%Err, 'read_lut_txtfile: DNOx', RC, THISLOC=LOC )
+      CALL HCO_ERROR( 'read_lut_txtfile: DNOx', RC, THISLOC=LOC )
       RETURN
    ENDIF
 
@@ -1953,7 +1953,7 @@ CONTAINS
    IF ( PRESENT(T) ) THEN
       READ( fId, FMT=FMAT, IOSTAT=IOS ) T
       IF ( IOS /= 0 ) THEN
-         CALL HCO_ERROR( HcoState%Config%Err, 'read_lut_txtfile: T', RC, THISLOC=LOC )
+         CALL HCO_ERROR( 'read_lut_txtfile: T', RC, THISLOC=LOC )
          RETURN
       ENDIF
    ENDIF
@@ -1961,7 +1961,7 @@ CONTAINS
    IF ( PRESENT(JNO2) ) THEN
       READ( fId, FMT=FMAT, IOSTAT=IOS ) JNO2
       IF ( IOS /= 0 ) THEN
-         CALL HCO_ERROR( HcoState%Config%Err, 'read_lut_txtfile: JNO2', RC, THISLOC=LOC )
+         CALL HCO_ERROR( 'read_lut_txtfile: JNO2', RC, THISLOC=LOC )
          RETURN
       ENDIF
    ENDIF
@@ -1969,7 +1969,7 @@ CONTAINS
    IF ( PRESENT(O3) ) THEN
       READ( fId, FMT=FMAT, IOSTAT=IOS ) O3
       IF ( IOS /= 0 ) THEN
-         CALL HCO_ERROR( HcoState%Config%Err, 'read_lut_txtfile: O3', RC, THISLOC=LOC )
+         CALL HCO_ERROR( 'read_lut_txtfile: O3', RC, THISLOC=LOC )
          RETURN
       ENDIF
    ENDIF
@@ -1977,7 +1977,7 @@ CONTAINS
    IF ( PRESENT(SEA0) ) THEN
       READ( fId, FMT=FMAT, IOSTAT=IOS ) SEA0
       IF ( IOS /= 0 ) THEN
-         CALL HCO_ERROR( HcoState%Config%Err, 'read_lut_txtfile: SEA0', RC, THISLOC=LOC )
+         CALL HCO_ERROR( 'read_lut_txtfile: SEA0', RC, THISLOC=LOC )
          RETURN
       ENDIF
    ENDIF
@@ -1985,7 +1985,7 @@ CONTAINS
    IF ( PRESENT(SEA5) ) THEN
       READ( fId, FMT=FMAT, IOSTAT=IOS ) SEA5
       IF ( IOS /= 0 ) THEN
-         CALL HCO_ERROR( HcoState%Config%Err, 'read_lut_txtfile: SEA5', RC, THISLOC=LOC )
+         CALL HCO_ERROR( 'read_lut_txtfile: SEA5', RC, THISLOC=LOC )
          RETURN
       ENDIF
    ENDIF
@@ -1993,7 +1993,7 @@ CONTAINS
    IF ( PRESENT(JRATIO) ) THEN
       READ( fId, FMT=FMAT, IOSTAT=IOS ) JRATIO
       IF ( IOS /= 0 ) THEN
-         CALL HCO_ERROR( HcoState%Config%Err, 'read_lut_txtfile: JRATIO', RC, THISLOC=LOC )
+         CALL HCO_ERROR( 'read_lut_txtfile: JRATIO', RC, THISLOC=LOC )
          RETURN
       ENDIF
    ENDIF
@@ -2001,7 +2001,7 @@ CONTAINS
    IF ( PRESENT(NOX) ) THEN
       READ( fId, FMT=FMAT, IOSTAT=IOS ) NOX
       IF ( IOS /= 0 ) THEN
-         CALL HCO_ERROR( HcoState%Config%Err, 'read_lut_txtfile: NOX', RC, THISLOC=LOC )
+         CALL HCO_ERROR( 'read_lut_txtfile: NOX', RC, THISLOC=LOC )
          RETURN
       ENDIF
    ENDIF
@@ -2020,7 +2020,7 @@ CONTAINS
 !         CASE ( 4 )
 !            TMPARR => DNOx
 !         CASE DEFAULT
-!            CALL HCO_ERROR( HcoState%Config%Err, 'I > 4', RC, THISLOC=LOC )
+!            CALL HCO_ERROR( 'I > 4', RC, THISLOC=LOC )
 !            RETURN
 !      END SELECT
 !
@@ -2120,35 +2120,35 @@ CONTAINS
    ! Open file for reading
    OPEN ( fID, FILE=TRIM(FILENAME), ACTION="WRITE", FORM="FORMATTED", IOSTAT=IOS )
    IF ( IOS /= 0 ) THEN
-      CALL HCO_ERROR( HcoState%Config%Err, 'write_lut_txtfile:1', RC, THISLOC=LOC )
+      CALL HCO_ERROR( 'write_lut_txtfile:1', RC, THISLOC=LOC )
       RETURN
    ENDIF
 
    ! Read FNOx
    WRITE( fId, FMT=FMAT, IOSTAT=IOS ) FNOx
    IF ( IOS /= 0 ) THEN
-      CALL HCO_ERROR( HcoState%Config%Err, 'write_lut_txtfile: FNOx', RC, THISLOC=LOC )
+      CALL HCO_ERROR( 'write_lut_txtfile: FNOx', RC, THISLOC=LOC )
       RETURN
    ENDIF
 
    ! Read OPE
    WRITE( fId, FMT=FMAT, IOSTAT=IOS ) OPE
    IF ( IOS /= 0 ) THEN
-      CALL HCO_ERROR( HcoState%Config%Err, 'read_lut_txtfile: OPE', RC, THISLOC=LOC )
+      CALL HCO_ERROR( 'read_lut_txtfile: OPE', RC, THISLOC=LOC )
       RETURN
    ENDIF
 
    ! Read MOE
    WRITE( fId, FMT=FMAT, IOSTAT=IOS ) MOE
    IF ( IOS /= 0 ) THEN
-      CALL HCO_ERROR( HcoState%Config%Err, 'read_lut_txtfile: MOE', RC, THISLOC=LOC )
+      CALL HCO_ERROR( 'read_lut_txtfile: MOE', RC, THISLOC=LOC )
       RETURN
    ENDIF
 
    ! Read DNOx
    WRITE( fId, FMT=FMAT, IOSTAT=IOS ) DNOx
    IF ( IOS /= 0 ) THEN
-      CALL HCO_ERROR( HcoState%Config%Err, 'read_lut_txtfile: DNOx', RC, THISLOC=LOC )
+      CALL HCO_ERROR( 'read_lut_txtfile: DNOx', RC, THISLOC=LOC )
       RETURN
    ENDIF
 
@@ -2156,7 +2156,7 @@ CONTAINS
    IF ( PRESENT(T) ) THEN
       WRITE( fId, FMT=FMAT, IOSTAT=IOS ) T
       IF ( IOS /= 0 ) THEN
-         CALL HCO_ERROR( HcoState%Config%Err, 'read_lut_txtfile: T', RC, THISLOC=LOC )
+         CALL HCO_ERROR( 'read_lut_txtfile: T', RC, THISLOC=LOC )
          RETURN
       ENDIF
    ENDIF
@@ -2164,7 +2164,7 @@ CONTAINS
    IF ( PRESENT(JNO2) ) THEN
       WRITE( fId, FMT=FMAT, IOSTAT=IOS ) JNO2
       IF ( IOS /= 0 ) THEN
-         CALL HCO_ERROR( HcoState%Config%Err, 'read_lut_txtfile: JNO2', RC, THISLOC=LOC )
+         CALL HCO_ERROR( 'read_lut_txtfile: JNO2', RC, THISLOC=LOC )
          RETURN
       ENDIF
    ENDIF
@@ -2172,7 +2172,7 @@ CONTAINS
    IF ( PRESENT(O3) ) THEN
       WRITE( fId, FMT=FMAT, IOSTAT=IOS ) O3
       IF ( IOS /= 0 ) THEN
-         CALL HCO_ERROR( HcoState%Config%Err, 'read_lut_txtfile: O3', RC, THISLOC=LOC )
+         CALL HCO_ERROR( 'read_lut_txtfile: O3', RC, THISLOC=LOC )
          RETURN
       ENDIF
    ENDIF
@@ -2180,7 +2180,7 @@ CONTAINS
    IF ( PRESENT(SEA0) ) THEN
       WRITE( fId, FMT=FMAT, IOSTAT=IOS ) SEA0
       IF ( IOS /= 0 ) THEN
-         CALL HCO_ERROR( HcoState%Config%Err, 'read_lut_txtfile: SEA0', RC, THISLOC=LOC )
+         CALL HCO_ERROR( 'read_lut_txtfile: SEA0', RC, THISLOC=LOC )
          RETURN
       ENDIF
    ENDIF
@@ -2188,7 +2188,7 @@ CONTAINS
    IF ( PRESENT(SEA5) ) THEN
       WRITE( fId, FMT=FMAT, IOSTAT=IOS ) SEA5
       IF ( IOS /= 0 ) THEN
-         CALL HCO_ERROR( HcoState%Config%Err, 'read_lut_txtfile: SEA5', RC, THISLOC=LOC )
+         CALL HCO_ERROR( 'read_lut_txtfile: SEA5', RC, THISLOC=LOC )
          RETURN
       ENDIF
    ENDIF
@@ -2196,7 +2196,7 @@ CONTAINS
    IF ( PRESENT(JRATIO) ) THEN
       WRITE( fId, FMT=FMAT, IOSTAT=IOS ) JRATIO
       IF ( IOS /= 0 ) THEN
-         CALL HCO_ERROR( HcoState%Config%Err, 'read_lut_txtfile: JRATIO', RC, THISLOC=LOC )
+         CALL HCO_ERROR( 'read_lut_txtfile: JRATIO', RC, THISLOC=LOC )
          RETURN
       ENDIF
    ENDIF
@@ -2204,7 +2204,7 @@ CONTAINS
    IF ( PRESENT(NOX) ) THEN
       WRITE( fId, FMT=FMAT, IOSTAT=IOS ) NOX
       IF ( IOS /= 0 ) THEN
-         CALL HCO_ERROR( HcoState%Config%Err, 'read_lut_txtfile: NOX', RC, THISLOC=LOC )
+         CALL HCO_ERROR( 'read_lut_txtfile: NOX', RC, THISLOC=LOC )
          RETURN
       ENDIF
    ENDIF
@@ -2628,7 +2628,7 @@ CONTAINS
             MOE_LUT     => Inst%MOE_LUT18
          CASE DEFAULT
              MSG = 'LUT error: Wind speed interpolation error!'
-             CALL HCO_ERROR(HcoState%Config%Err,MSG, RC, THISLOC=LOC )
+             CALL HCO_ERROR(MSG, RC, THISLOC=LOC )
              RETURN
       END SELECT
 
@@ -2700,7 +2700,7 @@ CONTAINS
             !print*, VARS
 
             MSG = 'LUT error: Fracnox should be between 0 and 1!'
-            CALL HCO_ERROR(HcoState%Config%Err,MSG, RC, THISLOC=LOC )
+            CALL HCO_ERROR(MSG, RC, THISLOC=LOC )
             RETURN
          ENDIF
 

--- a/src/Extensions/hcox_seaflux_mod.F90
+++ b/src/Extensions/hcox_seaflux_mod.F90
@@ -196,7 +196,7 @@ CONTAINS
     CALL InstGet ( ExtState%SeaFlux, Inst, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        WRITE(MSG,*) 'Cannot find SeaFlux instance Nr. ', ExtState%SeaFlux
-       CALL HCO_ERROR(HcoState%Config%Err,MSG,RC)
+       CALL HCO_ERROR(MSG,RC)
        RETURN
     ENDIF
 
@@ -240,7 +240,7 @@ CONTAINS
        CALL HCO_EmisAdd ( HcoState, SOURCE, HcoID, RC, ExtNr=Inst%ExtNr )
        IF ( RC /= HCO_SUCCESS ) THEN
           MSG = 'HCO_EmisAdd error: ' // TRIM(Inst%OcSpecs(OcID)%OcSpcName)
-          CALL HCO_ERROR(HcoState%Config%Err,MSG, RC )
+          CALL HCO_ERROR(MSG, RC )
           RETURN
        ENDIF
        IF ( RC /= HCO_SUCCESS ) RETURN
@@ -540,7 +540,7 @@ CONTAINS
 
     ! Check exit status
     IF ( RC /= HCO_SUCCESS ) THEN
-       CALL HCO_ERROR(HcoState%Config%Err,MSG, RC )
+       CALL HCO_ERROR(MSG, RC )
        RETURN
     ENDIF
 
@@ -674,7 +674,7 @@ CONTAINS
     ! Create instance for this simulation
     CALL InstCreate ( ExtNr, ExtState%SeaFlux, Inst, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, 'Cannot create SeaFlux instance', RC )
+       CALL HCO_ERROR ( 'Cannot create SeaFlux instance', RC )
        RETURN
     ENDIF
 
@@ -712,7 +712,7 @@ CONTAINS
 
     I = I + 1
     IF ( I > Inst%nOcSpc ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, ERR, RC )
+       CALL HCO_ERROR ( ERR, RC )
        RETURN
     ENDIF
 
@@ -727,7 +727,7 @@ CONTAINS
 
     I = I + 1
     IF ( I > Inst%nOcSpc ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, ERR, RC )
+       CALL HCO_ERROR ( ERR, RC )
        RETURN
     ENDIF
 
@@ -742,7 +742,7 @@ CONTAINS
 
     I = I + 1
     IF ( I > Inst%nOcSpc ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, ERR, RC )
+       CALL HCO_ERROR ( ERR, RC )
        RETURN
     ENDIF
 
@@ -757,7 +757,7 @@ CONTAINS
 
     I = I + 1
     IF ( I > Inst%nOcSpc ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, ERR, RC )
+       CALL HCO_ERROR ( ERR, RC )
        RETURN
     ENDIF
 

--- a/src/Extensions/hcox_seasalt_mod.F90
+++ b/src/Extensions/hcox_seasalt_mod.F90
@@ -272,7 +272,7 @@ CONTAINS
     CALL InstGet ( ExtState%SeaSalt, Inst, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        WRITE(MSG,*) 'Cannot find SeaSalt instance Nr. ', ExtState%SeaSalt
-       CALL HCO_ERROR(HcoState%Config%Err,MSG,RC)
+       CALL HCO_ERROR(MSG,RC)
        RETURN
     ENDIF
 
@@ -295,7 +295,7 @@ CONTAINS
        CALL HCO_EvalFld ( HcoState, 'MODIS_CHLR', Inst%CHLR, RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           WRITE(MSG,*) 'Cannot find MODIS CHLR data for marine POA'
-          CALL HCO_ERROR(HcoState%Config%Err, MSG, RC)
+          CALL HCO_ERROR(MSG, RC)
           RETURN
        ENDIF
     ENDIF
@@ -309,7 +309,7 @@ CONTAINS
       CALL HCO_EvalFld ( HcoState, 'MULTISEAICE', MULTI, RC )
       IF ( RC /= HCO_SUCCESS ) THEN
           WRITE(MSG,*) 'Cannot find MULTISEAICE data for blowing snow'
-          CALL HCO_ERROR(HcoState%Config%Err, MSG, RC)
+          CALL HCO_ERROR(MSG, RC)
           RETURN
       ENDIF
     ENDIF
@@ -604,7 +604,7 @@ CONTAINS
        CALL HCO_EmisAdd( HcoState, FLUXSALA, Inst%IDTSALA, &
                          RC,       ExtNr=Inst%ExtNrSS )
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, 'HCO_EmisAdd error: FLUXSALA', RC )
+          CALL HCO_ERROR( 'HCO_EmisAdd error: FLUXSALA', RC )
           RETURN
        ENDIF
     ENDIF
@@ -616,7 +616,7 @@ CONTAINS
        CALL HCO_EmisAdd( HcoState, FLUXSALC, Inst%IDTSALC, &
                          RC,       ExtNr=Inst%ExtNrSS )
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, 'HCO_EmisAdd error: FLUXSALC', RC )
+          CALL HCO_ERROR( 'HCO_EmisAdd error: FLUXSALC', RC )
           RETURN
        ENDIF
 
@@ -629,7 +629,7 @@ CONTAINS
        CALL HCO_EmisAdd( HcoState, FLUXSALACL, Inst%IDTSALACL, &
                          RC,        ExtNr=Inst%ExtNrSS )
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, 'HCO_EmisAdd error: FLUXSALACL', RC)
+          CALL HCO_ERROR( 'HCO_EmisAdd error: FLUXSALACL', RC)
           RETURN
        ENDIF
     ENDIF
@@ -641,7 +641,7 @@ CONTAINS
        CALL HCO_EmisAdd( HcoState, FLUXSALCCL, Inst%IDTSALCCL, &
                          RC,        ExtNr=Inst%ExtNrSS )
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, 'HCO_EmisAdd error: FLUXSALCCL', RC)
+          CALL HCO_ERROR( 'HCO_EmisAdd error: FLUXSALCCL', RC)
           RETURN
        ENDIF
     ENDIF
@@ -653,7 +653,7 @@ CONTAINS
        CALL HCO_EmisAdd( HcoState, FLUXSALAAL, Inst%IDTSALAAL, &
                          RC,        ExtNr=Inst%ExtNrSS )
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, 'HCO_EmisAdd error: FLUXSALAAL', RC)
+          CALL HCO_ERROR( 'HCO_EmisAdd error: FLUXSALAAL', RC)
           RETURN
        ENDIF
     ENDIF
@@ -665,7 +665,7 @@ CONTAINS
        CALL HCO_EmisAdd( HcoState, FLUXSALCAL, Inst%IDTSALCAL, &
                          RC,        ExtNr=Inst%ExtNrSS )
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, 'HCO_EmisAdd error: FLUXSALCAL', RC)
+          CALL HCO_ERROR( 'HCO_EmisAdd error: FLUXSALCAL', RC)
           RETURN
        ENDIF
     ENDIF
@@ -683,7 +683,7 @@ CONTAINS
        CALL HCO_EmisAdd( HcoState, FLUXBrSalA, Inst%IDTBrSalA, &
                          RC,       ExtNr=Inst%ExtNrSS )
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, 'HCO_EmisAdd error: FLUXBrSalA', RC )
+          CALL HCO_ERROR( 'HCO_EmisAdd error: FLUXBrSalA', RC )
           RETURN
        ENDIF
 
@@ -691,7 +691,7 @@ CONTAINS
        CALL HCO_EmisAdd( HcoState, FLUXBrSalC, Inst%IDTBrSalC, &
                          RC,       ExtNr=Inst%ExtNrSS )
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, 'HCO_EmisAdd error: FLUXBrSalC', RC )
+          CALL HCO_ERROR( 'HCO_EmisAdd error: FLUXBrSalC', RC )
           RETURN
        ENDIF
 
@@ -704,7 +704,7 @@ CONTAINS
        CALL HCO_EmisAdd( HcoState, FLUXMOPO, Inst%IDTMOPO, &
                          RC,       ExtNr=Inst%ExtNrSS )
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, 'HCO_EmisAdd error: FLUXMOPO', RC )
+          CALL HCO_ERROR( 'HCO_EmisAdd error: FLUXMOPO', RC )
           RETURN
        ENDIF
 
@@ -717,7 +717,7 @@ CONTAINS
        CALL HCO_EmisAdd( HcoState, FLUXMOPI, Inst%IDTMOPI, &
                          RC,       ExtNr=Inst%ExtNrSS )
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, 'HCO_EmisAdd error: FLUXMOPI', RC )
+          CALL HCO_ERROR( 'HCO_EmisAdd error: FLUXMOPI', RC )
           RETURN
        ENDIF
 
@@ -810,7 +810,7 @@ CONTAINS
     Inst => NULL()
     CALL InstCreate ( ExtNrSS, ExtState%SeaSalt, Inst, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, 'Cannot create SeaSalt instance', RC )
+       CALL HCO_ERROR ( 'Cannot create SeaSalt instance', RC )
        RETURN
     ENDIF
     ! Also fill ExtNrSS - this is the same as the parent ExtNr
@@ -843,7 +843,7 @@ CONTAINS
     IF ( RC /= HCO_SUCCESS ) RETURN
     IF ( nSpcSS < minLen ) THEN
        MSG = 'Not enough sea salt emission species set'
-       CALL HCO_ERROR(HcoState%Config%Err,MSG, RC )
+       CALL HCO_ERROR(MSG, RC )
        RETURN
     ENDIF
     Inst%IDTSALA = HcoIDsSS(1)
@@ -1026,53 +1026,53 @@ CONTAINS
 
     ALLOCATE ( Inst%NR  ( Inst%NSALT ), STAT=AS )
     IF ( AS/=0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'Cannot allocate NR', RC )
+       CALL HCO_ERROR( 'Cannot allocate NR', RC )
        RETURN
     ENDIF
     Inst%NR = 0
 
     ALLOCATE ( Inst%SS_DEN  ( Inst%NSALT ), STAT=AS )
     IF ( AS/=0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'Cannot allocate SS_DEN', RC )
+       CALL HCO_ERROR( 'Cannot allocate SS_DEN', RC )
        RETURN
     ENDIF
     Inst%SS_DEN = 2200.d0
 
     ALLOCATE ( Inst%SRRC   ( NR_MAX,   Inst%NSALT ), STAT=AS )
     IF ( AS/=0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'Cannot allocate SRRC', RC )
+       CALL HCO_ERROR( 'Cannot allocate SRRC', RC )
        RETURN
     ENDIF
     Inst%SRRC = 0d0
     ALLOCATE ( Inst%SRRC_N ( NR_MAX,   Inst%NSALT ), STAT=AS )
     IF ( AS/=0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'Cannot allocate SRRC_N', RC )
+       CALL HCO_ERROR( 'Cannot allocate SRRC_N', RC )
        RETURN
     ENDIF
     Inst%SRRC_N = 0d0
     ALLOCATE ( Inst%RREDGE ( 0:NR_MAX, Inst%NSALT ), STAT=AS )
     IF ( AS/=0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'Cannot allocate RREDGE', RC )
+       CALL HCO_ERROR( 'Cannot allocate RREDGE', RC )
        RETURN
     ENDIF
     Inst%RREDGE = 0d0
     ALLOCATE ( Inst%RRMID  ( NR_MAX,   Inst%NSALT ), STAT=AS )
     IF ( AS/=0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'Cannot allocate RRMID', RC )
+       CALL HCO_ERROR( 'Cannot allocate RRMID', RC )
        RETURN
     ENDIF
     Inst%RRMID = 0d0
 
     ALLOCATE ( Inst%NDENS_SALA( HcoState%NX, HcoState%NY), STAT=AS )
     IF ( AS/=0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'Cannot allocate NDENS_SALA', RC )
+       CALL HCO_ERROR( 'Cannot allocate NDENS_SALA', RC )
        RETURN
     ENDIF
     Inst%NDENS_SALA = 0.0_sp
 
     ALLOCATE ( Inst%NDENS_SALC( HcoState%NX, HcoState%NY), STAT=AS )
     IF ( AS/=0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'Cannot allocate NDENS_SALC', RC )
+       CALL HCO_ERROR( 'Cannot allocate NDENS_SALC', RC )
        RETURN
     ENDIF
     Inst%NDENS_SALC = 0.0_sp
@@ -1081,56 +1081,56 @@ CONTAINS
     IF ( Inst%EmitSnowSS ) THEN
         ALLOCATE ( Inst%F_DI_N_FYI( NR_MAX,   Inst%NSALT ), STAT=AS )
         IF ( AS/=0 ) THEN
-           CALL HCO_ERROR( HcoState%Config%Err, 'Cannot allocate F_DI_N_FYI', RC )
+           CALL HCO_ERROR( 'Cannot allocate F_DI_N_FYI', RC )
            RETURN
         ENDIF
         Inst%F_DI_N_FYI = 0.0_sp
 
         ALLOCATE ( Inst%F_DI_N_MYI( NR_MAX,   Inst%NSALT ), STAT=AS )
         IF ( AS/=0 ) THEN
-           CALL HCO_ERROR( HcoState%Config%Err, 'Cannot allocate F_DI_N_MYI', RC )
+           CALL HCO_ERROR( 'Cannot allocate F_DI_N_MYI', RC )
            RETURN
         ENDIF
         Inst%F_DI_N_MYI = 0.0_sp
 
         ALLOCATE ( Inst%F_DN_N_FYI( NR_MAX,   Inst%NSALT ), STAT=AS )
         IF ( AS/=0 ) THEN
-           CALL HCO_ERROR( 'HcoState%Config%Err, Cannot allocate F_DN_N_FYI', RC )
+           CALL HCO_ERROR( 'Cannot allocate F_DN_N_FYI', RC )
            RETURN
         ENDIF
         Inst%F_DN_N_FYI = 0.0_sp
 
         ALLOCATE ( Inst%F_DN_N_MYI( NR_MAX,   Inst%NSALT ), STAT=AS )
         IF ( AS/=0 ) THEN
-           CALL HCO_ERROR( 'HcoState%Config%Err, Cannot allocate F_DN_N_MYI', RC )
+           CALL HCO_ERROR( 'Cannot allocate F_DN_N_MYI', RC )
            RETURN
         ENDIF
         Inst%F_DN_N_MYI = 0.0_sp
 
         ALLOCATE ( Inst%F_DI_S_FYI( NR_MAX,   Inst%NSALT ), STAT=AS )
         IF ( AS/=0 ) THEN
-           CALL HCO_ERROR( HcoState%Config%Err, 'Cannot allocate F_DI_S_FYI', RC )
+           CALL HCO_ERROR( 'Cannot allocate F_DI_S_FYI', RC )
            RETURN
         ENDIF
         Inst%F_DI_S_FYI = 0.0_sp
 
         ALLOCATE ( Inst%F_DI_S_MYI( NR_MAX,   Inst%NSALT ), STAT=AS )
         IF ( AS/=0 ) THEN
-           CALL HCO_ERROR( HcoState%Config%Err, 'Cannot allocate F_DI_S_MYI', RC )
+           CALL HCO_ERROR( 'Cannot allocate F_DI_S_MYI', RC )
            RETURN
         ENDIF
         Inst%F_DI_S_MYI = 0.0_sp
 
         ALLOCATE ( Inst%F_DN_S_FYI( NR_MAX,   Inst%NSALT ), STAT=AS )
         IF ( AS/=0 ) THEN
-           CALL HCO_ERROR( HcoState%Config%Err, 'Cannot allocate F_DN_S_FYI', RC )
+           CALL HCO_ERROR( 'Cannot allocate F_DN_S_FYI', RC )
            RETURN
         ENDIF
         Inst%F_DN_S_FYI = 0.0_sp
 
         ALLOCATE ( Inst%F_DN_S_MYI( NR_MAX,   Inst%NSALT ), STAT=AS )
         IF ( AS/=0 ) THEN
-           CALL HCO_ERROR( HcoState%Config%Err, 'Cannot allocate F_DN_S_MYI', RC )
+           CALL HCO_ERROR( 'Cannot allocate F_DN_S_MYI', RC )
            RETURN
         ENDIF
         Inst%F_DN_S_MYI = 0.0_sp
@@ -1141,7 +1141,7 @@ CONTAINS
        ! Allocate density of phobic marine organic aerosols
        ALLOCATE ( Inst%NDENS_MOPO( HcoState%NX, HcoState%NY), STAT=AS )
        IF ( AS/=0 ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, 'Cannot allocate NDENS_MOPO', RC )
+          CALL HCO_ERROR( 'Cannot allocate NDENS_MOPO', RC )
           RETURN
        ENDIF
        Inst%NDENS_MOPO = 0.0_sp
@@ -1149,14 +1149,14 @@ CONTAINS
        ! Allocate density of philic marine organic aerosols
        ALLOCATE ( Inst%NDENS_MOPI( HcoState%NX, HcoState%NY), STAT=AS )
        IF ( AS/=0 ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, 'Cannot allocate NDENS_MOPI', RC )
+          CALL HCO_ERROR( 'Cannot allocate NDENS_MOPI', RC )
           RETURN
        ENDIF
        Inst%NDENS_MOPI = 0.0_sp
 
        ALLOCATE ( Inst%CHLR( HcoState%NX, HcoState%NY), STAT=AS )
        IF ( AS/=0 ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, 'Cannot allocate CHLR', RC )
+          CALL HCO_ERROR( 'Cannot allocate CHLR', RC )
           RETURN
        ENDIF
        Inst%CHLR = 0.0_hp
@@ -1209,7 +1209,7 @@ CONTAINS
        ! Error check
        IF ( Inst%NR(N) > NR_MAX ) THEN
           MSG = 'Too many bins'
-          CALL HCO_ERROR(HcoState%Config%Err,MSG, RC )
+          CALL HCO_ERROR(MSG, RC )
           RETURN
        ENDIF
 

--- a/src/Extensions/hcox_soilnox_mod.F90
+++ b/src/Extensions/hcox_soilnox_mod.F90
@@ -316,7 +316,7 @@ CONTAINS
     CALL InstGet ( ExtState%SoilNox, Inst, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        WRITE(MSG,*) 'Cannot find soil NOx instance Nr. ', ExtState%SoilNOx
-       CALL HCO_ERROR(HcoState%Config%Err,MSG,RC)
+       CALL HCO_ERROR(MSG,RC)
        RETURN
     ENDIF
 
@@ -391,7 +391,7 @@ CONTAINS
           CALL GetExtOpt( HcoState%Config, Inst%ExtNr, 'DRYCOEFF', &
                            OptValChar=DMY, FOUND=FOUND, RC=RC )
           IF ( .NOT. FOUND ) THEN
-             CALL HCO_ERROR( HcoState%Config%Err, 'DRYCOEFF not defined', RC )
+             CALL HCO_ERROR( 'DRYCOEFF not defined', RC )
              RETURN
           ENDIF
           ALLOCATE(VecDp(MaxDryCoeff))
@@ -546,7 +546,7 @@ CONTAINS
     CALL HCO_EmisAdd( HcoState, FLUX_2D, Inst%IDTNO, &
                       RC,       ExtNr=Inst%ExtNr )
     IF ( RC /= HCO_SUCCESS ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'HCO_EmisAdd error', RC )
+       CALL HCO_ERROR( 'HCO_EmisAdd error', RC )
        RETURN
     ENDIF
 
@@ -639,7 +639,7 @@ CONTAINS
     Inst => NULL()
     CALL InstCreate ( ExtNr, ExtState%SoilNox, Inst, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, 'Cannot create soil NOx instance', RC )
+       CALL HCO_ERROR ( 'Cannot create soil NOx instance', RC )
        RETURN
     ENDIF
 
@@ -662,7 +662,7 @@ CONTAINS
     IF ( RC /= HCO_SUCCESS ) RETURN
     IF ( nSpc /= 1 ) THEN
        MSG = 'Module soil NOx accepts only one species!'
-       CALL HCO_ERROR(HcoState%Config%Err,MSG, RC )
+       CALL HCO_ERROR(MSG, RC )
        RETURN
     ENDIF
     Inst%IDTNO = HcoIDs(1)
@@ -703,42 +703,42 @@ CONTAINS
 
     ALLOCATE( Inst%FertNO_Diag( I, J ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'FertNO_Diag', RC )
+       CALL HCO_ERROR( 'FertNO_Diag', RC )
        RETURN
     ENDIF
     Inst%FertNO_Diag = 0.0_sp
 
     ALLOCATE( Inst%DRYPERIOD( I, J ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'DRYPERIOD', RC )
+       CALL HCO_ERROR( 'DRYPERIOD', RC )
        RETURN
     ENDIF
     Inst%DRYPERIOD     = 0.0_sp
 
     ALLOCATE( Inst%PFACTOR( I, J ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'PFACTOR', RC )
+       CALL HCO_ERROR( 'PFACTOR', RC )
        RETURN
     ENDIF
     Inst%PFACTOR       = 0.0_sp
 
     ALLOCATE( Inst%GWET_PREV( I, J ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'GWET_PREV', RC )
+       CALL HCO_ERROR( 'GWET_PREV', RC )
        RETURN
     ENDIF
     Inst%GWET_PREV     = 0.0_sp
 
     ALLOCATE( Inst%DEP_RESERVOIR( I, J ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'DEP_RESERVOIR', RC )
+       CALL HCO_ERROR( 'DEP_RESERVOIR', RC )
        RETURN
     ENDIF
     Inst%DEP_RESERVOIR = 0.0_sp
 
     ALLOCATE( Inst%CANOPYNOX( I, J, NBIOM ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'CANOPYNOX', RC )
+       CALL HCO_ERROR( 'CANOPYNOX', RC )
        RETURN
     ENDIF
     Inst%CANOPYNOX     = 0e+0_hp
@@ -746,13 +746,13 @@ CONTAINS
     ! Reserve 24 pointers for land fractions for each Koppen category
     ALLOCATE ( Inst%LANDTYPE(NBIOM), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'LANDTYPE', RC )
+       CALL HCO_ERROR( 'LANDTYPE', RC )
        RETURN
     ENDIF
     DO II = 1,NBIOM
        ALLOCATE( Inst%LANDTYPE(II)%VAL( I, J ), STAT=AS )
        IF ( AS /= 0 ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, 'LANDTYPE array', RC )
+          CALL HCO_ERROR( 'LANDTYPE array', RC )
           RETURN
        ENDIF
        Inst%LANDTYPE(II)%Val = 0.0_hp
@@ -762,7 +762,7 @@ CONTAINS
                Inst%CLIMARID  ( I, J ), &
                Inst%CLIMNARID ( I, J ), STAT=AS )
     IF ( AS /= 0 ) THEN
-       CALL HCO_ERROR( HcoState%Config%Err, 'SOILFERT', RC )
+       CALL HCO_ERROR( 'SOILFERT', RC )
        RETURN
     ENDIF
     Inst%SOILFERT  = 0.0_hp

--- a/src/Extensions/hcox_state_mod.F90
+++ b/src/Extensions/hcox_state_mod.F90
@@ -1066,7 +1066,7 @@ CONTAINS
        ! Allocate temporary array
        ALLOCATE(Arr2D(HcoState%NX,HcoState%NY),STAT=AS)
        IF ( AS /= 0 ) THEN
-          CALL HCO_ERROR ( HcoState%Config%Err, "Arr2D allocation error", RC, THISLOC=LOC )
+          CALL HCO_ERROR ( "Arr2D allocation error", RC, THISLOC=LOC )
           RETURN
        ENDIF
 
@@ -1099,7 +1099,7 @@ CONTAINS
                 IF ( FailIfNotFilled ) THEN
                    MSG = 'Cannot fill extension field ' // TRIM(FldName) // &
                          ' because target field is not associated.'
-                   CALL HCO_ERROR(HcoState%Config%Err,MSG, RC, THISLOC=LOC )
+                   CALL HCO_ERROR(MSG, RC, THISLOC=LOC )
                    RETURN
                 ENDIF
 
@@ -1117,7 +1117,7 @@ CONTAINS
                       'Expected dimensions: ', HcoState%NX, HcoState%NY, &
                       '; encountered dimensions: ', NX, NY, '. Error occured ', &
                       'for field ', TRIM(FldName)
-                   CALL HCO_ERROR(HcoState%Config%Err,MSG, RC, THISLOC=LOC )
+                   CALL HCO_ERROR(MSG, RC, THISLOC=LOC )
                    RETURN
                 ENDIF
 
@@ -1140,7 +1140,7 @@ CONTAINS
           ! Field not found and no target defined
           ELSEIF ( FailIfNotFilled ) THEN
              MSG = 'Cannot fill extension field ' // TRIM(FldName)
-             CALL HCO_ERROR(HcoState%Config%Err,MSG, RC, THISLOC=LOC )
+             CALL HCO_ERROR(MSG, RC, THISLOC=LOC )
              RETURN
           ENDIF
        ENDIF ! FIRST
@@ -1156,7 +1156,7 @@ CONTAINS
              IF ( PRESENT(Filled) ) Filled = .TRUE.
           ELSEIF ( FailIfNotFilled ) Then
              MSG = 'Cannot find extension field in HEMCO data list: ' // TRIM(FldName)
-             CALL HCO_ERROR(HcoState%Config%Err,MSG, RC, THISLOC=LOC )
+             CALL HCO_ERROR(MSG, RC, THISLOC=LOC )
              RETURN
           ENDIF
        ENDIF ! FromList
@@ -1165,7 +1165,7 @@ CONTAINS
     ! Make sure array exists
     IF ( FailIfNotFilled .AND. .NOT. ASSOCIATED(ExtDat%Arr%Val) ) THEN
        MSG = 'ExtState array not filled: ' // TRIM(FldName)
-       CALL HCO_ERROR(HcoState%Config%Err,MSG, RC, THISLOC=LOC )
+       CALL HCO_ERROR(MSG, RC, THISLOC=LOC )
     ENDIF
 
     ! Cleanup
@@ -1259,7 +1259,7 @@ CONTAINS
        ! Allocate temporary array
        ALLOCATE(Arr2D(HcoState%NX,HcoState%NY),STAT=AS)
        IF ( AS /= 0 ) THEN
-          CALL HCO_ERROR ( HcoState%Config%Err, "Arr2D allocation error", RC, THISLOC=LOC )
+          CALL HCO_ERROR ( "Arr2D allocation error", RC, THISLOC=LOC )
           RETURN
        ENDIF
 
@@ -1292,7 +1292,7 @@ CONTAINS
                 IF ( FailIfNotFilled ) THEN
                    MSG = 'Cannot fill extension field ' // TRIM(FldName) // &
                          ' because target field is not associated.'
-                   CALL HCO_ERROR(HcoState%Config%Err,MSG, RC, THISLOC=LOC )
+                   CALL HCO_ERROR(MSG, RC, THISLOC=LOC )
                    RETURN
                 ENDIF
 
@@ -1310,7 +1310,7 @@ CONTAINS
                       'Expected dimensions: ', HcoState%NX, HcoState%NY, &
                       '; encountered dimensions: ', NX, NY, '. Error occured ', &
                       'for field ', TRIM(FldName)
-                   CALL HCO_ERROR(HcoState%Config%Err,MSG, RC, THISLOC=LOC )
+                   CALL HCO_ERROR(MSG, RC, THISLOC=LOC )
                    RETURN
                 ENDIF
 
@@ -1333,7 +1333,7 @@ CONTAINS
           ! Field not found and no target defined
           ELSEIF ( FailIfNotFilled ) THEN
              MSG = 'Cannot fill extension field ' // TRIM(FldName)
-             CALL HCO_ERROR(HcoState%Config%Err,MSG, RC, THISLOC=LOC )
+             CALL HCO_ERROR(MSG, RC, THISLOC=LOC )
              RETURN
           ENDIF
        ENDIF ! FIRST
@@ -1349,7 +1349,7 @@ CONTAINS
              IF ( PRESENT(Filled) ) Filled = .TRUE.
           ELSEIF ( FailIfNotFilled ) THEN
              MSG = 'Cannot find extension field in HEMCO data list: ' // TRIM(FldName)
-             CALL HCO_ERROR(HcoState%Config%Err,MSG, RC, THISLOC=LOC )
+             CALL HCO_ERROR(MSG, RC, THISLOC=LOC )
              RETURN
           ENDIF
        ENDIF ! FromList
@@ -1358,7 +1358,7 @@ CONTAINS
     ! Make sure array exists
     IF ( FailIfNotFilled .AND. .NOT. ASSOCIATED(ExtDat%Arr%Val) ) THEN
        MSG = 'ExtState array not filled: ' // TRIM(FldName)
-       CALL HCO_ERROR(HcoState%Config%Err,MSG, RC, THISLOC=LOC )
+       CALL HCO_ERROR(MSG, RC, THISLOC=LOC )
     ENDIF
 
     ! Cleanup
@@ -1452,7 +1452,7 @@ CONTAINS
        ! Allocate temporary array
        ALLOCATE(Arr2D(HcoState%NX,HcoState%NY),STAT=AS)
        IF ( AS /= 0 ) THEN
-          CALL HCO_ERROR ( HcoState%Config%Err, "Arr2D allocation error", RC, THISLOC=LOC )
+          CALL HCO_ERROR ( "Arr2D allocation error", RC, THISLOC=LOC )
           RETURN
        ENDIF
 
@@ -1485,7 +1485,7 @@ CONTAINS
                 IF ( FailIfNotFilled ) THEN
                    MSG = 'Cannot fill extension field ' // TRIM(FldName) // &
                          ' because target field is not associated.'
-                   CALL HCO_ERROR(HcoState%Config%Err,MSG, RC, THISLOC=LOC )
+                   CALL HCO_ERROR(MSG, RC, THISLOC=LOC )
                    RETURN
                 ENDIF
 
@@ -1503,7 +1503,7 @@ CONTAINS
                       'Expected dimensions: ', HcoState%NX, HcoState%NY, &
                       '; encountered dimensions: ', NX, NY, '. Error occured ', &
                       'for field ', TRIM(FldName)
-                   CALL HCO_ERROR(HcoState%Config%Err,MSG, RC, THISLOC=LOC )
+                   CALL HCO_ERROR(MSG, RC, THISLOC=LOC )
                    RETURN
                 ENDIF
 
@@ -1526,7 +1526,7 @@ CONTAINS
           ! Not found in list and no target defined
           ELSEIF ( FailIfNotFilled ) THEN
              MSG = 'Cannot fill extension field ' // TRIM(FldName)
-             CALL HCO_ERROR(HcoState%Config%Err,MSG, RC, THISLOC=LOC )
+             CALL HCO_ERROR(MSG, RC, THISLOC=LOC )
              RETURN
           ENDIF
 
@@ -1545,7 +1545,7 @@ CONTAINS
 
           ELSEIF ( FailIfNotFilled ) THEN
              MSG = 'Cannot find extension field in HEMCO data list: ' // TRIM(FldName)
-             CALL HCO_ERROR(HcoState%Config%Err,MSG, RC, THISLOC=LOC )
+             CALL HCO_ERROR(MSG, RC, THISLOC=LOC )
              RETURN
           ENDIF
 
@@ -1555,7 +1555,7 @@ CONTAINS
     ! Make sure array exists
     IF ( FailIfNotFilled .AND. .NOT. ASSOCIATED(ExtDat%Arr%Val) ) THEN
        MSG = 'ExtState array not filled: ' // TRIM(FldName)
-       CALL HCO_ERROR(HcoState%Config%Err,MSG, RC, THISLOC=LOC )
+       CALL HCO_ERROR(MSG, RC, THISLOC=LOC )
     ENDIF
 
     ! Cleanup
@@ -1659,7 +1659,7 @@ CONTAINS
        ! Allocate temporary array
        ALLOCATE(Arr3D(HcoState%NX,HcoState%NY,NZ_EXPECTED),STAT=AS)
        IF ( AS /= 0 ) THEN
-          CALL HCO_ERROR ( HcoState%Config%Err, "Arr3D allocation error", RC, THISLOC=LOC )
+          CALL HCO_ERROR ( "Arr3D allocation error", RC, THISLOC=LOC )
           RETURN
        ENDIF
 
@@ -1692,7 +1692,7 @@ CONTAINS
                 IF ( FailIfNotFilled ) THEN
                    MSG = 'Cannot fill extension field ' // TRIM(FldName) // &
                          ' because target field is not associated.'
-                   CALL HCO_ERROR(HcoState%Config%Err,MSG, RC, THISLOC=LOC )
+                   CALL HCO_ERROR(MSG, RC, THISLOC=LOC )
                    RETURN
                 ENDIF
 
@@ -1711,7 +1711,7 @@ CONTAINS
                       'Expected dimensions: ', HcoState%NX, HcoState%NY, NZ_EXPECTED, &
                       '; encountered dimensions: ', NX, NY, NZ, '. Error occured ', &
                       'for field ', TRIM(FldName)
-                   CALL HCO_ERROR(HcoState%Config%Err,MSG, RC, THISLOC=LOC )
+                   CALL HCO_ERROR(MSG, RC, THISLOC=LOC )
                    RETURN
                 ENDIF
 
@@ -1736,7 +1736,7 @@ CONTAINS
              ! Target array must be present
              IF ( .NOT. PRESENT(Trgt) ) THEN
                 MSG = 'Cannot fill extension field ' // TRIM(FldName)
-                CALL HCO_ERROR(HcoState%Config%Err,MSG, RC, THISLOC=LOC )
+                CALL HCO_ERROR(MSG, RC, THISLOC=LOC )
                 RETURN
              ENDIF
           ENDIF
@@ -1756,7 +1756,7 @@ CONTAINS
 
           ELSEIF ( FailIfNotFilled ) THEN
              MSG = 'Cannot find extension field in HEMCO data list: ' // TRIM(FldName)
-             CALL HCO_ERROR(HcoState%Config%Err,MSG, RC, THISLOC=LOC )
+             CALL HCO_ERROR(MSG, RC, THISLOC=LOC )
              RETURN
 
           ENDIF
@@ -1766,7 +1766,7 @@ CONTAINS
     ! Make sure array exists
     IF ( FailIfNotFilled .AND. .NOT. ASSOCIATED(ExtDat%Arr%Val) ) THEN
        MSG = 'ExtState array not filled: ' // TRIM(FldName)
-       CALL HCO_ERROR(HcoState%Config%Err,MSG, RC, THISLOC=LOC )
+       CALL HCO_ERROR(MSG, RC, THISLOC=LOC )
     ENDIF
 
     ! Cleanup
@@ -1870,7 +1870,7 @@ CONTAINS
        ! Allocate temporary array
        ALLOCATE(Arr3D(HcoState%NX,HcoState%NY,NZ_EXPECTED),STAT=AS)
        IF ( AS /= 0 ) THEN
-          CALL HCO_ERROR ( HcoState%Config%Err, "Arr3D allocation error", RC, THISLOC=LOC )
+          CALL HCO_ERROR ( "Arr3D allocation error", RC, THISLOC=LOC )
           RETURN
        ENDIF
 
@@ -1903,7 +1903,7 @@ CONTAINS
                 IF ( FailIfNotFilled ) THEN
                    MSG = 'Cannot fill extension field ' // TRIM(FldName) // &
                          ' because target field is not associated.'
-                   CALL HCO_ERROR(HcoState%Config%Err,MSG, RC, THISLOC=LOC )
+                   CALL HCO_ERROR(MSG, RC, THISLOC=LOC )
                    RETURN
                 ENDIF
 
@@ -1922,7 +1922,7 @@ CONTAINS
                       'Expected dimensions: ', HcoState%NX, HcoState%NY, NZ_EXPECTED, &
                       '; encountered dimensions: ', NX, NY, NZ, '. Error occured ', &
                       'for field ', TRIM(FldName)
-                   CALL HCO_ERROR(HcoState%Config%Err,MSG, RC, THISLOC=LOC )
+                   CALL HCO_ERROR(MSG, RC, THISLOC=LOC )
                    RETURN
                 ENDIF
 
@@ -1947,7 +1947,7 @@ CONTAINS
              ! Target array must be present
              IF ( .NOT. PRESENT(Trgt) ) THEN
                 MSG = 'Cannot fill extension field ' // TRIM(FldName)
-                CALL HCO_ERROR(HcoState%Config%Err,MSG, RC, THISLOC=LOC )
+                CALL HCO_ERROR(MSG, RC, THISLOC=LOC )
                 RETURN
              ENDIF
           ENDIF
@@ -1965,7 +1965,7 @@ CONTAINS
              IF ( PRESENT(Filled) ) Filled = .TRUE.
           ELSEIF ( FailIfNotFilled ) THEN
              MSG = 'Cannot find extension field in HEMCO data list: ' // TRIM(FldName)
-             CALL HCO_ERROR(HcoState%Config%Err,MSG, RC, THISLOC=LOC )
+             CALL HCO_ERROR(MSG, RC, THISLOC=LOC )
              RETURN
           ENDIF
        ENDIF !FromList
@@ -1974,7 +1974,7 @@ CONTAINS
     ! Make sure array exists
     IF ( FailIfNotFilled .AND. .NOT. ASSOCIATED(ExtDat%Arr%Val) ) THEN
        MSG = 'ExtState array not filled: ' // TRIM(FldName)
-       CALL HCO_ERROR(HcoState%Config%Err,MSG, RC, THISLOC=LOC )
+       CALL HCO_ERROR(MSG, RC, THISLOC=LOC )
     ENDIF
 
     ! Cleanup

--- a/src/Extensions/hcox_template_mod.F90x
+++ b/src/Extensions/hcox_template_mod.F90x
@@ -126,7 +126,7 @@ CONTAINS
     CALL InstGet ( ExtState%<yourname>, Inst, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        WRITE(MSG,*) 'Cannot find <yourname> instance Nr. ', ExtState%<yourname>
-       CALL HCO_ERROR(HcoState%Config%Err,MSG,RC)
+       CALL HCO_ERROR(MSG,RC)
        RETURN
     ENDIF
 
@@ -203,7 +203,7 @@ CONTAINS
     ! for future reference to the instance. See InstCreate for more details.
     CALL InstCreate ( ExtNr, ExtState%<yourname>, Inst, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, 'Cannot create <yourname> instance', RC )
+       CALL HCO_ERROR ( 'Cannot create <yourname> instance', RC )
        RETURN
     ENDIF
 
@@ -213,7 +213,7 @@ CONTAINS
 
     ! There must be at least one species
     IF ( Inst%nSpc == 0 ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, 'No <yourname> species specified', RC )
+       CALL HCO_ERROR ( 'No <yourname> species specified', RC )
        RETURN
     ENDIF
 

--- a/src/Extensions/hcox_tomas_dustdead_mod.F
+++ b/src/Extensions/hcox_tomas_dustdead_mod.F
@@ -286,7 +286,7 @@
       IF ( RC /= HCO_SUCCESS ) THEN
        WRITE(MSG,*) 'Cannot find TOMAS DEAD instance Nr. ',
      &               ExtState%TOMAS_DustDead
-       CALL HCO_ERROR(HcoState%Config%Err,MSG,RC)
+       CALL HCO_ERROR(MSG,RC)
        RETURN
       ENDIF
 
@@ -479,7 +479,7 @@
      &                        Inst%HcoIDs(N), RC,  ExtNr=Inst%ExtNr )
             IF ( RC /= HCO_SUCCESS ) THEN
                WRITE(MSG,*) 'HCO_EmisAdd error: dust bin ', N
-               CALL HCO_ERROR(HcoState%Config%Err,MSG, RC )
+               CALL HCO_ERROR(MSG, RC )
                RETURN
             ENDIF
 
@@ -533,7 +533,7 @@
             CALL HCO_EmisAdd( HcoState, FLUXN(:,:,N), HcoID,
      &                        RC)
             IF ( RC /= HCO_SUCCESS ) THEN
-               CALL HCO_ERROR( HcoState%Config%Err,
+               CALL HCO_ERROR( 
      &                        'HCO_EmisAdd error: FLUXNDUST', RC )
                RETURN
             ENDIF
@@ -612,7 +612,7 @@
       Inst => NULL()
       CALL InstCreate ( ExtNr, ExtState%TOMAS_DustDead, Inst, RC )
       IF ( RC /= HCO_SUCCESS ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err,
+       CALL HCO_ERROR ( 
      &                 'Cannot create TOMAS DEAD instance', RC )
        RETURN
       ENDIF
@@ -635,7 +635,7 @@
       ! Sanity check
       IF ( nSpc /= NBINS ) THEN
          MSG = 'Number of dust species do not match number of bins!'
-         CALL HCO_ERROR(HcoState%Config%Err,MSG, RC )
+         CALL HCO_ERROR(MSG, RC )
          RETURN
       ENDIF
 
@@ -660,7 +660,7 @@
          MSG = 'Mass flux tuning factor not defined. ' //
      &         'Please explicitly set it by modifying the line ' //
      &         '` --> Mass tuning factor: XX.X` in HEMCO_Config.rc. '
-            CALL HCO_ERROR(HcoState%Config%Err, MSG,
+            CALL HCO_ERROR(MSG,
      &                     RC, THISLOC='HCOX_DustDead_Init')
          RETURN
       ENDIF
@@ -697,7 +697,7 @@
      &           Inst%VAI_DST       ( HcoState%NX, HcoState%NY),
      &           STAT=AS )
       IF ( AS /= 0 ) THEN
-        CALL HCO_ERROR ( HcoState%Config%Err, 'Allocation error', RC )
+        CALL HCO_ERROR ( 'Allocation error', RC )
         RETURN
       ENDIF
       Inst%ERD_FCT_GEO    = 0.0_hp
@@ -712,98 +712,98 @@
 !      ! Allocate arrays
 !      ALLOCATE( Inst%FLX_LW_DWN_SFC( I, J ), STAT=AS )
 !      IF ( AS /= 0 ) THEN
-!        CALL HCO_ERROR ( HcoState%Config%Err, 'FLX_LW_DWN_SFC', RC )
+!        CALL HCO_ERROR ( 'FLX_LW_DWN_SFC', RC )
 !        RETURN
 !      ENDIF
 !      Inst%FLX_LW_DWN_SFC = 0d0
 
 !      ALLOCATE( Inst%FLX_SW_ABS_SFC( I, J ), STAT=AS )
 !      IF ( AS /= 0 ) THEN
-!        CALL HCO_ERROR ( HcoState%Config%Err, 'FLX_SW_ABS_SFC', RC )
+!        CALL HCO_ERROR ( 'FLX_SW_ABS_SFC', RC )
 !        RETURN
 !      ENDIF
 !      Inst%FLX_SW_ABS_SFC = 0d0
 
 !      ALLOCATE( Inst%TPT_GND( I, J ), STAT=AS )
 !      IF ( AS /= 0 ) THEN
-!        CALL HCO_ERROR ( HcoState%Config%Err, 'TPT_GND', RC )
+!        CALL HCO_ERROR ( 'TPT_GND', RC )
 !        RETURN
 !      ENDIF
 !      Inst%TPT_GND = 0d0
 
 !      ALLOCATE( Inst%TPT_SOI( I, J ), STAT=AS )
 !      IF ( AS /= 0 ) THEN
-!        CALL HCO_ERROR ( HcoState%Config%Err, 'TPT_SOI', RC )
+!        CALL HCO_ERROR ( 'TPT_SOI', RC )
 !        RETURN
 !      ENDIF
 !      Inst%TPT_SOI = 0d0
 
 !      ALLOCATE( Inst%VWC_SFC( I, J ), STAT=AS )
 !      IF ( AS /= 0 ) THEN
-!        CALL HCO_ERROR ( HcoState%Config%Err, 'VWC_SFC', RC )
+!        CALL HCO_ERROR ( 'VWC_SFC', RC )
 !        RETURN
 !      ENDIF
 !      Inst%VWC_SFC = 0d0
 
 !      ALLOCATE( Inst%SRC_STR( I, J ), STAT=AS )
 !      IF ( AS /= 0 ) THEN
-!        CALL HCO_ERROR ( HcoState%Config%Err, 'SRC_STR', RC )
+!        CALL HCO_ERROR ( 'SRC_STR', RC )
 !        RETURN
 !      ENDIF
 !      Inst%SRC_STR = 0d0
 
       ALLOCATE( Inst%PLN_TYP( 0:28, 3 ), STAT=AS )
       IF ( AS /= 0 ) THEN
-        CALL HCO_ERROR ( HcoState%Config%Err, 'PLN_TYP', RC )
+        CALL HCO_ERROR ( 'PLN_TYP', RC )
         RETURN
       ENDIF
       Inst%PLN_TYP = 0
 
       ALLOCATE( Inst%PLN_FRC( 0:28, 3 ), STAT=AS )
       IF ( AS /= 0 ) THEN
-        CALL HCO_ERROR ( HcoState%Config%Err, 'PLN_FRC', RC )
+        CALL HCO_ERROR ( 'PLN_FRC', RC )
         RETURN
       ENDIF
       Inst%PLN_FRC = 0d0
 
       ALLOCATE( Inst%TAI( MVT, 12 ), STAT=AS )
       IF ( AS /= 0 ) THEN
-        CALL HCO_ERROR ( HcoState%Config%Err, 'TAI', RC )
+        CALL HCO_ERROR ( 'TAI', RC )
         RETURN
       ENDIF
       Inst%TAI = 0d0
 
       ALLOCATE( Inst%DMT_VWR( NBINS ), STAT=AS )
       IF ( AS /= 0 ) THEN
-        CALL HCO_ERROR ( HcoState%Config%Err, 'DMT_VWR', RC )
+        CALL HCO_ERROR ( 'DMT_VWR', RC )
         RETURN
       ENDIF
       Inst%DMT_VWR = 0d0
 
 !      ALLOCATE( Inst%DNS_AER( NBINS ), STAT=AS )
 !      IF ( AS /= 0 ) THEN
-!        CALL HCO_ERROR ( HcoState%Config%Err, 'DNS_AER', RC )
+!        CALL HCO_ERROR ( 'DNS_AER', RC )
 !        RETURN
 !      ENDIF
 !      Inst%DNS_AER = 0d0
 
       ALLOCATE( Inst%OVR_SRC_SNK_FRC( DST_SRC_NBR, NBINS ), STAT=AS )
       IF ( AS /= 0 ) THEN
-        CALL HCO_ERROR ( HcoState%Config%Err, 'OVR_SRC_SNK_FRC', RC )
+        CALL HCO_ERROR ( 'OVR_SRC_SNK_FRC', RC )
         RETURN
       ENDIF
       Inst%OVR_SRC_SNK_FRC = 0d0
 
       ALLOCATE( Inst%OVR_SRC_SNK_MSS( DST_SRC_NBR, NBINS ), STAT=AS )
       IF ( AS /= 0 ) THEN
-        CALL HCO_ERROR ( HcoState%Config%Err, 'OVR_SRC_SNK_MSS', RC )
+        CALL HCO_ERROR ( 'OVR_SRC_SNK_MSS', RC )
         RETURN
       ENDIF
       Inst%OVR_SRC_SNK_MSS = 0d0
 
 !      ALLOCATE( Inst%OROGRAPHY( I, J ), STAT=AS )
 !      IF ( AS /= 0 ) THEN
-!        CALL HCO_ERROR ( HcoState%Config%Err, 'OROGRAPHY', RC )
+!        CALL HCO_ERROR ( 'OROGRAPHY', RC )
 !        RETURN
 !      ENDIF
 !      Inst%OROGRAPHY = 0
@@ -814,7 +814,7 @@
       ! Bin size min diameter [m]
       ALLOCATE( Inst%DMT_MIN( NBINS ), STAT=AS )
       IF ( AS /= 0 ) THEN
-        CALL HCO_ERROR ( HcoState%Config%Err, 'DMT_MIN', RC )
+        CALL HCO_ERROR ( 'DMT_MIN', RC )
         RETURN
       ENDIF
 
@@ -827,7 +827,7 @@
       ! Bin size max diameter [m]
       ALLOCATE( Inst%DMT_MAX( NBINS ), STAT=AS )
       IF ( AS /= 0 ) THEN
-        CALL HCO_ERROR ( HcoState%Config%Err, 'DMT_MAX', RC )
+        CALL HCO_ERROR ( 'DMT_MAX', RC )
         RETURN
       ENDIF
 
@@ -843,7 +843,7 @@
       ! Bin size min diameter [m]
 !      ALLOCATE( Inst%DMT_MIN( NBINS ), STAT=AS )
 !      IF ( AS /= 0 ) THEN
-!        CALL HCO_ERROR ( HcoState%Config%Err, 'DMT_MIN', RC )
+!        CALL HCO_ERROR ( 'DMT_MIN', RC )
 !        RETURN
 !      ENDIF
 !      Inst%DMT_MIN(1) = 0.2d-6
@@ -854,7 +854,7 @@
       ! Bin size max diameter [m]
 !      ALLOCATE( Inst%DMT_MAX( NBINS ), STAT=AS )
 !      IF ( AS /= 0 ) THEN
-!        CALL HCO_ERROR ( HcoState%Config%Err, 'DMT_MAX', RC )
+!        CALL HCO_ERROR ( 'DMT_MAX', RC )
 !        RETURN
 !      ENDIF
 !      Inst%DMT_MAX(1) = 2.0d-6
@@ -868,7 +868,7 @@
       ! Mass median diameter BSM96 p. 73 Table 2
       ALLOCATE( Inst%DMT_VMA_SRC( DST_SRC_NBR ), STAT=AS )
       IF ( AS /= 0 ) THEN
-        CALL HCO_ERROR ( HcoState%Config%Err, 'DMT_VMA_SRC', RC )
+        CALL HCO_ERROR ( 'DMT_VMA_SRC', RC )
         RETURN
       ENDIF
       Inst%DMT_VMA_SRC(1) = 0.832d-6
@@ -879,7 +879,7 @@
       ! BSM96 p. 73 Table 2
       ALLOCATE( Inst%GSD_ANL_SRC( DST_SRC_NBR ), STAT=AS )
       IF ( AS /= 0 ) THEN
-        CALL HCO_ERROR ( HcoState%Config%Err, 'GSD_ANL_SRC', RC )
+        CALL HCO_ERROR ( 'GSD_ANL_SRC', RC )
         RETURN
       ENDIF
       Inst%GSD_ANL_SRC(1) = 2.10d0
@@ -889,7 +889,7 @@
       ! MSS_FRC_SRC:  Mass fraction BSM96 p. 73 Table 2
       ALLOCATE( Inst%MSS_FRC_SRC( DST_SRC_NBR ), STAT=AS )
       IF ( AS /= 0 ) THEN
-        CALL HCO_ERROR ( HcoState%Config%Err, 'MSS_FRC_SRC', RC )
+        CALL HCO_ERROR ( 'MSS_FRC_SRC', RC )
         RETURN
       ENDIF
       Inst%MSS_FRC_SRC(1) = 0.036d0
@@ -1211,7 +1211,7 @@
          ! Stop occasional haywire model runs
 !         IF ( TPT_MDP(I) > 350.0d0 ) THEN
 !            MSG = 'TPT_MDP(i) > 350.0'
-!            CALL HCO_ERROR(HcoState%Config%Err,MSG, RC, THISLOC='DST_MBL' )
+!            CALL HCO_ERROR(MSG, RC, THISLOC='DST_MBL' )
 !            RETURN
 !         ENDIF
          ! Now simply restrict to 350K, rather than crashing
@@ -2642,7 +2642,7 @@
          ! tdf 10/27/2K3 -- Sanity check
          IF ( RGH_MMN(LON_IDX) <= 0.0 ) THEN
             MSG = 'RGH_MMN <= 0.0'
-            CALL HCO_ERROR(HcoState%Config%Err,MSG,RC,THISLOC='BLM_MBL')
+            CALL HCO_ERROR(MSG,RC,THISLOC='BLM_MBL')
             RETURN
          ENDIF
 
@@ -2656,7 +2656,7 @@
          ! Sanity check
          IF ( WND_FRC_DENOM <= 0.0 ) THEN
             MSG = 'WND_FRC_DENOM <= 0.0'
-            CALL HCO_ERROR(HcoState%Config%Err,MSG,RC,THISLOC='BLM_MBL')
+            CALL HCO_ERROR(MSG,RC,THISLOC='BLM_MBL')
             RETURN
          ENDIF
 
@@ -3097,7 +3097,7 @@
 
               ! Presumably ocean snuck through
               ELSE
-                 CALL HCO_ERROR( HcoState%Config%Err,
+                 CALL HCO_ERROR( 
      &                          'pln_typ_idx == 0', RC,
      &                           THISLOC='RGH_MMN_GET' )
                  RETURN
@@ -3449,7 +3449,7 @@
 
       ! Error check
       IF ( RYN_NBR < 0.03D0 ) THEN
-         CALL HCO_ERROR ( HcoState%Config%Err, 'RYN_NBR < 0.03', RC,
+         CALL HCO_ERROR ( 'RYN_NBR < 0.03', RC,
      &      THISLOC='WND_FRC_THR_SLT_GET' )
          RETURN
 
@@ -3773,7 +3773,7 @@
       ! Error check
       if ( FEFF <= 0.0D0 .OR. FEFF > 1.0D0 ) THEN
          MSG = 'Feff out of range!'
-         CALL HCO_ERROR(HcoState%Config%Err,MSG, RC,
+         CALL HCO_ERROR(MSG, RC,
      &      THISLOC='FRC_THR_NC_DRG_GET' )
          RETURN
       ENDIF
@@ -4078,7 +4078,7 @@
                IF ( MSS_FRC_CACO3_SZ_CRR < 0.0D0  .OR.
      &              MSS_FRC_CACO3_SZ_CRR > 1.0D0 ) THEN
                   MSG = 'mss_frc_CaC_s < 0.0.or.mss_frc_CaC_s > 1.0!'
-                  CALL HCO_ERROR(HcoState%Config%Err,MSG, RC,
+                  CALL HCO_ERROR(MSG, RC,
      &               THISLOC='FLX_MSS_CACO3_MSK' )
                   RETURN
                ENDIF
@@ -4086,7 +4086,7 @@
                IF ( MSS_FRC_CACO3_SLC(LON_IDX) < 0.0D0  .OR.
      &              MSS_FRC_CACO3_SLC(LON_IDX) > 1.0D0 ) THEN
                   MSG = 'mss_frc_CaCO3_s < 0.0.or.mss_frc_CaCO3 > 1.0!'
-                  CALL HCO_ERROR(HcoState%Config%Err,MSG, RC,
+                  CALL HCO_ERROR(MSG, RC,
      &               THISLOC='FLX_MSS_CACO3_MSK' )
                   RETURN
                ENDIF
@@ -4593,7 +4593,7 @@
       ! Error check
       IF ( VAI_MBL_THR <= 0.0d0 ) THEN
          MSG = 'VAI_MBL_THR <= 0.0'
-         CALL HCO_ERROR(HcoState%Config%Err,MSG, RC,
+         CALL HCO_ERROR(MSG, RC,
      &        THISLOC='LND_FRC_MBL_GET' )
          RETURN
       ENDIF
@@ -4720,14 +4720,14 @@
          ! Error check
          IF ( LND_FRC_MBL(lon_idx) > 1.0D0 ) THEN
             MSG = 'LND_FRC_MBL > 1'
-            CALL HCO_ERROR(HcoState%Config%Err,MSG, RC,
+            CALL HCO_ERROR(MSG, RC,
      &         THISLOC='LND_FRC_MBL_GET' )
             RETURN
          ENDIF
 
          IF ( LND_FRC_MBL(LON_IDX) < 0.0D0 )   then
             MSG = 'LND_FRC_MBL < 0'
-            CALL HCO_ERROR(HcoState%Config%Err,MSG, RC,
+            CALL HCO_ERROR(MSG, RC,
      &         THISLOC='LND_FRC_MBL_GET' )
             RETURN
          ENDIF
@@ -4917,7 +4917,7 @@
          ! 19990913: erf() in SGI /usr/lib64/mips4/libftn.so is bogus
          IF ( ABS( 0.8427d0 - ERF(1.0d0) ) / 0.8427d0 > 0.001d0 ) THEN
             MSG = 'ERF error 1 in OVR_SRC_SNK_FRC_GET!'
-            CALL HCO_ERROR(HcoState%Config%Err,MSG, RC,
+            CALL HCO_ERROR(MSG, RC,
      &         THISLOC='OVR_SRC_SNK_FRC_GET' )
             RETURN
          ENDIF
@@ -4925,7 +4925,7 @@
          ! Another ERF check
          IF ( ERF( 0.0D0 ) /= 0.0D0 ) THEN
             MSG = 'ERF error 2 in OVR_SRC_SNK_FRC_GET!'
-            CALL HCO_ERROR(HcoState%Config%Err,MSG, RC,
+            CALL HCO_ERROR(MSG, RC,
      &         THISLOC='OVR_SRC_SNK_FRC_GET' )
             RETURN
          ENDIF

--- a/src/Extensions/hcox_tomas_jeagle_mod.F90
+++ b/src/Extensions/hcox_tomas_jeagle_mod.F90
@@ -155,7 +155,7 @@ CONTAINS
     CALL InstGet ( ExtState%TOMAS_Jeagle, Inst, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        WRITE(MSG,*) 'Cannot find TOMAS_Jeagle instance Nr. ', ExtState%TOMAS_Jeagle
-       CALL HCO_ERROR(HcoState%Config%Err,MSG,RC)
+       CALL HCO_ERROR(MSG,RC)
        RETURN
     ENDIF
 
@@ -270,7 +270,7 @@ CONTAINS
        ! Add mass to the HEMCO data structure (jkodros)
        CALL HCO_EmisAdd( HcoState, Inst%TC2(:,:,:,K), Inst%HcoIDs(K), RC)
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, 'HCO_EmisAdd error: FLUXSALT', RC )
+          CALL HCO_ERROR( 'HCO_EmisAdd error: FLUXSALT', RC )
           RETURN
        ENDIF
 
@@ -291,7 +291,7 @@ CONTAINS
        ! Add number to the HEMCO data structure
        CALL HCO_EmisAdd( HcoState, Inst%TC1(:,:,:,K), HcoID, RC)
        IF ( RC /= HCO_SUCCESS ) THEN
-          CALL HCO_ERROR( HcoState%Config%Err, 'HCO_EmisAdd error: FLUXSALT', RC )
+          CALL HCO_ERROR( 'HCO_EmisAdd error: FLUXSALT', RC )
           RETURN
        ENDIF
     ENDDO
@@ -378,7 +378,7 @@ CONTAINS
     Inst => NULL()
     CALL InstCreate ( ExtNr, ExtState%TOMAS_Jeagle, Inst, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, 'Cannot create TOMAS_Jeagle instance', RC )
+       CALL HCO_ERROR ( 'Cannot create TOMAS_Jeagle instance', RC )
        RETURN
     ENDIF
     ! Also fill Inst%ExtNr
@@ -394,7 +394,7 @@ CONTAINS
     IF ( RC /= HCO_SUCCESS ) RETURN
     IF ( nSpc < HcoState%MicroPhys%nBins ) THEN
        MSG = 'Not enough sea salt emission species set'
-       CALL HCO_ERROR(HcoState%Config%Err,MSG, RC )
+       CALL HCO_ERROR(MSG, RC )
        RETURN
     ENDIF
 
@@ -402,7 +402,7 @@ CONTAINS
     ALLOCATE ( Inst%TOMAS_DBIN( HcoState%MicroPhys%nBins ), STAT=RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        MSG = 'Cannot allocate TOMAS_DBIN array (hcox_tomas_jeagle_mod.F90)'
-       CALL HCO_ERROR(HcoState%Config%Err,MSG, RC )
+       CALL HCO_ERROR(MSG, RC )
        RETURN
     ENDIF
 
@@ -410,7 +410,7 @@ CONTAINS
     ALLOCATE ( Inst%DRFAC( HcoState%MicroPhys%nBins ), STAT=RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        MSG = 'Cannot allocate DRFAC array (hcox_tomas_jeagle_mod.F90)'
-       CALL HCO_ERROR(HcoState%Config%Err,MSG, RC )
+       CALL HCO_ERROR(MSG, RC )
        RETURN
     ENDIF
 
@@ -419,7 +419,7 @@ CONTAINS
                HcoState%NZ, HcoState%MicroPhys%nBins ), STAT=RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        MSG = 'Cannot allocate TC1 array (hcox_tomas_jeagle_mod.F90)'
-       CALL HCO_ERROR(HcoState%Config%Err,MSG, RC )
+       CALL HCO_ERROR(MSG, RC )
        RETURN
     ELSE
     Inst%TC1 = 0d0
@@ -430,7 +430,7 @@ CONTAINS
                HcoState%NZ, HcoState%MicroPhys%nBins ), STAT=RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        MSG = 'Cannot allocate TC2 array (hcox_tomas_jeagle_mod.F90)'
-       CALL HCO_ERROR(HcoState%Config%Err,MSG, RC )
+       CALL HCO_ERROR(MSG, RC )
        RETURN
     ELSE
     Inst%TC2 = 0d0
@@ -538,7 +538,7 @@ CONTAINS
     ELSE
 
        MSG = 'Adjust TOMAS_Jeagle emiss coeff (TOMAS_COEF) for your model res: SRCSALT30: hcox_TOMAS_jeagle_mod.F90'
-       CALL HCO_ERROR(HcoState%Config%Err,MSG, RC )
+       CALL HCO_ERROR(MSG, RC )
 
     ENDIF
 

--- a/src/Extensions/hcox_volcano_mod.F90
+++ b/src/Extensions/hcox_volcano_mod.F90
@@ -194,7 +194,7 @@ CONTAINS
     CALL InstGet( ExtState%Volcano, Inst, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        WRITE( ErrMsg, * ) 'Cannot find Volcano instance Nr. ', ExtState%Volcano
-       CALL HCO_Error( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+       CALL HCO_Error( ErrMsg, RC, ThisLoc )
        RETURN
     ENDIF
 
@@ -205,7 +205,7 @@ CONTAINS
     CALL ReadVolcTable( HcoState, ExtState, Inst, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        ErrMsg = 'Error encountered in "ReadVolcTable"!'
-       CALL HCO_Error( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+       CALL HCO_Error( ErrMsg, RC, ThisLoc )
        RETURN
     ENDIF
 
@@ -220,7 +220,7 @@ CONTAINS
                       SO2degas, SO2erupt, RC    )
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Error encountered in "EmitVolc"!'
-          CALL HCO_Error( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           RETURN
        ENDIF
 
@@ -239,7 +239,7 @@ CONTAINS
                            TRIM(Inst%SpcScalFldNme(N)), RC )
           IF ( RC /= HCO_SUCCESS ) THEN
              ErrMsg = 'Error encountered in "HCOX_Scale (degassing)"!'
-             CALL HCO_Error( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+             CALL HCO_Error( ErrMsg, RC, ThisLoc )
              RETURN
           ENDIF
 
@@ -248,7 +248,7 @@ CONTAINS
                             RC, ExtNr=Inst%ExtNr, Cat=Inst%CatDegas )
           IF ( RC /= HCO_SUCCESS ) THEN
              ErrMsg = 'Error encountered in "HCO_EmisAdd" (degassing)!'
-             CALL HCO_Error( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+             CALL HCO_Error( ErrMsg, RC, ThisLoc )
              RETURN
           ENDIF
 
@@ -264,7 +264,7 @@ CONTAINS
                            TRIM(Inst%SpcScalFldNme(N)), RC )
           IF ( RC /= HCO_SUCCESS ) THEN
              ErrMsg = 'Error encountered in "HCOX_Scale" (eruptive"!'
-             CALL HCO_Error( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+             CALL HCO_Error( ErrMsg, RC, ThisLoc )
              RETURN
           ENDIF
 
@@ -273,7 +273,7 @@ CONTAINS
                             RC, ExtNr=Inst%ExtNr, Cat=Inst%CatErupt )
           IF ( RC /= HCO_SUCCESS ) THEN
              ErrMsg = 'Error encountered in "HCO_EmisAdd" (eruptive)!'
-             CALL HCO_Error( HcoState%Config%Err, ErrMsg, RC, ThisLoc )
+             CALL HCO_Error( ErrMsg, RC, ThisLoc )
              RETURN
           ENDIF
 
@@ -361,7 +361,7 @@ CONTAINS
     Inst => NULL()
     CALL InstCreate( ExtNr, ExtState%Volcano, Inst, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
-       CALL HCO_Error( HcoState%Config%Err,                                  &
+       CALL HCO_Error(                                  &
                       'Cannot create Volcano instance', RC                  )
        RETURN
     ENDIF
@@ -373,7 +373,7 @@ CONTAINS
 
     ! There must be at least one species
     IF ( Inst%nSpc == 0 ) THEN
-       CALL HCO_Error( HcoState%Config%Err,                                  &
+       CALL HCO_Error(                                  &
                       'No Volcano species specified', RC                    )
        RETURN
     ENDIF
@@ -405,7 +405,7 @@ CONTAINS
        MSG = 'Cannot read Volcano table file name. Please provide '       // &
              'the Volcano table as a setting to the Volcano extension. '  // &
              'The name of this setting must be `Volcano_Table`.'
-       CALL HCO_Error( HcoState%Config%Err, MSG, RC )
+       CALL HCO_Error( MSG, RC )
        RETURN
     ENDIF
 
@@ -595,7 +595,7 @@ CONTAINS
        ELSE
           IF ( .not. FileExists ) THEN
              WRITE( MSG, 300 ) TRIM( FileMsg ), TRIM( ThisFile )
-             CALL HCO_ERROR( HcoState%Config%Err, MSG, RC )
+             CALL HCO_ERROR( MSG, RC )
              RETURN
           ENDIF
        ENDIF
@@ -609,7 +609,7 @@ CONTAINS
        OPEN ( LUN, FILE=TRIM(ThisFile), STATUS='OLD', IOSTAT=IOS )
        IF ( IOS /= 0 ) THEN
           MSG = 'Error reading ' // TRIM(ThisFile)
-          CALL HCO_ERROR( HcoState%Config%Err,  MSG, RC, THISLOC=LOC )
+          CALL HCO_ERROR(  MSG, RC, THISLOC=LOC )
           RETURN
        ENDIF
 
@@ -655,7 +655,7 @@ CONTAINS
                    Inst%VolcEnd(nVolc), &
                    STAT=AS )
           IF ( AS /= 0 ) THEN
-             CALL HCO_ERROR ( HcoState%Config%Err, &
+             CALL HCO_ERROR ( &
                               'Volc allocation error', RC, THISLOC=LOC )
              RETURN
           ENDIF
@@ -691,7 +691,7 @@ CONTAINS
                 WRITE(MSG,*) 'N exceeds nVolc: ', N, nVolc, &
                              ' - This error occurred when reading ', &
                              TRIM(ThisFile), '. This line: ', TRIM(ThisLine)
-                CALL HCO_ERROR ( HcoState%Config%Err, MSG, RC, THISLOC = LOC )
+                CALL HCO_ERROR ( MSG, RC, THISLOC = LOC )
                 RETURN
              ENDIF
 
@@ -705,7 +705,7 @@ CONTAINS
                 WRITE(MSG,*) 'Cannot parse line ', TRIM(ThisLine), &
                              'Expected five or seven entries, separated by ', &
                              'space character, instead found ', nCol
-                CALL HCO_ERROR ( HcoState%Config%Err, MSG, RC, THISLOC = LOC )
+                CALL HCO_ERROR ( MSG, RC, THISLOC = LOC )
                 RETURN
              ENDIF
 
@@ -727,7 +727,7 @@ CONTAINS
           IF ( N /= nVolc ) THEN
              WRITE(MSG,*) 'N /= nVolc: ', N, nVolc, &
                           ' - This error occurred when reading ', TRIM(ThisFile)
-             CALL HCO_ERROR ( HcoState%Config%Err, MSG, RC, THISLOC = LOC )
+             CALL HCO_ERROR ( MSG, RC, THISLOC = LOC )
              RETURN
           ENDIF
 
@@ -821,17 +821,17 @@ CONTAINS
 
     ! Make sure all required grid quantities are defined
     IF ( .NOT. ASSOCIATED(HcoState%Grid%AREA_M2%Val) ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, &
+       CALL HCO_ERROR ( &
                        'Grid box areas not defined', RC, THISLOC=LOC )
        RETURN
     ENDIF
     IF ( .NOT. ASSOCIATED(HcoState%Grid%ZSFC%Val) ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, &
+       CALL HCO_ERROR ( &
                        'Surface heights not defined', RC, THISLOC=LOC )
        RETURN
     ENDIF
     IF ( .NOT. ASSOCIATED(HcoState%Grid%BXHEIGHT_M%Val) ) THEN
-       CALL HCO_ERROR ( HcoState%Config%Err, &
+       CALL HCO_ERROR ( &
                        'Grid box heights not defined', RC, THISLOC=LOC )
        RETURN
     ENDIF

--- a/src/Interfaces/MAPL_ESMF/hcoi_esmf_mod.F90
+++ b/src/Interfaces/MAPL_ESMF/hcoi_esmf_mod.F90
@@ -716,7 +716,7 @@ CONTAINS
 
          ! Error check
          IF ( .NOT. Filled ) THEN
-            CALL HCO_ERROR(HcoState%Config%Err,'Cannot fill '//TRIM(FldName),RC)
+            CALL HCO_ERROR('Cannot fill '//TRIM(FldName),RC)
             ASSERT_(.FALSE.)
          ENDIF
 

--- a/src/Interfaces/Shared/hco_interface_common.F90
+++ b/src/Interfaces/Shared/hco_interface_common.F90
@@ -260,14 +260,14 @@ CONTAINS
     ! Trap potential errors
     IF ( RC /= HCO_SUCCESS ) THEN
        ErrMsg = 'Error in getting diagnostics: ' // TRIM(DiagnName)
-       CALL HCO_Error( HcoState%Config%Err, ErrMsg, RC )
+       CALL HCO_Error( ErrMsg, RC )
        RETURN
     ENDIF
 
     IF ( (FLAG /= HCO_SUCCESS) .AND. StopIfNotFound ) THEN
        ErrMsg = 'Cannot get diagnostics for this time stamp: ' //    &
                  TRIM(DiagnName)
-       CALL HCO_Error( HcoState%Config%Err, ErrMsg, RC )
+       CALL HCO_Error( ErrMsg, RC )
        RETURN
     ENDIF
 
@@ -290,7 +290,7 @@ CONTAINS
           ! Error if no 2D or 3D data available
           ELSE
              ErrMsg = 'no data defined: '// TRIM(DiagnName)
-             CALL HCO_Error( HcoState%Config%Err, ErrMsg, RC )
+             CALL HCO_Error( ErrMsg, RC )
              RETURN
           ENDIF
 
@@ -300,14 +300,14 @@ CONTAINS
              Ptr3D => DgnCont%Arr3D%Val
           ELSE
              ErrMsg = 'no 3D data defined: '// TRIM(DiagnName)
-             CALL HCO_Error( HcoState%Config%Err, ErrMsg, RC )
+             CALL HCO_Error( ErrMsg, RC )
              RETURN
           ENDIF
 
        ! Error otherwise
        ELSE
           ErrMsg = 'Please define output data pointer: ' // TRIM(DiagnName)
-          CALL HCO_Error( HcoState%Config%Err, ErrMsg, RC )
+          CALL HCO_Error( ErrMsg, RC )
           RETURN
        ENDIF
     ENDIF

--- a/src/Interfaces/Standalone/hcoi_standalone_mod.F90
+++ b/src/Interfaces/Standalone/hcoi_standalone_mod.F90
@@ -194,7 +194,7 @@ CONTAINS
     CALL HCOI_Sa_Init( am_I_Root, ConfigFile, IsDryRun, RC                  )
     IF ( RC /= HCO_SUCCESS ) THEN
        ErrMsg = 'Error encountered in routine "HCO_Sa_Init"!'
-       CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc                   )
+       CALL HCO_Error( ErrMsg, RC, ThisLoc                   )
        RETURN
     ENDIF
 
@@ -202,7 +202,7 @@ CONTAINS
     CALL HCOI_Sa_Run( RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        ErrMsg = 'Error encountered in routine "HCOI_Sa_Run"!'
-       CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc                   )
+       CALL HCO_Error( ErrMsg, RC, ThisLoc                   )
        RETURN
     ENDIF
 
@@ -279,7 +279,7 @@ CONTAINS
                           0,         RC,        IsDryRun=IsDryRun )
     IF ( RC /= HCO_SUCCESS ) THEN
        ErrMsg = 'Error encountered in routine "Config_Readfile!"'
-       CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+       CALL HCO_Error( ErrMsg, RC, ThisLoc )
        RETURN
     ENDIF
 
@@ -290,7 +290,7 @@ CONTAINS
        CALL HCO_LogFile_Open( HcoConfig%Err, RC=RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Error encountered in routine "HCO_Logfile_Open_Readfile!"'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           RETURN
        ENDIF
     ENDIF
@@ -304,7 +304,7 @@ CONTAINS
     CALL Get_nnMatch( HcoConfig, nnMatch, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        ErrMsg = 'Error encountered in routine "Get_nnMatch"!'
-       CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+       CALL HCO_Error( ErrMsg, RC, ThisLoc )
        CALL Flush( HcoState%Config%Err%Lun )
        RETURN
     ENDIF
@@ -315,7 +315,7 @@ CONTAINS
     CALL HcoState_Init( HcoState, HcoConfig, nnMatch, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        ErrMsg = 'Error encountered in routine "HcoState_Init"!'
-       CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+       CALL HCO_Error( ErrMsg, RC, ThisLoc )
        CALL Flush( HcoState%Config%Err%Lun )
        RETURN
     ENDIF
@@ -325,7 +325,7 @@ CONTAINS
     CALL Set_Grid ( HcoState, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        ErrMsg = 'Error encountered in routine "Set_Grid"!'
-       CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+       CALL HCO_Error( ErrMsg, RC, ThisLoc )
        CALL Flush( HcoState%Config%Err%Lun )
        RETURN
     ENDIF
@@ -335,7 +335,7 @@ CONTAINS
     CALL Register_Species( HcoState, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        ErrMsg = 'Error encountered in routine "Register_Species"!'
-       CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+       CALL HCO_Error( ErrMsg, RC, ThisLoc )
        CALL Flush( HcoState%Config%Err%Lun )
        RETURN
     ENDIF
@@ -345,7 +345,7 @@ CONTAINS
     CALL Read_Time( HcoState, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        ErrMsg = 'Error encountered in routine "Read_Time"!'
-       CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+       CALL HCO_Error( ErrMsg, RC, ThisLoc )
        CALL Flush( HcoState%Config%Err%Lun )
        RETURN
     ENDIF
@@ -366,7 +366,7 @@ CONTAINS
                      OptValBool=Dum, Found=Found, RC=RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        ErrMsg = 'Error encountered in routine "GetExtOpt"!'
-       CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+       CALL HCO_Error( ErrMsg, RC, ThisLoc )
        CALL Flush( HcoState%Config%Err%Lun )
        RETURN
     ENDIF
@@ -390,7 +390,7 @@ CONTAINS
     CALL Init_Dry_Run( IsDryRun, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        ErrMsg = 'Error encountered in routine "Init_Dry_Run"!'
-       CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+       CALL HCO_Error( ErrMsg, RC, ThisLoc )
        CALL Flush( HcoState%Config%Err%Lun )
        RETURN
     ENDIF
@@ -404,7 +404,7 @@ CONTAINS
     CALL HCO_Init( HcoState, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        ErrMsg = 'Error encountered in routine "HCO_Init"!'
-       CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+       CALL HCO_Error( ErrMsg, RC, ThisLoc )
        CALL Flush( HcoState%Config%Err%Lun )
        RETURN
     ENDIF
@@ -417,7 +417,7 @@ CONTAINS
     CALL HCOX_Init( HcoState, ExtState, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        ErrMsg = 'Error encountered in routine "HCOX_Init"!'
-       CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+       CALL HCO_Error( ErrMsg, RC, ThisLoc )
        CALL Flush( HcoState%Config%Err%Lun )
        RETURN
     ENDIF
@@ -442,7 +442,7 @@ CONTAINS
        CALL Define_Diagnostics( HcoState, RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Error encountered in routine "Define_Diagnostics"!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           CALL Flush( HcoState%Config%Err%Lun )
           RETURN
        ENDIF
@@ -547,7 +547,7 @@ CONTAINS
                            cMM=MT, cDD=DY, cH=HR, cM=MN, cS=SC, RC=RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Error encountered in routine "HcoClock_Get"!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           RETURN
        ENDIF
 
@@ -570,7 +570,7 @@ CONTAINS
           CALL HCO_FluxArrReset( HcoState, RC )
           IF ( RC /= HCO_SUCCESS ) THEN
              ErrMsg = 'Error encountered in routine "HCO_FluxArrReset"!'
-             CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+             CALL HCO_Error( ErrMsg, RC, ThisLoc )
              RETURN
           ENDIF
        ENDIF
@@ -606,7 +606,7 @@ CONTAINS
        CALL HCO_Run( HcoState, 1, RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Error encountered in routine "Hco_Run", phase 1!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           RETURN
        ENDIF
 
@@ -616,7 +616,7 @@ CONTAINS
           CALL ExtState_SetFields( HcoState, ExtState, RC )
           IF ( RC /= HCO_SUCCESS ) THEN
              ErrMsg = 'Error encountered in routine "ExtState_SetFields"!'
-             CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+             CALL HCO_Error( ErrMsg, RC, ThisLoc )
              RETURN
           ENDIF
 
@@ -624,7 +624,7 @@ CONTAINS
           CALL ExtState_UpdateFields( HcoState, ExtState, RC )
           IF ( RC /= HCO_SUCCESS ) THEN
              ErrMsg = 'Error encountered in routine "ExtState_Update_Fields"!'
-             CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+             CALL HCO_Error( ErrMsg, RC, ThisLoc )
              RETURN
           ENDIF
 
@@ -632,7 +632,7 @@ CONTAINS
           CALL HCO_Run( HcoState, 2, RC )
           IF ( RC /= HCO_SUCCESS ) THEN
              ErrMsg = 'Error encountered in routine "Hco_Run", phase 2!'
-             CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+             CALL HCO_Error( ErrMsg, RC, ThisLoc )
              RETURN
           ENDIF
        ENDIF
@@ -646,7 +646,7 @@ CONTAINS
        CALL HCOX_Run ( HcoState, ExtState, RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Error encountered in routine "HCOX_Run"!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           RETURN
        ENDIF
 
@@ -657,7 +657,7 @@ CONTAINS
           CALL HcoDiagn_AutoUpdate ( HcoState, RC )
           IF ( RC /= HCO_SUCCESS ) THEN
              ErrMsg = 'Error encountered in routine "HCOX_AutoUpdate"!'
-             CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+             CALL HCO_Error( ErrMsg, RC, ThisLoc )
              RETURN
           ENDIF
        ENDIF
@@ -718,7 +718,7 @@ CONTAINS
     CALL HCO_FINAL( HcoState, .FALSE., RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        ErrMsg = 'Error encountered in routine "HCO_Final"!'
-       CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+       CALL HCO_Error( ErrMsg, RC, ThisLoc )
        RETURN
     ENDIF
 
@@ -727,7 +727,7 @@ CONTAINS
     CALL HCOX_FINAL( HcoState, ExtState, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        ErrMsg = 'Error encountered in routine "HCOX_Final"!'
-       CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+       CALL HCO_Error( ErrMsg, RC, ThisLoc )
        RETURN
     ENDIF
 
@@ -819,7 +819,7 @@ CONTAINS
        MSG = 'Please provide filename with species definitions ' // &
              'in the configuration file settings, e.g. ' // &
              'SpecFile: MySpecies.rc'
-       CALL HCO_Error ( HcoConfig%Err, MSG, RC, THISLOC=LOC )
+       CALL HCO_Error ( MSG, RC, THISLOC=LOC )
        RETURN
     ENDIF
 
@@ -830,7 +830,7 @@ CONTAINS
     OPEN( IU_FILE, FILE=TRIM(SpecFile), STATUS='OLD', IOSTAT=IOS )
     IF ( IOS /= 0 ) THEN
        MSG = 'Error 1 reading ' // TRIM(SpecFile)
-       CALL HCO_Error( HcoConfig%Err, MSG, RC, THISLOC=LOC )
+       CALL HCO_Error( MSG, RC, THISLOC=LOC )
        RETURN
     ENDIF
 
@@ -843,7 +843,7 @@ CONTAINS
           MSG = 'Error encountered in reading SpecFile!.  Please ' // &
                 'doublecheck that all species information has '    // &
                 'been correctly entered.'
-          CALL HCO_Error ( HcoConfig%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_Error ( MSG, RC, THISLOC=LOC )
        ENDIF
        nModelSpec = nModelSpec + 1
     ENDDO
@@ -853,7 +853,7 @@ CONTAINS
        MSG = 'Species file ' // TRIM(SpecFile)      // &
              ' does not seem to have any content. ' // &
              'You must define at least one species.'
-       CALL HCO_Error( HcoConfig%Err, MSG, RC, THISLOC=LOC )
+       CALL HCO_Error( MSG, RC, THISLOC=LOC )
     ENDIF
 
     ! Go back to line one
@@ -891,7 +891,7 @@ CONTAINS
        CALL GetNextLine( IU_FILE, DUM, EOF, RC )
        IF ( RC /= HCO_SUCCESS .OR. EOF ) THEN
           WRITE(MSG,100) N, TRIM(SpecFile)
-          CALL HCO_Error( HcoConfig%Err, MSG, RC, THISLOC=LOC )
+          CALL HCO_Error( MSG, RC, THISLOC=LOC )
           RETURN
        ENDIF
 
@@ -930,7 +930,7 @@ CONTAINS
                           'to have 8 entries (ID, Name, MW, ', &
                           'K0, CR, PKA, e.g.: ', &
                           '1 CO   28.0 0.0 0.0 0.0'
-             CALL HCO_Error ( HcoConfig%Err, MSG, RC, THISLOC=LOC )
+             CALL HCO_Error ( MSG, RC, THISLOC=LOC )
              RETURN
           ENDIF
 
@@ -968,7 +968,7 @@ CONTAINS
        MSG = 'Error encountered in reading SpecFile!.  The species '      // &
              'ID numbers do not start at 1!  Please check SpecFile '      // &
              'for typos.'
-       CALL HCO_Error ( HcoConfig%Err, MSG, RC, THISLOC=LOC )
+       CALL HCO_Error ( MSG, RC, THISLOC=LOC )
        RETURN
     ENDIF
 
@@ -978,7 +978,7 @@ CONTAINS
              'of the last species does not match the number of species '  // &
              'that were read from SpecFile!  Please check SpecFile for '  //&
              'typos.'
-       CALL HCO_Error ( HcoConfig%Err, MSG, RC, THISLOC=LOC )
+       CALL HCO_Error ( MSG, RC, THISLOC=LOC )
        RETURN
     ENDIF
 
@@ -1070,7 +1070,7 @@ CONTAINS
                      OptValChar=MyGridFile,   Found=FOUND, RC=RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        ErrMsg = 'Error encountered in routine "GetExtOpt"!'
-       CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+       CALL HCO_Error( ErrMsg, RC, ThisLoc )
        RETURN
     ENDIF
     IF ( FOUND ) GridFile = MyGridFile
@@ -1089,7 +1089,7 @@ CONTAINS
     OPEN( IU_FILE, FILE=TRIM(GridFile), STATUS='OLD', IOSTAT=IOS )
     IF ( IOS /= 0 ) THEN
        ErrMsg = 'Error 1 reading ' // TRIM(GridFile)
-       CALL HCO_Error( HcoState%Config%Err, ErrMsg, RC, THISLOC=ThisLoc )
+       CALL HCO_Error( ErrMsg, RC, THISLOC=ThisLoc )
        RETURN
     ENDIF
 
@@ -1108,7 +1108,7 @@ CONTAINS
        CALL GetNextLine( IU_FILE, DUM, EOF, RC )
        IF ( RC /= HCO_SUCCESS .OR. EOF ) THEN
           ErrMsg= 'Error 2 reading ' // TRIM(GridFile)
-          CALL HCO_Error( HcoState%Config%Err, ErrMsg, RC, THISLOC=ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, THISLOC=ThisLoc )
           RETURN
        ENDIF
 
@@ -1117,7 +1117,7 @@ CONTAINS
        LOW = NextCharPos ( TRIM(DUM), COL, 1 )
        IF ( LOW < 0 .OR. LOW == LNG ) THEN
           ErrMsg = 'Cannot extract size information from ' // TRIM(DUM)
-          CALL HCO_Error( HcoState%Config%Err, ErrMsg, RC, THISLOC=ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, THISLOC=ThisLoc )
           RETURN
        ENDIF
        LOW = LOW + 1
@@ -1134,24 +1134,24 @@ CONTAINS
     ! Make sure values are in valid range
     IF ( XMIN >= XMAX ) THEN
        WRITE(ErrMsg,*) 'Lower lon must be smaller than upper lon: ', XMIN, XMAX
-       CALL HCO_Error( HcoState%Config%Err, ErrMsg, RC, THISLOC=ThisLoc )
+       CALL HCO_Error( ErrMsg, RC, THISLOC=ThisLoc )
        RETURN
     ENDIF
     IF ( YMIN >= YMAX ) THEN
        WRITE(ErrMsg,*) 'Lower lat must be smaller than upper lat: ', YMIN, YMAX
-       CALL HCO_Error( HcoState%Config%Err, ErrMsg, RC, THISLOC=ThisLoc )
+       CALL HCO_Error( ErrMsg, RC, THISLOC=ThisLoc )
        RETURN
     ENDIF
 
     ! Restrict latitude values to -90.0 and 90.0.
     IF ( YMIN < -90.0_hp ) THEN
        WRITE(ErrMsg,*) 'Lower latitude must be between -90 and 90 degN: ', YMIN
-       CALL HCO_Error( HcoState%Config%Err, ErrMsg, RC, THISLOC=ThisLoc )
+       CALL HCO_Error( ErrMsg, RC, THISLOC=ThisLoc )
        RETURN
     ENDIF
     IF ( YMAX > 90.0_hp ) THEN
        WRITE(ErrMsg,*) 'Upper latitude must be between -90 and 90 degN: ', YMAX
-       CALL HCO_Error( HcoState%Config%Err, ErrMsg, RC, THISLOC=ThisLoc )
+       CALL HCO_Error( ErrMsg, RC, THISLOC=ThisLoc )
        RETURN
     ENDIF
 
@@ -1168,7 +1168,7 @@ CONTAINS
        CALL GetNextLine( IU_FILE, DUM, EOF, RC )
        IF ( RC /= HCO_SUCCESS .OR. EOF ) THEN
           ErrMsg = 'Error 3 reading ' // TRIM(GridFile)
-          CALL HCO_Error( HcoState%Config%Err, ErrMsg, RC, THISLOC=ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, THISLOC=ThisLoc )
           RETURN
        ENDIF
 
@@ -1177,7 +1177,7 @@ CONTAINS
        LOW = NextCharPos ( TRIM(DUM), COL, 1 )
        IF ( LOW < 0 .OR. LOW == LNG ) THEN
           ErrMsg = 'Cannot extract size information from ' // TRIM(DUM)
-          CALL HCO_Error( HcoState%Config%Err, ErrMsg, RC, THISLOC=ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, THISLOC=ThisLoc )
           RETURN
        ENDIF
        LOW = LOW + 1
@@ -1223,7 +1223,7 @@ CONTAINS
        CALL GetNextLine( IU_FILE, DUM, EOF, RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           MSG = 'Error reading grid edges and/or midpoints in ' // TRIM(GridFile)
-          CALL HCO_Error( HcoState%Config%Err, ErrMsg, RC, THISLOC=ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, THISLOC=ThisLoc )
           RETURN
        ENDIF
 
@@ -1285,7 +1285,7 @@ CONTAINS
                 IF ( TRIM(DUM(1:5)) == 'XEDGE' ) THEN
                    IF ( I > NX+1 ) THEN
                       WRITE(ErrMsg,*) 'More than ', NX+1, ' longitude edges found in ', TRIM(DUM)
-                      CALL HCO_Error( HcoState%Config%Err, ErrMsg, RC, THISLOC=ThisLoc )
+                      CALL HCO_Error( ErrMsg, RC, THISLOC=ThisLoc )
                       RETURN
                    ENDIF
                    XEDGE(I,:,1) = DVAL
@@ -1294,7 +1294,7 @@ CONTAINS
                 ELSEIF ( TRIM(DUM(1:5)) == 'YEDGE' ) THEN
                    IF ( I > NY+1 ) THEN
                       WRITE(ErrMsg,*) 'More than ', NY+1, ' latitude edges found in ', TRIM(DUM)
-                      CALL HCO_Error( HcoState%Config%Err, ErrMsg, RC, THISLOC=ThisLoc )
+                      CALL HCO_Error( ErrMsg, RC, THISLOC=ThisLoc )
                       RETURN
                    ENDIF
                    YEDGE(:,I,1) = DVAL
@@ -1303,7 +1303,7 @@ CONTAINS
                 ELSEIF ( TRIM(DUM(1:4)) == 'XMID' ) THEN
                    IF ( I > NX ) THEN
                       WRITE(ErrMsg,*) 'More than ', NX, ' latitude mid-points found in ', TRIM(DUM)
-                      CALL HCO_Error( HcoState%Config%Err, ErrMsg, RC, THISLOC=ThisLoc )
+                      CALL HCO_Error( ErrMsg, RC, THISLOC=ThisLoc )
                       RETURN
                    ENDIF
                    XMID(I,:,1) = DVAL
@@ -1312,7 +1312,7 @@ CONTAINS
                 ELSEIF ( TRIM(DUM(1:4)) == 'YMID' ) THEN
                    IF ( I > NY ) THEN
                       WRITE(ErrMsg,*) 'More than ', NY, ' latitude mid-points found in ', TRIM(DUM)
-                      CALL HCO_Error( HcoState%Config%Err, ErrMsg, RC, THISLOC=ThisLoc )
+                      CALL HCO_Error( ErrMsg, RC, THISLOC=ThisLoc )
                       RETURN
                    ENDIF
                    YMID(:,I,1) = DVAL
@@ -1321,7 +1321,7 @@ CONTAINS
                 ELSEIF ( TRIM(DUM(1:2)) == 'AP' ) THEN
                    IF ( I > (NZ+1) ) THEN
                       WRITE(ErrMsg,*) 'More than ', NZ+1, ' Ap values found in ', TRIM(DUM)
-                      CALL HCO_Error( HcoState%Config%Err, ErrMsg, RC, THISLOC=ThisLoc )
+                      CALL HCO_Error( ErrMsg, RC, THISLOC=ThisLoc )
                       RETURN
                    ENDIF
                    AP(I) = DVAL
@@ -1330,7 +1330,7 @@ CONTAINS
                 ELSEIF ( TRIM(DUM(1:2)) == 'BP' ) THEN
                    IF ( I > (NZ+1) ) THEN
                       WRITE(ErrMsg,*) 'More than ', NZ+1, ' Bp values found in ', TRIM(DUM)
-                      CALL HCO_Error( HcoState%Config%Err, ErrMsg, RC, THISLOC=ThisLoc )
+                      CALL HCO_Error( ErrMsg, RC, THISLOC=ThisLoc )
                       RETURN
                    ENDIF
                    BP(I) = DVAL
@@ -1344,32 +1344,32 @@ CONTAINS
           ! Error check: all values must have been filled
           IF ( TRIM(DUM(1:5)) == 'XEDGE' .AND. I /= NX+1 ) THEN
              WRITE(ErrMsg,*) 'Error reading XEDGES: exactly ', NX+1, ' values must be given: ', TRIM(DUM)
-             CALL HCO_Error( HcoState%Config%Err, ErrMsg, RC, THISLOC=ThisLoc )
+             CALL HCO_Error( ErrMsg, RC, THISLOC=ThisLoc )
              RETURN
           ENDIF
           IF ( TRIM(DUM(1:5)) == 'YEDGE' .AND. I /= NY+1 ) THEN
              WRITE(ErrMsg,*) 'Error reading YEDGES: exactly ', NY+1, ' values must be given: ', TRIM(DUM)
-             CALL HCO_Error( HcoState%Config%Err, ErrMsg, RC, THISLOC=ThisLoc )
+             CALL HCO_Error( ErrMsg, RC, THISLOC=ThisLoc )
              RETURN
           ENDIF
           IF ( TRIM(DUM(1:4)) == 'XMID' .AND. I /= NX ) THEN
              WRITE(ErrMsg,*) 'Error reading XMID: exactly ', NX, ' values must be given: ', TRIM(DUM)
-             CALL HCO_Error( HcoState%Config%Err, ErrMsg, RC, THISLOC=ThisLoc )
+             CALL HCO_Error( ErrMsg, RC, THISLOC=ThisLoc )
              RETURN
           ENDIF
           IF ( TRIM(DUM(1:4)) == 'YMID' .AND. I /= NY ) THEN
              WRITE(ErrMsg,*) 'Error reading YMID: exactly ', NY, ' values must be given: ', TRIM(DUM)
-             CALL HCO_Error( HcoState%Config%Err, ErrMsg, RC, THISLOC=ThisLoc )
+             CALL HCO_Error( ErrMsg, RC, THISLOC=ThisLoc )
              RETURN
           ENDIF
           IF ( TRIM(DUM(1:2)) == 'AP' .AND. I /= NZ+1 ) THEN
              WRITE(ErrMsg,*) 'Error reading AP: exactly ', NZ+1, ' values must be given: ', TRIM(DUM)
-             CALL HCO_Error( HcoState%Config%Err, ErrMsg, RC, THISLOC=ThisLoc )
+             CALL HCO_Error( ErrMsg, RC, THISLOC=ThisLoc )
              RETURN
           ENDIF
           IF ( TRIM(DUM(1:2)) == 'BP' .AND. I /= NZ+1 ) THEN
              WRITE(ErrMsg,*) 'Error reading BP: exactly ', NZ+1, ' values must be given: ', TRIM(DUM)
-             CALL HCO_Error( HcoState%Config%Err, ErrMsg, RC, THISLOC=ThisLoc )
+             CALL HCO_Error( ErrMsg, RC, THISLOC=ThisLoc )
              RETURN
           ENDIF
 
@@ -1380,12 +1380,12 @@ CONTAINS
     IF ( ALL(AP==HCO_MISSVAL) .AND. .NOT. ALL(BP==HCO_MISSVAL) ) THEN
        WRITE(ErrMsg,*) 'At least a few AP values are missing, please provide exactly ', &
                     NZ+1, 'AP and BP values.'
-       CALL HCO_Error( HcoState%Config%Err, ErrMsg, RC, THISLOC=ThisLoc )
+       CALL HCO_Error( ErrMsg, RC, THISLOC=ThisLoc )
        RETURN
     ELSEIF ( .NOT. ALL(AP==HCO_MISSVAL) .AND. ALL(BP==HCO_MISSVAL) ) THEN
        WRITE(ErrMsg,*) 'At least a few BP values are missing, please provide exactly ', &
                     NZ+1, 'AP and BP values.'
-       CALL HCO_Error( HcoState%Config%Err, ErrMsg, RC, THISLOC=ThisLoc )
+       CALL HCO_Error( ErrMsg, RC, THISLOC=ThisLoc )
        RETURN
     ENDIF
 
@@ -1612,7 +1612,7 @@ CONTAINS
                               HcoSpecNames, nHcoSpec, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        ErrMsg = 'Error encountered in routine "Config_GetSpecNames"!'
-       CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+       CALL HCO_Error( ErrMsg, RC, ThisLoc )
        RETURN
     ENDIF
 
@@ -1624,7 +1624,7 @@ CONTAINS
                            ModelSpecPKA,   RC                    )
     IF ( RC /= HCO_SUCCESS ) THEN
        ErrMsg = 'Error encountered in routine "Model_GetSpecies"!'
-       CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+       CALL HCO_Error( ErrMsg, RC, ThisLoc )
        RETURN
     ENDIF
 
@@ -1632,7 +1632,7 @@ CONTAINS
     ALLOCATE(matchIDx(nHcoSpec),STAT=AS)
     IF ( AS/=0 ) THEN
        ErrMsg = 'Allocation error matchIDx'
-       CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+       CALL HCO_Error( ErrMsg, RC, ThisLoc )
        RETURN
     ENDIF
     matchIDx(:) = -1
@@ -1641,7 +1641,7 @@ CONTAINS
                         matchIDx,       nnMatch         )
     IF ( nnMatch == 0 ) THEN
        ErrMsg = 'HCO_CharMatch returned found matching species!'
-       CALL HCO_Error(HcoConfig%Err, ErrMsg, RC, ThisLoc )
+       CALL HCO_Error(ErrMsg, RC, ThisLoc )
        RETURN
     ENDIF
 
@@ -1785,7 +1785,7 @@ CONTAINS
        HcoState%Diagn%HcoDiagnIDDefault, nnDiagn=N, RC=RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        ErrMsg = 'Error encountered in routine "DiagnCollection_Get"!'
-       CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+       CALL HCO_Error( ErrMsg, RC, ThisLoc )
        RETURN
     ENDIF
 
@@ -1828,7 +1828,7 @@ CONTAINS
           ! Trap potential errors
           IF ( RC /= HCO_SUCCESS ) THEN
              ErrMsg = 'Error defining diagnostic: ' // TRIM( DiagnName )
-             CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+             CALL HCO_Error( ErrMsg, RC, ThisLoc )
              RETURN
           ENDIF
        ENDDO !I
@@ -1875,7 +1875,7 @@ CONTAINS
           ! Trap potential errors
           IF ( RC /= HCO_SUCCESS ) THEN
              ErrMsg = 'Error defining diagnostic: ' // TRIM( DiagnName )
-             CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+             CALL HCO_Error( ErrMsg, RC, ThisLoc )
              RETURN
           ENDIF
        ENDDO
@@ -1907,7 +1907,7 @@ CONTAINS
        ! Trap potential errors
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Error defining diagnostic: ' // TRIM( DiagnName )
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           RETURN
        ENDIF
 
@@ -1980,7 +1980,7 @@ CONTAINS
                      OptValChar=MyTimeFile,   Found=FOUND, RC=RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        ErrMsg = 'Error encountered in routine "Hco_Run"!'
-       CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+       CALL HCO_Error( ErrMsg, RC, ThisLoc )
        RETURN
     ENDIF
     IF ( FOUND ) TimeFile = MyTimeFile
@@ -1995,7 +1995,7 @@ CONTAINS
     OPEN( IU_FILE, FILE=TRIM(TimeFile), STATUS='OLD', IOSTAT=IOS )
     IF ( IOS /= 0 ) THEN
        ErrMsg = 'Error 1 reading ' // TRIM(TimeFile)
-       CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+       CALL HCO_Error( ErrMsg, RC, ThisLoc )
        RETURN
     ENDIF
 
@@ -2005,7 +2005,7 @@ CONTAINS
        CALL GetNextLine( IU_FILE, DUM, EOF, RC )
        IF ( RC /= HCO_SUCCESS .OR. EOF ) THEN
           ErrMsg = 'Error reading time in ' // TRIM(TimeFile)
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           RETURN
        ENDIF
 
@@ -2014,7 +2014,7 @@ CONTAINS
        LOW = NextCharPos ( TRIM(DUM), COL, 1 )
        IF ( LOW < 0 .OR. LOW == LNG ) THEN
           ErrMsg = 'Cannot extract index after colon: ' // TRIM(DUM)
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           RETURN
        ENDIF
        LOW = LOW + 1
@@ -2027,7 +2027,7 @@ CONTAINS
        IF ( LNG /= 19 ) THEN
           ErrMsg = 'Provided time stamp is not `YYYY-MM-DD HH:MM:SS`! ' // &
                    TRIM(DUM)
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           RETURN
        ENDIF
 
@@ -2044,7 +2044,7 @@ CONTAINS
     CALL GetNextLine( IU_FILE, DUM, EOF, RC )
     IF ( (RC /= HCO_SUCCESS) .OR. EOF ) THEN
        ErrMsg = 'Cannot read emission time step from ' // TRIM(TimeFile)
-       CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+       CALL HCO_Error( ErrMsg, RC, ThisLoc )
        RETURN
     ENDIF
 
@@ -2053,7 +2053,7 @@ CONTAINS
     LOW = NextCharPos ( TRIM(DUM), COL, 1 )
     IF ( LOW < 0 .OR. LOW == LNG ) THEN
        ErrMsg = 'Cannot extract index after colon: ' // TRIM(DUM)
-       CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+       CALL HCO_Error( ErrMsg, RC, ThisLoc )
        RETURN
     ENDIF
     LOW = LOW + 1
@@ -2158,7 +2158,7 @@ CONTAINS
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Could not find quantity "' // TRIM( Name )            // &
                     '" for the HEMCO standalone simulation!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           CALL HCO_Leave( HcoState%Config%Err, RC )
           RETURN
        ENDIF
@@ -2171,7 +2171,7 @@ CONTAINS
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Could not find quantity "' // TRIM( Name )            // &
                    '" for the HEMCO standalone simulation!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           CALL HCO_Leave( HcoState%Config%Err, RC )
           RETURN
        ENDIF
@@ -2185,7 +2185,7 @@ CONTAINS
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Could not find quantity "' // TRIM( Name )            // &
                    '" for the HEMCO standalone simulation!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           CALL HCO_Leave( HcoState%Config%Err, RC )
           RETURN
        ENDIF
@@ -2199,7 +2199,7 @@ CONTAINS
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Could not find quantity "' // TRIM( Name )            // &
                    '" for the HEMCO standalone simulation!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           CALL HCO_Leave( HcoState%Config%Err, RC )
           RETURN
        ENDIF
@@ -2213,7 +2213,7 @@ CONTAINS
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Could not find quantity "' // TRIM( Name )            // &
                    '" for the HEMCO standalone simulation!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           CALL HCO_Leave( HcoState%Config%Err, RC )
           RETURN
        ENDIF
@@ -2226,7 +2226,7 @@ CONTAINS
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Could not find quantity "' // TRIM( Name )            // &
                    '" for the HEMCO standalone simulation!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           CALL HCO_Leave( HcoState%Config%Err, RC )
           RETURN
        ENDIF
@@ -2240,7 +2240,7 @@ CONTAINS
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Could not find quantity "' // TRIM( Name )            // &
                    '" for the HEMCO standalone simulation!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           CALL HCO_Leave( HcoState%Config%Err, RC )
           RETURN
        ENDIF
@@ -2253,7 +2253,7 @@ CONTAINS
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Could not find quantity "' // TRIM( Name )            // &
                    '" for the HEMCO standalone simulation!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           CALL HCO_Leave( HcoState%Config%Err, RC )
           RETURN
        ENDIF
@@ -2267,7 +2267,7 @@ CONTAINS
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Could not find quantity "' // TRIM( Name )            // &
                    '" for the HEMCO standalone simulation!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           CALL HCO_Leave( HcoState%Config%Err, RC )
           RETURN
        ENDIF
@@ -2280,7 +2280,7 @@ CONTAINS
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Could not find quantity "' // TRIM( Name )            // &
                    '" for the HEMCO standalone simulation!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           CALL HCO_Leave( HcoState%Config%Err, RC )
           RETURN
       ENDIF
@@ -2294,7 +2294,7 @@ CONTAINS
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Could not find quantity "' // TRIM( Name )            // &
                    '" for the HEMCO standalone simulation!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           CALL HCO_Leave( HcoState%Config%Err, RC )
           RETURN
        ENDIF
@@ -2308,7 +2308,7 @@ CONTAINS
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Could not find quantity "' // TRIM( Name )            // &
                    '" for the HEMCO standalone simulation!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg , RC, ThisLoc )
+          CALL HCO_Error( ErrMsg , RC, ThisLoc )
           CALL HCO_Leave( HcoState%Config%Err, RC )
           RETURN
        ENDIF
@@ -2322,7 +2322,7 @@ CONTAINS
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Could not find quantity "' // TRIM( Name )            // &
                    '" for the HEMCO standalone simulation!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           CALL HCO_Leave( HcoState%Config%Err, RC )
           RETURN
        ENDIF
@@ -2336,7 +2336,7 @@ CONTAINS
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Could not find quantity "' // TRIM( Name )            // &
                    '" for the HEMCO standalone simulation!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           CALL HCO_Leave( HcoState%Config%Err, RC )
           RETURN
        ENDIF
@@ -2349,7 +2349,7 @@ CONTAINS
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Could not find quantity "' // TRIM( Name )            // &
                    '" for the HEMCO standalone simulation!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           CALL HCO_Leave( HcoState%Config%Err, RC )
           RETURN
        ENDIF
@@ -2362,7 +2362,7 @@ CONTAINS
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Could not find quantity "' // TRIM( Name )            // &
                    '" for the HEMCO standalone simulation!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           CALL HCO_Leave( HcoState%Config%Err, RC )
           RETURN
        ENDIF
@@ -2376,7 +2376,7 @@ CONTAINS
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Could not find quantity "' // TRIM( Name )            // &
                    '" for the HEMCO standalone simulation!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           CALL HCO_Leave( HcoState%Config%Err, RC )
           RETURN
        ENDIF
@@ -2390,7 +2390,7 @@ CONTAINS
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Could not find quantity "' // TRIM( Name )            // &
                    '" for the HEMCO standalone simulation!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           CALL HCO_Leave( HcoState%Config%Err, RC )
           RETURN
        ENDIF
@@ -2404,7 +2404,7 @@ CONTAINS
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Could not find quantity "' // TRIM( Name )            // &
                    '" for the HEMCO standalone simulation!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           CALL HCO_Leave( HcoState%Config%Err, RC )
           RETURN
        ENDIF
@@ -2418,7 +2418,7 @@ CONTAINS
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Could not find quantity "' // TRIM( Name )            // &
                    '" for the HEMCO standalone simulation!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           CALL HCO_Leave( HcoState%Config%Err, RC )
           RETURN
        ENDIF
@@ -2432,7 +2432,7 @@ CONTAINS
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Could not find quantity "' // TRIM( Name )            // &
                    '" for the HEMCO standalone simulation!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           CALL HCO_Leave( HcoState%Config%Err, RC )
           RETURN
        ENDIF
@@ -2445,7 +2445,7 @@ CONTAINS
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Could not find quantity "' // TRIM( Name )            // &
                    '" for the HEMCO standalone simulation!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           CALL HCO_Leave( HcoState%Config%Err, RC )
           RETURN
        ENDIF
@@ -2458,7 +2458,7 @@ CONTAINS
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Could not find quantity "' // TRIM( Name )            // &
                    '" for the HEMCO standalone simulation!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           CALL HCO_Leave( HcoState%Config%Err, RC )
           RETURN
        ENDIF
@@ -2471,7 +2471,7 @@ CONTAINS
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Could not find quantity "' // TRIM( Name )            // &
                    '" for the HEMCO standalone simulation!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           CALL HCO_Leave( HcoState%Config%Err, RC )
           RETURN
        ENDIF
@@ -2484,7 +2484,7 @@ CONTAINS
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Could not find quantity "' // TRIM( Name )            // &
                    '" for the HEMCO standalone simulation!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           CALL HCO_Leave( HcoState%Config%Err, RC )
           RETURN
        ENDIF
@@ -2498,7 +2498,7 @@ CONTAINS
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Could not find quantity "' // TRIM( Name )            // &
                    '" for the HEMCO standalone simulation!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           CALL HCO_Leave( HcoState%Config%Err, RC )
           RETURN
        ENDIF
@@ -2512,7 +2512,7 @@ CONTAINS
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Could not find quantity "' // TRIM( Name )            // &
                    '" for the HEMCO standalone simulation!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           CALL HCO_Leave( HcoState%Config%Err, RC )
           RETURN
        ENDIF
@@ -2526,7 +2526,7 @@ CONTAINS
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Could not find quantity "' // TRIM( Name )            // &
                    '" for the HEMCO standalone simulation!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           CALL HCO_Leave( HcoState%Config%Err, RC )
           RETURN
        ENDIF
@@ -2540,7 +2540,7 @@ CONTAINS
       IF ( RC == HCO_SUCCESS ) THEN
          ErrMsg = 'Could not find quantity "' // TRIM( Name )             // &
                   '" for the HEMCO standalone simulation!'
-         CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+         CALL HCO_Error( ErrMsg, RC, ThisLoc )
          CALL HCO_Leave( HcoState%Config%Err, RC )
          RETURN
       ENDIF
@@ -2553,7 +2553,7 @@ CONTAINS
       IF ( RC == HCO_SUCCESS ) THEN
          ErrMsg = 'Could not find quantity "' // TRIM( Name )             // &
                   '" for the HEMCO standalone simulation!'
-         CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+         CALL HCO_Error( ErrMsg, RC, ThisLoc )
          CALL HCO_Leave( HcoState%Config%Err, RC )
          RETURN
       ENDIF
@@ -2575,7 +2575,7 @@ CONTAINS
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Could not find quantity "' // TRIM( Name )            // &
                    '" for the HEMCO standalone simulation!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           CALL HCO_Leave( HcoState%Config%Err, RC )
           RETURN
        ENDIF
@@ -2589,7 +2589,7 @@ CONTAINS
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Could not find quantity "' // TRIM( Name )            // &
                    '" for the HEMCO standalone simulation!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           CALL HCO_Leave( HcoState%Config%Err, RC )
           RETURN
        ENDIF
@@ -2603,7 +2603,7 @@ CONTAINS
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Could not find quantity "' // TRIM( Name )            // &
                    '" for the HEMCO standalone simulation!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           CALL HCO_Leave( HcoState%Config%Err, RC )
           RETURN
        ENDIF
@@ -2617,7 +2617,7 @@ CONTAINS
        IF ( RC == HCO_SUCCESS ) THEN
           ErrMsg = 'Could not find quantity "' // TRIM( Name )            // &
                    '" for the HEMCO standalone simulation!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           CALL HCO_Leave( HcoState%Config%Err, RC )
           RETURN
        ENDIF
@@ -2630,7 +2630,7 @@ CONTAINS
        IF ( RC == HCO_SUCCESS ) THEN
           ErrMsg = 'Could not find quantity "' // TRIM( Name )            // &
                    '" for the HEMCO standalone simulation!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           CALL HCO_Leave( HcoState%Config%Err, RC )
           RETURN
        ENDIF
@@ -2643,7 +2643,7 @@ CONTAINS
        IF ( RC == HCO_SUCCESS ) THEN
           ErrMsg = 'Could not find quantity "' // TRIM( Name )            // &
                    '" for the HEMCO standalone simulation!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           CALL HCO_Leave( HcoState%Config%Err, RC )
           RETURN
        ENDIF
@@ -2657,7 +2657,7 @@ CONTAINS
        IF ( RC == HCO_SUCCESS ) THEN
           ErrMsg = 'Could not find quantity "' // TRIM( Name )            // &
                 '" for the HEMCO standalone simulation!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           CALL HCO_Leave( HcoState%Config%Err, RC )
           RETURN
        ENDIF
@@ -2670,7 +2670,7 @@ CONTAINS
        IF ( RC == HCO_SUCCESS ) THEN
           ErrMsg = 'Could not find quantity "' // TRIM( Name )            // &
                 '" for the HEMCO standalone simulation!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           CALL HCO_Leave( HcoState%Config%Err, RC )
           RETURN
        ENDIF
@@ -2683,7 +2683,7 @@ CONTAINS
        IF ( RC == HCO_SUCCESS ) THEN
           ErrMsg = 'Could not find quantity "' // TRIM( Name )            // &
                    '" for the HEMCO standalone simulation!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           CALL HCO_Leave( HcoState%Config%Err, RC )
           RETURN
        ENDIF
@@ -2696,7 +2696,7 @@ CONTAINS
        IF ( RC == HCO_SUCCESS ) THEN
           ErrMsg = 'Could not find quantity "' // TRIM( Name )            // &
                    '" for the HEMCO standalone simulation!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           CALL HCO_Leave( HcoState%Config%Err, RC )
           RETURN
        ENDIF
@@ -2710,7 +2710,7 @@ CONTAINS
        IF ( RC == HCO_SUCCESS ) THEN
           ErrMsg = 'Could not find quantity "' // TRIM( Name )            // &
                 '" for the HEMCO standalone simulation!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           CALL HCO_Leave( HcoState%Config%Err, RC )
           RETURN
        ENDIF
@@ -2723,7 +2723,7 @@ CONTAINS
        IF ( RC == HCO_SUCCESS ) THEN
           ErrMsg = 'Could not find quantity "' // TRIM( Name )            // &
                    '" for the HEMCO standalone simulation!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           CALL HCO_Leave( HcoState%Config%Err, RC )
           RETURN
        ENDIF
@@ -2737,7 +2737,7 @@ CONTAINS
        IF ( RC == HCO_SUCCESS ) THEN
           ErrMsg = 'Could not find quantity "' // TRIM( Name )            // &
                    '" for the HEMCO standalone simulation!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           CALL HCO_Leave( HcoState%Config%Err, RC )
           RETURN
        ENDIF
@@ -2775,7 +2775,7 @@ CONTAINS
           CALL HCO_ArrAssert( ExtState%SUNCOS%Arr, HcoState%NX, HcoState%NY, RC )
           IF ( RC /= HCO_SUCCESS ) THEN
              ErrMsg = 'SUNCOS array is not the expected dimensions!'
-             CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+             CALL HCO_Error( ErrMsg, RC, ThisLoc )
              CALL HCO_Leave( HcoState%Config%Err, RC )
              RETURN
           ENDIF
@@ -2784,7 +2784,7 @@ CONTAINS
        CALL HCO_GetSUNCOS( HcoState, ExtState%SUNCOS%Arr%Val, 0, RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Error encountered in routine "HCO_GetSuncos"!'
-          CALL HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+          CALL HCO_Error( ErrMsg, RC, ThisLoc )
           CALL HCO_Leave( HcoState%Config%Err, RC )
           RETURN
        ENDIF


### PR DESCRIPTION
This update send all HCO_ERROR messages to stderr and writes from all threads. It also prints core number in HEMCO error messages if using MAPL/ESMF. This update is a quick fix for inconsistency writing HEMCO error messages to log which were impact trouble-shooting in GEOS. There were several issues that are now addressed:
    
    1. HCO_ERROR was sometimes called to pass error messages to HEMCO.log and
       other times called to pass error messages to stdout. This leads to
       confusion about where to look for error messages.
    
    2. If the error message was passed to HEMCO.log then it was only written
       by the root thread. Because HCO_ERROR is called right before early
       program termination the root thread would sometimes not get to write
       the message before early exit. This was especially true for MPI
       applications with many cores.
    
    3. Passing the error message to HEMCO.log requires that the HEMCO.log is
       open to write. But the HEMCO.log file is only opened by the root
       thread and other processes can get ahead of that if using many cores.

The subroutine that HCO_ERROR invokes if passing messages to HEMCO.log is still present in the code but will be reassessed in the future. For now, writing messages when there is early termination to std out and by all threads is the most straightforward and consistent way to alert users to the source of the error.
   