### PR TITLE
Added support for driving GEOS-Chem with native GEOS meteorological files.

### DIFF
--- a/src/Core/hco_geotools_mod.F90
+++ b/src/Core/hco_geotools_mod.F90
@@ -70,18 +70,18 @@ CONTAINS
 ! !IROUTINE: HCO_LandType_Sp
 !
 ! !DESCRIPTION: Function HCO\_LANDTYPE returns the land type based upon
-!  the land water index (0=water,1=land,2=ice) and the surface albedo.
+!  the land water index (0=water,1=land,2=ice) and the fraction of land ice.
 !  Inputs are in single precision.
 !\\
 !\\
 ! !INTERFACE:
 !
-  FUNCTION HCO_LandType_Sp( WLI, Albedo ) Result ( LandType )
+  FUNCTION HCO_LandType_Sp( WLI, FRLANDIC ) Result ( LandType )
 !
 ! !INPUT PARAMETERS:
 !
     REAL(sp), INTENT(IN) :: WLI       ! Land type: 0=water,1=land,2=ice
-    REAL(sp), INTENT(IN) :: Albedo    ! Surface albedo
+    REAL(sp), INTENT(IN) :: FRLANDIC  ! Fraction of grid-box covered in land ice
 !
 ! !RETURN VALUE
 !
@@ -98,25 +98,24 @@ CONTAINS
 !BOC
 !
 ! !DEFINED PARAMETERS:
-!
-    ! Set threshold for albedo over ice. All surfaces w/ an albedo above
-    ! this value will be classified as ice.
-    REAL(sp), PARAMETER :: albd_ice = 0.695_sp
+!   
+    ! Threshold at which a grid-box is considered ice
+    REAL(sp), PARAMETER :: frac_classify_land_ice_as_ice = 0.5_sp
 
     !--------------------------
     ! HCO_LANDTYPE begins here
     !--------------------------
 
     ! Water:
-    IF ( NINT(WLI) == 0 .AND. Albedo < albd_ice ) THEN
+    IF ( NINT(WLI) == 0 .AND. FRLANDIC < frac_classify_land_ice_as_ice ) THEN
        LandType = 0
 
     ! Land:
-    ELSEIF ( NINT(WLI) == 1 .AND. Albedo < albd_ice ) THEN
+    ELSEIF ( NINT(WLI) == 1 .AND. FRLANDIC < frac_classify_land_ice_as_ice ) THEN
        LandType = 1
 
     ! Ice:
-    ELSEIF ( NINT(WLI) == 2 .OR. Albedo >= albd_ice ) THEN
+    ELSEIF ( NINT(WLI) == 2 .OR. FRLANDIC >= frac_classify_land_ice_as_ice ) THEN
        LandType = 2
     ENDIF
 
@@ -130,18 +129,18 @@ CONTAINS
 ! !IROUTINE: HCO_LandType_Dp
 !
 ! !DESCRIPTION: Function HCO\_LandType\_Dp returns the land type based upon
-! the land water index (0=water,1=land,2=ice) and the surface albedo.
+! the land water index (0=water,1=land,2=ice) and the fraction of land ice.
 ! Inputs are in double precision.
 !\\
 !\\
 ! !INTERFACE:
 !
-  FUNCTION HCO_LandType_Dp( WLI, Albedo ) Result ( LandType )
+  FUNCTION HCO_LandType_Dp( WLI, FRLANDIC ) Result ( LandType )
 !
 ! !INPUT PARAMETERS:
 !
     REAL(dp), INTENT(IN) :: WLI       ! Land type: 0=water,1=land,2=ice
-    REAL(dp), INTENT(IN) :: Albedo    ! Surface albedo
+    REAL(dp), INTENT(IN) :: FRLANDIC    ! Surface albedo
 !
 ! !RETURN VALUE:
 !
@@ -159,9 +158,8 @@ CONTAINS
 !
 ! !DEFINED PARAMETERS::
 !
