### PR TITLE
Add DimMax property to ModelSpc for HEMCO_CESM interface.

### DIFF
--- a/src/Core/hco_types_mod.F90
+++ b/src/Core/hco_types_mod.F90
@@ -94,6 +94,11 @@ MODULE HCO_TYPES_MOD
      INTEGER                 :: HcoID      ! HEMCO species ID
      INTEGER                 :: ModID      ! Model species ID
      CHARACTER(LEN= 31)      :: SpcName    ! species names
+#ifdef HEMCO_CESM
+     INTEGER                 :: DimMax     ! Maximum dimensions supported: 2 (2-D), 3 (3-D)
+                                           ! HEMCO_CESM only, as 3-D emissions must be listed
+                                           ! in extfrc_list to be supported by CESM/CAM.
+#endif
   END TYPE ModSpc
 
   !=========================================================================


### PR DESCRIPTION
Hi GCST,

This is a minor change to the `ModSpc` derived type in HEMCO to add a property `DimMax`. It is used only in the HEMCO-CESM interface (and enclosed in `#ifdef HEMCO_CESM`) to determine whether 2-D or 3-D emissions are calculated for a given species.

This is because the list of species for which emissions can be vertically distributed is defined at higher level in `mo_sim_dat.F90` (kind of like species database) in CAM. Keeping this property cached in the Model Species derived type will avoid lengthy lookups to the list when looping through species.

Thanks!
Haipeng