### PR TITLE
[PULL REQUEST] Add fix for species indexing in sea salt extension when using marinePOA option

### DIFF
--- a/src/Extensions/hcox_seasalt_mod.F90
+++ b/src/Extensions/hcox_seasalt_mod.F90
@@ -994,9 +994,9 @@ CONTAINS
        CALL HCO_MSG(HcoState%Config%Err,MSG)
 
        IF ( Inst%CalcBrSalt ) THEN
-          WRITE(MSG,*) 'BrSALA: ', TRIM(SpcNamesSS(8)), Inst%IDTBrSALA
+          WRITE(MSG,*) 'BrSALA: ', TRIM(SpcNamesSS(7)), Inst%IDTBrSALA
           CALL HCO_MSG(HcoState%Config%Err,MSG)
-          WRITE(MSG,*) 'BrSALC: ', TRIM(SpcNamesSS(9)), Inst%IDTBrSALC
+          WRITE(MSG,*) 'BrSALC: ', TRIM(SpcNamesSS(8)), Inst%IDTBrSALC
           CALL HCO_MSG(HcoState%Config%Err,MSG)
           WRITE(MSG,*) 'Br- mass content: ', Inst%BrContent
           CALL HCO_MSG(HcoState%Config%Err,MSG)
@@ -1004,11 +1004,11 @@ CONTAINS
 
        IF ( HcoState%MarinePOA ) THEN
           WRITE(MSG,*) 'Hydrophobic marine organic aerosol: ',        &
-                       TRIM(SpcNamesSS(10)), ':', Inst%IDTMOPO
+                       TRIM(SpcNamesSS(9)), ':', Inst%IDTMOPO
           CALL HCO_MSG(HcoState%Config%Err,MSG)
 
           WRITE(MSG,*) 'Hydrophilic marine organic aerosol: ',        &
-                       TRIM(SpcNamesSS(11)), ':', Inst%IDTMOPI
+                       TRIM(SpcNamesSS(10)), ':', Inst%IDTMOPI
           CALL HCO_MSG(HcoState%Config%Err,MSG)
        ENDIF
     ENDIF


### PR DESCRIPTION
An out-of-bounds error currently occurs in hcox_seasalt_mod.F90 when using the marinePOA option. This is because of the removal of the Br2 species in GEOS-Chem 12.9.0, which changed the species indices in that extension. The WRITE statements in HCOX_SeaSalt_Init were never updated to use the new species indices and this PR fixes that.

NOTE: This was not caught earlier in integration tests because the marinePOA simulation was using offline sea salt emissions by default. In the automated run directory updates (https://github.com/geoschem/geos-chem/pull/459) this has been corrected and the marinePOA simulation uses the SeaSalt extension in HEMCO to properly compute MOPI and MOPO emissions which are not included in the offline sea salt files.