### PR TITLE
Throw an error if HEMCO reads netCDF data on 360_day, 365_day, or noleap calendars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased 3.6.1]
 ### Added
   - GEOS-only updates
+  - Throw an error if HEMCO reads netCDF data on a climatological calendar (`360_day`, `365_day`, `noleap`). These are not supported in ESMF/MAPL, so for consistency's sake, we also need to not support these when running HEMCO outside of the ESMF environment.
 
 ## [3.6.0] - 2023-02-01
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased 3.6.1]
 ### Added
   - GEOS-only updates
-  - Throw an error if HEMCO reads netCDF data on a climatological calendar (`360_day`, `365_day`, `noleap`). These are not supported in ESMF/MAPL, so for consistency's sake, we also need to not support these when running HEMCO outside of the ESMF environment.
+  - Throw an error if input calendar is not supported
 
 ## [3.6.0] - 2023-02-01
 ### Added

--- a/src/Shared/NcdfUtil/hco_m_netcdf_io_readattr.F90
+++ b/src/Shared/NcdfUtil/hco_m_netcdf_io_readattr.F90
@@ -24,6 +24,7 @@ MODULE HCO_m_netcdf_io_readattr
   PUBLIC :: NcGet_Var_Attributes
   INTERFACE NcGet_Var_Attributes
      MODULE PROCEDURE NcGet_Var_Attr_C
+     MODULE PROCEDURE NcGet_Var_Attr_C_nostop
      MODULE PROCEDURE NcGet_Var_Attr_I4
      MODULE PROCEDURE NcGet_Var_Attr_R4
      MODULE PROCEDURE NcGet_Var_Attr_R8
@@ -118,7 +119,7 @@ CONTAINS
 ! !LOCAL VARIABLES:
 !
     CHARACTER(LEN=512) :: errMsg
-    INTEGER            :: status, vId
+    INTEGER            :: status, vId, EC
 
     ! Zero return value
     attValue = ''
@@ -130,7 +131,7 @@ CONTAINS
     IF ( status /= NF_NOERR ) THEN
        errMsg = 'In NcGet_Var_Attr_C: ' // TRIM( varName )        // &
                  ', '                   // Nf_Strerror( status )
-       CALL Do_Err_Out ( errMsg, .TRUE., 1, fId, 0, 0, 0.0d0, 0.0d0)
+       CALL Do_Err_Out( errMsg, .TRUE., 0, 0, 0, 0, 0.0d0, 0.0d0 )
     ENDIF
 
     !  Get the attribute
@@ -951,5 +952,74 @@ CONTAINS
     endif
 
   END SUBROUTINE NcGet_Glob_Attr_R8_arr
+!EOC
+!------------------------------------------------------------------------------
+!       NcdfUtilities: by Harvard Atmospheric Chemistry Modeling Group        !
+!                      and NASA/GSFC, SIVO, Code 610.3                        !
+!------------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE: NcGet_Var_Attr_C_nostop
+!
+! !DESCRIPTION: Returns a variable attribute of type CHARACTER.  Similar
+!  to NcGet_Var_Attr_C, but does not stop upon error,  Instead, a status
+!  flag is passed back to the calling routine.
+!\\
+!\\
+! !INTERFACE:
+!
+  SUBROUTINE NcGet_Var_Attr_C_nostop( fId, varName, attName, attValue, RC )
+!
+! !INPUT PARAMETERS:
+!
+    INTEGER,          INTENT(IN)  :: fId        ! netCDF file ID
+    CHARACTER(LEN=*), INTENT(IN)  :: varName    ! netCDF variable name
+    CHARACTER(LEN=*), INTENT(IN)  :: attName    ! Name of variable attribute
+!
+! !OUTPUT PARAMETERS:
+!
+    CHARACTER(LEN=*), INTENT(OUT) :: attValue   ! Attribute value
+    INTEGER,          INTENT(OUT) :: RC         ! Success or failure?
+!
+! !DESCRIPTION: Reads a variable attribute (CHARACTER type) from a netCDF file.
+!\\
+!\\
+! !AUTHOR:
+!  Bob Yantosca (based on code by Jules Kouatchou and Maharaj Bhat)
+!
+! !REVISION HISTORY:
+!  25 Jan 2012 - R. Yantosca - Initial version
+!  See https://github.com/geoschem/ncdfutil for complete history
+!EOP
+!------------------------------------------------------------------------------
+!BOC
+!
+! !LOCAL VARIABLES:
+!
+    CHARACTER(LEN=512) :: errMsg
+    INTEGER            :: status, vId
+
+    ! Zero return value
+    attValue = ''
+
+    ! Check if VARNAME is a valid variable
+    status = Nf_Inq_Varid ( fId, varName, vId )
+
+    ! Exit w/ error message if VARNAME is not valid
+    IF ( status /= NF_NOERR ) THEN
+       RC = status
+       RETURN
+    ENDIF
+
+    !  Get the attribute
+    status = Nf_Get_Att_Text( fId, vId, attName, attValue )
+
+    ! Exit w/ error message if unsuccessful
+    IF ( status /= NF_NOERR ) THEN
+       RC = status
+       RETURN
+    ENDIF
+
+  END SUBROUTINE NcGet_Var_Attr_C_nostop
 !EOC
 END MODULE HCO_m_netcdf_io_readattr