-    ! Set threshold for albedo over ice. All surfaces w/ an albedo above
-    ! this value will be classified as ice.
-    REAL(dp), PARAMETER :: albd_ice = 0.695_dp
+    ! Threshold at which a grid-box is considered ice
+    REAL(dp), PARAMETER :: frac_classify_land_ice_as_ice = 0.5_dp
 
     !--------------------------
     ! HCO_LANDTYPE begins here
@@ -172,7 +170,7 @@ CONTAINS
 
     ! Water:
 #if !defined( HEMCO_CESM )
-    IF ( NINT(WLI) == 0 .AND. Albedo < albd_ice ) THEN
+    IF ( NINT(WLI) == 0 .AND. FRLANDIC < frac_classify_land_ice_as_ice ) THEN
 #else
     IF ( NINT(WLI) == 0 ) THEN
 #endif
@@ -181,14 +179,14 @@ CONTAINS
     ! Land:
 
 #if !defined( HEMCO_CESM )
-    ELSEIF ( NINT(WLI) == 1 .AND. Albedo < albd_ice ) THEN
+    ELSEIF ( NINT(WLI) == 1 .AND. FRLANDIC < frac_classify_land_ice_as_ice ) THEN
 #else
     ELSEIF ( NINT(WLI) == 1 ) THEN
 #endif
        LandType = 1
 
     ! Ice:
-    ELSEIF ( NINT(WLI) == 2 .OR. Albedo >= albd_ice ) THEN
+    ELSEIF ( NINT(WLI) == 2 .OR. FRLANDIC >= frac_classify_land_ice_as_ice ) THEN
        LandType = 2
     ENDIF
 

--- a/src/Extensions/hcox_custom_mod.F90
+++ b/src/Extensions/hcox_custom_mod.F90
@@ -151,7 +151,7 @@ CONTAINS
 
        ! Get the land type for grid box (I,J)
        LANDTYPE = HCO_LANDTYPE( ExtState%WLI%Arr%Val(I,J),  &
-                                ExtState%ALBD%Arr%Val(I,J) )
+                                ExtState%FRLANDIC%Arr%Val(I,J) )
 
        ! Check surface type
        ! Ocean:
@@ -310,7 +310,7 @@ CONTAINS
     ! Activate met fields required by this extension
     ExtState%U10M%DoUse = .TRUE.
     ExtState%V10M%DoUse = .TRUE.
-    ExtState%ALBD%DoUse = .TRUE.
+    ExtState%FRLANDIC%DoUse    = .TRUE.
     ExtState%WLI%DoUse  = .TRUE.
 
     ! Activate this extension

--- a/src/Extensions/hcox_dustdead_mod.F
+++ b/src/Extensions/hcox_dustdead_mod.F
@@ -895,7 +895,7 @@
       ExtState%SNOWHGT%DoUse = .TRUE.
       ExtState%USTAR%DoUse   = .TRUE.
       ExtState%Z0%DoUse      = .TRUE.
-      ExtState%ALBD%DoUse    = .TRUE.
+      ExtState%FRLANDIC%DoUse    = .TRUE.
       ExtState%WLI%DoUse     = .TRUE.
 
       ! Leave w/ success
@@ -2096,7 +2096,7 @@
 
          ! Set orography to land type
          OROGRAPHY (I,J) = HCO_LANDTYPE( ExtState%WLI%Arr%Val(I,J),
-     &                                   ExtState%ALBD%Arr%Val(I,J) )
+     &                             ExtState%FRLANDIC%Arr%Val(I,J) )
 
       ENDDO
       ENDDO

--- a/src/Extensions/hcox_gc_POPs_mod.F90
+++ b/src/Extensions/hcox_gc_POPs_mod.F90
@@ -1517,9 +1517,9 @@ CONTAINS
 !------------------------------------------------------------------------------
 !BOC
 
