### PR TITLE
Updating README to add details on coupled HEMCO and HEMCO 3.0 reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,13 @@ This repository (https://github.com/geoschem/HEMCO) contains the Harmonized Emis
 different sources, regions, and species on a user-defined grid. It can combine, overlay, and
 update a set of data inventories ('base emissions') and scale factors, as specified by the user
 through the HEMCO configuration file. Emissions that depend on environmental variables and 
-non-linear  parameterizations are calculated in separate HEMCO extensions. HEMCO can be run 
+non-linear parameterizations are calculated in separate HEMCO extensions. HEMCO can be run 
 in standalone mode or coupled to an atmospheric model. A more detailed description of HEMCO 
 is given in Keller et al. (2014).
+
+HEMCO has been coupled to several atmospheric and Earth System Models, and can be coupled with
+or without using the Earth System Modeling Framework (ESMF). A detailed description of HEMCO
+coupled with other models is given in Lin et al. (2021).
 
 ## CI statuses
 
@@ -25,9 +29,15 @@ Build Matrix (main) | [![Build Status](https://dev.azure.com/geoschem/hemco/_api
 C. A. Keller, M. S. Long, R. M. Yantosca, A. M. Da Silva, S. Pawson, D. J. Jacob, *HEMCO v1.0: a versatile,
 ESMF-compliant component for calculation emissions in atmospheric models*, <u>Geosci. Model Dev.</u>, **7**, 1409-1417, 2014.
 
+Lin, H., Jacob, D. J., Lundgren, E. W., Sulprizio, M. P., Keller, C. A., Fritz, T. M., Eastham, S. D., Emmons, L. K., Campbell, P. C., Baker, B., Saylor, R. D., and Montuoro, R.: *Harmonized Emissions Component (HEMCO) 3.0 as a versatile emissions component for atmospheric models: application in the GEOS-Chem, NASA GEOS, WRF-GC, CESM2, NOAA GEFS-Aerosol, and NOAA UFS models*, <u>Geosci. Model Dev.</u>, **14**, 5487–5506, 2021. 
+
 ### Online user's manual
 
   * [The HEMCO User's Guide](http://hemco.readthedocs.io)
+
+### Technical documentation
+
+  * [Technical guide in the GEOS-Chem Wiki: Coupling HEMCO with other models](http://wiki.seas.harvard.edu/geos-chem/index.php/Coupling_HEMCO_with_other_models)
 
 
 ## Support


### PR DESCRIPTION
Hi GCST,

As HEMCO is coupled to models beyond GEOS-Chem I thought it would be useful to add a reference to these implementations in the HEMCO repository `README`. I've included a short blurb linking to the [HEMCO 3.0 paper](https://gmd.copernicus.org/articles/14/5487/2021/gmd-14-5487-2021.html) and a GEOS-Chem Wiki page [Coupling HEMCO to other models](http://wiki.seas.harvard.edu/geos-chem/index.php/Coupling_HEMCO_with_other_models) that also has some useful documentation, and isn't being linked from elsewhere. I'm happy to edit this to add/remove any information as necessary, just opening this PR for discussion. Thanks!

Best,
Haipeng