--- a/src/Shared/NcdfUtil/hco_ncdf_mod.F90
+++ b/src/Shared/NcdfUtil/hco_ncdf_mod.F90
@@ -416,10 +416,10 @@ CONTAINS
 
        ! Throw an error for climatological calendars without leap years
        SELECT CASE( TRIM( v_name ) )
-          CASE( '360_day', '365_day', '366_day', 'all_leap',              &
-                'allleap', 'no_leap', 'noleap'                           )
+          CASE( '360_day', '365_day', '366_day', 'all_leap',                 &
+                'allleap', 'no_leap', 'noleap'                              )
              WRITE( 6, '(/,a)' ) REPEAT( '=', 79 )
-             WRITE( 6, '(a,a)' ) 'HEMCO does not support calendar type ',
+             WRITE( 6, '(a  )' ) 'HEMCO does not support calendar type '  // &
                                  TRIM( v_name )
              WRITE( 6, '(/,a)' )  'HEMCO supports the following calendars:'
              WRITE( 6, '(a)'   )  ' - standard (i.e. mixed gregorian/julian)'

--- a/src/Shared/NcdfUtil/hco_ncdf_mod.F90
+++ b/src/Shared/NcdfUtil/hco_ncdf_mod.F90
@@ -412,10 +412,15 @@ CONTAINS
 
     ! Read calendar attribute
     IF ( PRESENT( timeCalendar ) ) THEN
-       CALL NcGet_Var_Attributes( fId, v_name, 'calendar', timeCalendar )
 
-       ! Throw an error for climatological calendars without leap years
-       SELECT CASE( TRIM( v_name ) )
+       ! We now get the status variable RC.  This will allow program
+       ! flow to continue if the "time:calendar" attribute is not found.
+       CALL NcGet_Var_Attributes( fId, v_name, 'calendar', timeCalendar, RC )
+
+       ! If "time:calendar" is found, then throw an error for
+       ! climatological calendars without leap years.
+       IF ( RC == 0 ) THEN
+        SELECT CASE( TRIM( v_name ) )
           CASE( '360_day', '365_day', '366_day', 'all_leap',                 &
                 'allleap', 'no_leap', 'noleap'                              )
              WRITE( 6, '(/,a)' ) REPEAT( '=', 79 )
@@ -428,9 +433,13 @@ CONTAINS
              RC = -1
           CASE DEFAULT
              ! Do nothing
-       END SELECT
+        END SELECT
+       ENDIF
+       
+       ! Reset RC so that we won't halt execution elsewhere
+       RC = 0
     ENDIF
-
+    
   END SUBROUTINE NC_READ_TIME
 !EOC
 !------------------------------------------------------------------------------