-      ! LWI=1 and ALBEDO less than 69.5% is a LAND box
+      ! LWI=1 and FRLANDIC less than 50% is a LAND box
       LAND = ( NINT( ExtState%WLI%Arr%Val(I,J) ) == 1   .and. &
-                     ExtState%ALBD%Arr%Val(I,J)  <  0.695e+0_hp )
+                     ExtState%FRLANDIC%Arr%Val(I,J)  <  0.5e+0_hp )
 
       END FUNCTION IS_LAND
 !EOC
@@ -1555,9 +1555,9 @@ CONTAINS
 !------------------------------------------------------------------------------
 !BOC
 
-      ! LWI=2 or ALBEDO > 69.5% is ice
+      ! LWI=2 or FRLANDIC > 50%
       ICE = ( NINT( ExtState%WLI%Arr%Val(I,J) ) == 2       .or. &
-                    ExtState%ALBD%Arr%Val(I,J)  >= 0.695e+0_hp )
+                    ExtState%FRLANDIC%Arr%Val(I,J)  >= 0.5+0_hp )
 
       END FUNCTION IS_ICE
 !EOC
@@ -1694,7 +1694,7 @@ CONTAINS
 
     ! Activate met fields required by this extension
     ExtState%POPG%DoUse        = .TRUE.
-    ExtState%ALBD%DoUse        = .TRUE.
+    ExtState%FRLANDIC%DoUse    = .TRUE.
     ExtState%AIRVOL%DoUse      = .TRUE.
     ExtState%AIRDEN%DoUse      = .TRUE.
     ExtState%FRAC_OF_PBL%DoUse = .TRUE.

--- a/src/Extensions/hcox_iodine_mod.F90
+++ b/src/Extensions/hcox_iodine_mod.F90
@@ -170,7 +170,7 @@ CONTAINS
        ! further check needed for ocean, but not available
        ! ( as parameterisation of iodide based on ocean data)
        IF ( HCO_LANDTYPE( ExtState%WLI%Arr%Val(I,J), &
-                          ExtState%ALBD%Arr%Val(I,J) ) /= 0 ) CYCLE
+                          ExtState%FRLANDIC%Arr%Val(I,J) ) /= 0 ) CYCLE
 
        ! Grid box surface area on simulation grid [m2]
        A_M2 = HcoState%Grid%AREA_M2%Val( I, J )
@@ -447,7 +447,7 @@ CONTAINS
 
     ! Activate met fields used by this module
     ExtState%WLI%DoUse   = .TRUE.
-    ExtState%ALBD%DoUse  = .TRUE.
+    ExtState%FRLANDIC%DoUse    = .TRUE.
     ExtState%TSKIN%DoUse = .TRUE.
     ExtState%U10M%DoUse  = .TRUE.
     ExtState%V10M%DoUse  = .TRUE.

--- a/src/Extensions/hcox_lightnox_mod.F90
+++ b/src/Extensions/hcox_lightnox_mod.F90
@@ -342,7 +342,7 @@ CONTAINS
        ! Get surface type. Note that these types are different than
        ! the types used elsewhere: 0 = land, 1=water, 2=ice!
        LNDTYPE = HCO_LANDTYPE( ExtState%WLI%Arr%Val(I,J),  &
-                               ExtState%ALBD%Arr%Val(I,J) )
+                               ExtState%FRLANDIC%Arr%Val(I,J) )
 
        ! Adjusted SFCTYPE variable for this module:
        IF ( LNDTYPE == 2 ) THEN
@@ -1065,7 +1065,7 @@ CONTAINS
     ExtState%TROPP%DoUse      = .TRUE.
     ExtState%CNV_MFC%DoUse    = .TRUE.
     ExtState%CNV_FRC%DoUse    = .TRUE.
-    ExtState%ALBD%DoUse       = .TRUE.
+    ExtState%FRLANDIC%DoUse    = .TRUE.
     ExtState%WLI%DoUse        = .TRUE.
     ExtState%LFR%DoUse        = .TRUE.
     ExtState%FLASH_DENS%DoUse = .TRUE.

