### PR TITLE
[PULL REQUEST] Apply fix for updating manual HEMCO diagnostics

### DIFF
--- a/src/Core/hco_calc_mod.F90
+++ b/src/Core/hco_calc_mod.F90
@@ -409,9 +409,12 @@ CONTAINS
           ! Add category emissions to diagnostics at category level
           ! (only if defined in the diagnostics list).
           IF ( Diagn_AutoFillLevelDefined(HcoState%Diagn,3) .AND. DoDiagn ) THEN
+             ! Bug fix: Make sure to pass COL=-1 to ensure all HEMCO diagnostics
+             ! are updated, including those manually defined in other models
+             ! (mps, 11/30/21)
              CALL Diagn_Update( HcoState,    ExtNr=ExtNr,   &
                                 Cat=PrevCat, Hier=-1,  HcoID=PrevSpc, &
-                                AutoFill=1,  Array3D=CatFlx, COL=HcoState%Diagn%HcoDiagnIDDefault, RC=RC ) 
+                                AutoFill=1,  Array3D=CatFlx, COL=-1, RC=RC ) 
              IF ( RC /= HCO_SUCCESS ) RETURN
 #ifdef ADJOINT
              IF (HcoState%IsAdjoint) THEN
@@ -460,9 +463,12 @@ CONTAINS
           ! The same diagnostics may be updated multiple times during
           ! the same time step, continuously adding emissions to it.
           IF ( Diagn_AutoFillLevelDefined(HcoState%Diagn,2) .AND. DoDiagn ) THEN
+             ! Bug fix: Make sure to pass COL=-1 to ensure all HEMCO diagnostics
+             ! are updated, including those manually defined in other models
+             ! (mps, 11/30/21)
              CALL Diagn_Update( HcoState,  ExtNr=ExtNr,  &
                                 Cat=-1,    Hier=-1,  HcoID=PrevSpc, &
-                               AutoFill=1,Array3D=SpcFlx, COL=HcoState%Diagn%HcoDiagnIDDefault, RC=RC ) 
+                               AutoFill=1,Array3D=SpcFlx, COL=-1, RC=RC ) 
              IF ( RC /= HCO_SUCCESS ) RETURN
 #ifdef ADJOINT
              IF (HcoState%IsAdjoint) THEN
@@ -627,11 +633,13 @@ CONTAINS
        ! Now remove PosOnly flag. TmpFlx is initialized to zero, so it's
        ! ok to keep negative values (ckeller, 7/12/15).
        IF ( Diagn_AutoFillLevelDefined(HcoState%Diagn,4) .AND. DoDiagn ) THEN
+             ! Bug fix: Make sure to pass COL=-1 to ensure all HEMCO diagnostics
+             ! are updated, including those manually defined in other models
+             ! (mps, 11/30/21)
           CALL Diagn_Update( HcoState,       ExtNr=ExtNr,   &
                              Cat=ThisCat,Hier=ThisHir,   HcoID=ThisSpc, &
-                             !AutoFill=1, Array3D=TmpFlx, PosOnly=.TRUE.,&
                              AutoFill=1, Array3D=TmpFlx, &
-                             COL=HcoState%Diagn%HcoDiagnIDDefault, RC=RC ) 
+                             COL=-1, RC=RC ) 
           IF ( RC /= HCO_SUCCESS ) RETURN
 #ifdef ADJOINT
           IF (HcoState%IsAdjoint) THEN


### PR DESCRIPTION
Several users reported issues with zero emissions in the Hg and CH4 simulations (see https://github.com/geoschem/HEMCO/issues/112, https://github.com/geoschem/geos-chem/issues/895, https://github.com/geoschem/geos-chem/issues/1011). The problem was tracked to the call to `Diagn_Update` in `hco_calc_mod.F90`. In commit https://github.com/geoschem/HEMCO/commit/057363277fc0820ee7d4828ccbd23c4308b9992b for the GCHP adjoint, the argument `COL=-1` was changed to `COL=HcoState%Diagn%HcoDiagnIDDefault` (where `HcoState%Diagn%HcoDiagnIDDefault` = 1). However, `COL=-1` is needed to update all HEMCO diagnostics, not just the default diagnostics. This is essential to update manual diagnostics, such as those defined in GEOS-Chem's `hcoi_gc_diagn_mod.F90` for the CH4, Hg, and TOMAS simulations. Without this fix, arrays containing all zeroes are passed when manual diagnostics are obtained via `HCO_GC_GetDiagn`. 

This commit reverts changes made in commit https://github.com/geoschem/HEMCO/commit/057363277fc0820ee7d4828ccbd23c4308b9992b for the GCHP adjoint. It is not clear if this has an impact on the GCHP adjoint, but if so then changing the value of COL should be done within an IF block so that it only applies to adjoint simulations.

This bug fix impacts the CH4, Hg, and TOMAS simulations in GEOS-Chem 13.1.0 - 13.3.2 and HEMCO 3.0.0 - 3.3.0.