--- a/src/Shared/NcdfUtil/hco_ncdf_mod.F90
+++ b/src/Shared/NcdfUtil/hco_ncdf_mod.F90
@@ -416,10 +416,14 @@ CONTAINS
 
        ! Throw an error for climatological calendars without leap years
        SELECT CASE( TRIM( v_name ) )
-          CASE( '360_day', '365_day', 'noleap' )
+          CASE( '360_day', '365_day', '366_day', 'all_leap',              &
+                'allleap', 'no_leap', 'noleap'                           )
              WRITE( 6, '(/,a)' ) REPEAT( '=', 79 )
-             WRITE( 6, '(a)' )                                               &
-             'HEMCO does not support 360_day, 365_day, and noleap calendars!'
+             WRITE( 6, '(a,a)' ) 'HEMCO does not support calendar type ',
+                                 TRIM( v_name )
+             WRITE( 6, '(/,a)' )  'HEMCO supports the following calendars:'
+             WRITE( 6, '(a)'   )  ' - standard (i.e. mixed gregorian/julian)'
+             WRITE( 6, '(a)'   )  ' - gregorian'
              WRITE( 6, '(a,/)' ) REPEAT( '=', 79 )
              RC = -1
           CASE DEFAULT

--- a/src/Shared/NcdfUtil/hco_ncdf_mod.F90
+++ b/src/Shared/NcdfUtil/hco_ncdf_mod.F90
@@ -413,6 +413,18 @@ CONTAINS
     ! Read calendar attribute
     IF ( PRESENT( timeCalendar ) ) THEN
        CALL NcGet_Var_Attributes( fId, v_name, 'calendar', timeCalendar )
+
+       ! Throw an error for climatological calendars without leap years
+       SELECT CASE( TRIM( v_name ) )
+          CASE( '360_day', '365_day', 'noleap' )
+             WRITE( 6, '(/,a)' ) REPEAT( '=', 79 )
+             WRITE( 6, '(a)' )                                               &
+             'HEMCO does not support 360_day, 365_day, and noleap calendars!'
+             WRITE( 6, '(a,/)' ) REPEAT( '=', 79 )
+             RC = -1
+          CASE DEFAULT
+             ! Do nothing
+       END SELECT
     ENDIF
 
   END SUBROUTINE NC_READ_TIME
@@ -1285,7 +1297,7 @@ CONTAINS
 ! !LOCAL VARIABLES:
 !
     ! Scalars
-    CHARACTER(LEN=255)  :: ncUnit
+    CHARACTER(LEN=255)  :: ncUnit, cal
     INTEGER             :: refYr, refMt, refDy, refHr, refMn, refSc
     INTEGER             :: T, YYYYMMDD, hhmmss
     REAL*8              :: realrefDy, refJulday, tJulday
@@ -1304,8 +1316,14 @@ CONTAINS
     IF ( PRESENT(refYear ) ) refYear  = 0
 
     ! Read time vector
-    CALL NC_READ_TIME ( fID, nTime, ncUnit, timeVec=tVec, RC=RC )
-    IF ( RC/=0 ) RETURN
+    CALL NC_READ_TIME ( fID,          nTime,            ncUnit,              &
+                        timeVec=tVec, timeCalendar=cal, RC=RC               )
+    IF ( RC/=0 ) THEN
+       WRITE( 6, '(/,a)' ) REPEAT( '=', 79 )
+       WRITE( 6, '(a)'   ) 'Error encountered in NC_READ_TIME (ncdf_mod.F90)'
+       WRITE( 6, '(a,/)' ) REPEAT( '=', 79 )
+       RETURN
+    ENDIF
 
     ! If nTime is zero, return here!
     IF ( nTime == 0 ) RETURN


### PR DESCRIPTION
This is the companion PR to #192.  We now have added an error trap in `src/Shared/NcdfUtil/ncdf_mod.F90` to prevent HEMCO from reading netCDF data with one of the following attributes:
```
time:calendar = "360_day"
time:calendar = "365_day"
time:calendar = "noleap"
```
These calendars are not supported by ESMF, which means that GCHP will not be able to read netCDF data placed on these calendars.  For consistency's sake, we now also prevent HEMCO from reading these data when not using ESMF.

Tagging @cdholmes