### PR TITLE
Make error messages when reading HEMCO_Config.rc more informational

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
-  - nothing yet
+## Unreleased [3.5.2]
+### Changed
+  - Replaced placeholder error messages in
+    `src/Core/hco_config_mod.f90` with more informational error
+    messages (often including the line of `HEMCO_Config.rc` where the
+    error happened).
 
 ## [3.5.0] - 2022-09-19
 ### Added


### PR DESCRIPTION
This PR removes several of the placeholder error messages in `HEMCO/src/Core/hco_config_mod.F90` (which contains routines that read the `HEMCO_Config.rc` file)  and replaces them with error messages containing more information.  In particular, the line of the HEMCO_Config.rc file where the error occurred is included in error output wherever possible.

A few other updates in this PR include:
- Declare "msg" and/or "errMsg" string variables as 512 characters
- Also note the section of HEMCO_Config.rc where the failure occurred
- For error messages where the line number is not able to be used, include the name of the routine where the error occurred
- Pass the location string to HCO_Error where it hasn't been done
- Add calls to HCO_Error where there were before print & return
- Trim comments to lie within 80 characters for readability

This should be a zero-diff PR.