--- a/src/Extensions/hcox_seaflux_mod.F90
+++ b/src/Extensions/hcox_seaflux_mod.F90
@@ -296,6 +296,7 @@ CONTAINS
 !
 ! !USES:
 !
+    USE ieee_arithmetic,    ONLY : ieee_is_finite
     USE Ocean_ToolBox_Mod,  ONLY : CALC_KG
     USE Hco_Henry_Mod,      ONLY : CALC_KH, CALC_HEFF
     USE HCO_CALC_MOD,       ONLY : HCO_CheckDepv
@@ -411,16 +412,9 @@ CONTAINS
        ! Make sure we have no negative seawater concentrations
        IF ( SeaConc(I,J) < 0.0_hp ) SeaConc(I,J) = 0.0_hp
 
-       ! Kludge: Do not check albedo for HEMCO within CESM because CESM
-       ! enforces nighttime "albedo" value to be 1.0 (hplin, 5/7/21)
-#if !defined( HEMCO_CESM )
-       ! Assume no air-sea exchange over snow/ice (ALBEDO > 0.4)
-       IF ( ExtState%ALBD%Arr%Val(I,J) > 0.4_hp ) CYCLE
-#endif
-
        ! Do only over the ocean:
        IF ( HCO_LANDTYPE( ExtState%WLI%Arr%Val(I,J), &
-                          ExtState%ALBD%Arr%Val(I,J) ) == 0 ) THEN
+                          ExtState%FRLANDIC%Arr%Val(I,J) ) == 0 ) THEN
 
           !-----------------------------------------------------------
           ! Get grid box and species specific quantities
@@ -851,7 +845,7 @@ CONTAINS
     ExtState%U10M%DoUse        = .TRUE.
     ExtState%V10M%DoUse        = .TRUE.
     ExtState%TSKIN%DoUse       = .TRUE.
-    ExtState%ALBD%DoUse        = .TRUE.
+    ExtState%FRLANDIC%DoUse    = .TRUE.
     ExtState%WLI%DoUse         = .TRUE.
     IF ( HcoState%Options%PBL_DRYDEP ) THEN
        ExtState%FRAC_OF_PBL%DoUse = .TRUE.

