### PR TITLE
Change diagnostic counter zero warning from warning level 1 to 2

### DIFF
--- a/src/Core/hco_diagn_mod.F90
+++ b/src/Core/hco_diagn_mod.F90
@@ -3137,7 +3137,7 @@ CONTAINS
        ! Prompt warning
        MSG = 'Diagnostics counter is zero - return empty array: ' // &
              TRIM(DgnCont%cName)
-       CALL HCO_WARNING( HcoState%Config%Err, MSG, RC, THISLOC=LOC, WARNLEV=1 )
+       CALL HCO_WARNING( HcoState%Config%Err, MSG, RC, THISLOC=LOC, WARNLEV=2 )
        RETURN
     ENDIF
 


### PR DESCRIPTION
This PR increases the HEMCO warning level for zero diagnostic counters from 1 to 2 so that the warnings are not printed by default (default warning level is 1 in all GEOS-Chem run directories). These warnings occur when HEMCO diagnostics are created but never populated, something that is common given the way we configure HEMCO diagnostics from config files. The prints happen every timestep and therefore clutter the log. Users can still find out if HEMCO diagnostics are created but not populated by increasing the warning level, something we recommend when debugging.

