### PR TITLE
Add fix to restore copying all needed HEMCO_Config.rc files when creating HEMCO standalone run directories

### DIFF
--- a/run/createRunDir.sh
+++ b/run/createRunDir.sh
@@ -300,13 +300,12 @@ cp ./HEMCO_sa_Spec.rc               ${rundir}
 cp ./${grid_file}                   ${rundir}
 cp ./runHEMCO.sh                    ${rundir}
 cp ./README                         ${rundir}
-if  [[ -f ${hco_config_dir}/HEMCO_Config.rc ]]; then
-    cp ${hco_config_dir}/HEMCO_Config.rc ${rundir}
+cp ${hco_config_dir}/HEMCO_Config.* ${rundir}
+if  [[ -f ${hco_config_dir}/HEMCO_Diagn.rc ]]; then
     cp ${hco_config_dir}/HEMCO_Diagn.rc ${rundir}
 else
     printf "\nCould not find a HEMCO_Diagn.rc file corresponding to HEMCO_Config.rc!\n"
     printf "A sample HEMCO_Diagn.rc will be copied to the run directory.\n"
-    cp ./HEMCO_Config.rc.sample ${rundir}/HEMCO_Config.rc
     cp ./HEMCO_Diagn.rc.sample ${rundir}/HEMCO_Diagn.rc
 fi
 


### PR DESCRIPTION
The previous commit changed the logic for copying HEMCO_Config.rc files and removed the wildcard character * from the copy command. The wildcard is needed to copy the HEMCO_Config.rc containing the met field entries (e.g. HEMCO_Config.rc.gmao_metfields) if it exists. That line is now restored here. In addition, the IF statement is also reverted so it checks for the existence of the HEMCO_Diagn.rc file as originally intended. The check for the existence of HEMCO_Config.rc is already done right after the user specifies the path to that file.