--- a/src/Extensions/hcox_seasalt_mod.F90
+++ b/src/Extensions/hcox_seasalt_mod.F90
@@ -249,7 +249,7 @@ CONTAINS
 
        ! Advance to next grid box if it's not over water
        IF ( HCO_LANDTYPE( ExtState%WLI%Arr%Val(I,J), &
-                          ExtState%ALBD%Arr%Val(I,J) ) /= 0 ) CYCLE
+                          ExtState%FRLANDIC%Arr%Val(I,J) ) /= 0 ) CYCLE
 
        ! Wind speed at 10 m altitude [m/s]
        W10M = SQRT( ExtState%U10M%Arr%Val(I,J)**2 &
@@ -980,7 +980,7 @@ CONTAINS
 
     ! Activate met fields used by this module
     ExtState%WLI%DoUse   = .TRUE.
-    ExtState%ALBD%DoUse  = .TRUE.
+    ExtState%FRLANDIC%DoUse    = .TRUE.
     ExtState%TSKIN%DoUse = .TRUE.
     ExtState%U10M%DoUse  = .TRUE.
     ExtState%V10M%DoUse  = .TRUE.

--- a/src/Extensions/hcox_soilnox_mod.F90
+++ b/src/Extensions/hcox_soilnox_mod.F90
@@ -812,7 +812,9 @@ CONTAINS
     ExtState%U10M%DoUse      = .TRUE.
     ExtState%V10M%DoUse      = .TRUE.
     ExtState%LAI%DoUse       = .TRUE.
-    ExtState%ALBD%DoUse      = .TRUE.
+    ExtState%FRLANDIC%DoUse    = .TRUE.
+    ExtState%WLI%DoUse         = .TRUE.
+    ExtState%SNODP%DoUse    = .TRUE.
     ExtState%RADSWG%DoUse    = .TRUE.
     ExtState%CLDFRC%DoUse    = .TRUE.
 
@@ -1078,6 +1080,7 @@ CONTAINS
 ! !USES:
 !
     USE Drydep_Toolbox_Mod, ONLY : BIOFIT
+    USE HCO_GeoTools_Mod, ONLY : HCO_LANDTYPE
 !
 ! !ARGUMENTS:
 !
@@ -1180,7 +1183,8 @@ CONTAINS
           KK = K
 
           ! If the surface is snow or ice, then set K=3
-          IF ( ExtState%ALBD%Arr%Val(I,J) > 0.4 ) KK = 3
+          IF ( (ExtState%SNODP%Arr%Val(I,J) > 0.2) .OR. &
+                (HCO_LANDTYPE(ExtState%WLI%Arr%Val(I,J), ExtState%FRLANDIC%Arr%Val(I,J)) == 2) ) KK = 3
 
           ! USE new MODIS/KOPPEN Biometypes to read data
 

--- a/src/Extensions/hcox_tomas_dustdead_mod.F
+++ b/src/Extensions/hcox_tomas_dustdead_mod.F
@@ -932,7 +932,7 @@
       ExtState%SNOWHGT%DoUse = .TRUE.
       ExtState%USTAR%DoUse   = .TRUE.
       ExtState%Z0%DoUse      = .TRUE.
-      ExtState%ALBD%DoUse    = .TRUE.
+      ExtState%FRLANDIC%DoUse    = .TRUE.
       ExtState%WLI%DoUse     = .TRUE.
 
       ! Leave w/ success
@@ -2132,7 +2132,7 @@
 
          ! Set orography to land type
          OROGRAPHY (I,J) = HCO_LANDTYPE( ExtState%WLI%Arr%Val(I,J),
-     &                                   ExtState%ALBD%Arr%Val(I,J) )
+     &                                   ExtState%FRLANDIC%Arr%Val(I,J) )
 
       ENDDO
       ENDDO

--- a/src/Extensions/hcox_tomas_jeagle_mod.F90
+++ b/src/Extensions/hcox_tomas_jeagle_mod.F90
@@ -184,7 +184,7 @@ CONTAINS
 
        ! Get the fraction of the box that is over water
        IF ( HCO_LandType( ExtState%WLI%Arr%Val(I,J),              &
-                          ExtState%ALBD%Arr%Val(I,J) ) == 0 ) THEN
+                          ExtState%FRLANDIC%Arr%Val(I,J) ) == 0 ) THEN
           FOCEAN = 1d0 - ExtState%FRCLND%Arr%Val(I,J)
        ELSE
           FOCEAN = 0.d0
@@ -548,7 +548,7 @@ CONTAINS
 
     ! Activate met fields
     ExtState%WLI%DoUse         = .TRUE.
-    ExtState%ALBD%DoUse        = .TRUE.
+    ExtState%FRLANDIC%DoUse    = .TRUE.
     ExtState%TSKIN%DoUse       = .TRUE.
     ExtState%U10M%DoUse        = .TRUE.
     ExtState%V10M%DoUse        = .TRUE.


### PR DESCRIPTION
The main change in this PR is eliminating ALBEDO as proxy for ice and snow in favor of LANDICE and SNODP.

## Testing
Here are the emission benchmark plots for the 7th day my test simulations (Ref uses preprocessed metfields, Dev uses native MERRA2 metfields): [Link to emissions PDFs](http://geoschemdata.wustl.edu/ExternalShare/GCST/GitHub-Supplement/GCHP-165/benchmark-results-1/Emissions/). 

## Parent PR (feature/native-metfields)
- https://github.com/geoschem/GCHP/issues/165