### PR TITLE
Remove memory leaks in HEMCO core and standalone routines (closes #190)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased 3.6.1]
 ### Added
   - GEOS-only updates
+  - Removed several memory leaks in HEMCO Core and Standalone routines
 
 ## [3.6.0] - 2023-02-01
 ### Added

--- a/src/Core/hco_arr_mod.F90
+++ b/src/Core/hco_arr_mod.F90
@@ -192,13 +192,16 @@ CONTAINS
 !
 ! !INPUT PARAMETERS:
 !
-    TYPE(Arr2D_Hp), POINTER       :: Arr       ! Array
-    INTEGER,        INTENT(IN)    :: nx        ! x-dim
-    INTEGER,        INTENT(IN)    :: ny        ! y-dim
+    INTEGER,        INTENT(IN)  :: nx        ! x-dim
+    INTEGER,        INTENT(IN)  :: ny        ! y-dim
 !
-! !INPUT/OUTPUT PARAMETERS:
+! INPUT/OUTPUT PARAMETERS:
 !
-    INTEGER,        INTENT(INOUT) :: RC        ! Return code
+    TYPE(Arr2D_Hp), POINTER     :: Arr       ! Array
+!
+! !OUTPUT PARAMETERS:
+!
+    INTEGER,        INTENT(OUT) :: RC        ! Success or failure?
 !
 ! !REVISION HISTORY:
 !  20 Apr 2013 - C. Keller - Initial version
@@ -209,23 +212,37 @@ CONTAINS
 !
 ! !LOCAL VARIABLES:
 !
-    CHARACTER(LEN=255)  :: LOC
+    ! Strings
+    CHARACTER(LEN=255)  :: errMsg, thisLoc
 
     ! ================================================================
     ! HCO_ArrInit_2D_Hp begins here
     ! ================================================================
-    LOC = 'HCO_ArrInit_2D_Hp (HCO_ARR_MOD.F90)'
 
-    NULLIFY (Arr)
-    ALLOCATE(Arr)
-    CALL HCO_ValInit( Arr%Val, nx, ny, Arr%Alloc, RC )
-    IF ( RC /= HCO_SUCCESS ) THEN
-        CALL HCO_ERROR( 'ERROR 0', RC, THISLOC=LOC )
-        RETURN
+    ! Initialize
+    RC      = HCO_SUCCESS
+    errMsg  = ''
+    thisLoc = 'HCO_ArrInit_2D_Hp (HCO_ARR_MOD.F90)'
+
+    ! Initialize the Arr object
+    IF ( .not. ASSOCIATED( Arr ) ) THEN
+       ALLOCATE( Arr, STAT=RC )
+       IF ( RC /= HCO_SUCCESS ) THEN
+          errMsg = 'Could not allocate the "Arr" object!'
+          CALL HCO_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+       Arr%Val   => NULL()
+       Arr%Alloc = .FALSE.
     ENDIF
 
-    ! Leave
-    RC = HCO_SUCCESS
+    ! Initialize the Arr%Val array
+    CALL HCO_ValInit( Arr%Val, nx, ny, Arr%Alloc, RC )
+    IF ( RC /= HCO_SUCCESS ) THEN
+       errMsg = 'Could not allocate the "Arr%Val" array!'
+       CALL HCO_ERROR( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
 
   END SUBROUTINE HCO_ArrInit_2D_Hp
 !EOC
@@ -248,13 +265,16 @@ CONTAINS
 !
 ! !INPUT PARAMETERS:
 !
-    TYPE(Arr2D_Sp), POINTER       :: Arr       ! Array
-    INTEGER,        INTENT(IN)    :: nx        ! x-dim
-    INTEGER,        INTENT(IN)    :: ny        ! y-dim
+    INTEGER,        INTENT(IN)  :: nx        ! x-dim
+    INTEGER,        INTENT(IN)  :: ny        ! y-dim
 !
-! !INPUT/OUTPUT PARAMETERS:
+! INPUT/OUTPUT PARAMETERS:
 !
-    INTEGER,        INTENT(INOUT) :: RC        ! Return code
+    TYPE(Arr2D_Sp), POINTER     :: Arr       ! Array
+!
+! !OUTPUT PARAMETERS:
+!
+    INTEGER,        INTENT(OUT) :: RC        ! Success or failure?
 !
 ! !REVISION HISTORY:
 !  20 Apr 2013 - C. Keller - Initial version
@@ -265,23 +285,37 @@ CONTAINS
 !
 ! !LOCAL VARIABLES:
 !
-    CHARACTER(LEN=255)  :: LOC
+    ! Strings
+    CHARACTER(LEN=255)  :: errMsg, thisLoc
 
     ! ================================================================
     ! HCO_ArrInit_2D_Sp begins here
     ! ================================================================
-    LOC = 'HCO_ArrInit_2D_Sp (HCO_ARR_MOD.F90)'
 
-    NULLIFY (Arr)
-    ALLOCATE(Arr)
-    CALL HCO_ValInit( Arr%Val, nx, ny, Arr%Alloc, RC )
-    IF ( RC /= HCO_SUCCESS ) THEN
-        CALL HCO_ERROR( 'ERROR 1', RC, THISLOC=LOC )
-        RETURN
+    ! Initialize
+    RC      = HCO_SUCCESS
+    errMsg  = ''
+    thisLoc = 'HCO_ArrInit_2D_Sp (HCO_ARR_MOD.F90)'
+
+    ! Initialize the Arr object
+    IF ( .not. ASSOCIATED( Arr ) ) THEN
+       ALLOCATE( Arr, STAT=RC )
+       IF ( RC /= HCO_SUCCESS ) THEN
+          errMsg = 'Could not allocate the "Arr" object!'
+          CALL HCO_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+       Arr%Val   => NULL()
+       Arr%Alloc = .FALSE.
     ENDIF
 
-    ! Leave
-    RC = HCO_SUCCESS
+    ! Initialize the Arr%Val array
+    CALL HCO_ValInit( Arr%Val, nx, ny, Arr%Alloc, RC )
+    IF ( RC /= HCO_SUCCESS ) THEN
+       errMsg = 'Could not allocate the "Arr%Val" array!'
+       CALL HCO_ERROR( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
 
   END SUBROUTINE HCO_ArrInit_2D_Sp
 !EOC
@@ -304,13 +338,16 @@ CONTAINS
 !
 ! !INPUT PARAMETERS:
 !
-    TYPE(Arr2D_I),  POINTER       :: Arr   ! Array
-    INTEGER,        INTENT(IN)    :: nx        ! x-dim
-    INTEGER,        INTENT(IN)    :: ny        ! y-dim
+    INTEGER,        INTENT(IN)  :: nx        ! x-dim
+    INTEGER,        INTENT(IN)  :: ny        ! y-dim
 !
-! !INPUT/OUTPUT PARAMETERS:
+! INPUT/OUTPUT PARAMETERS:
 !
-    INTEGER,        INTENT(INOUT) :: RC        ! Return code
+    TYPE(Arr2D_I), POINTER      :: Arr       ! Array
+!
+! !OUTPUT PARAMETERS:
+!
+    INTEGER,        INTENT(OUT) :: RC        ! Success or failure?
 !
 ! !REVISION HISTORY:
 !  20 Apr 2013 - C. Keller - Initial version
@@ -321,23 +358,39 @@ CONTAINS
 !
 ! !LOCAL VARIABLES:
 !
-    CHARACTER(LEN=255)  :: LOC
+    ! Strings
+    CHARACTER(LEN=255)  :: errMsg, thisLoc
 
     ! ================================================================
     ! HCO_ArrInit_2D_I begins here
     ! ================================================================
-    LOC = 'HCO_ArrInit_2D_I (HCO_ARR_MOD.F90)'
 
-    NULLIFY (Arr)
-    ALLOCATE(Arr)
-    CALL HCO_ValInit( Arr%Val, nx, ny, Arr%Alloc, RC )
-    IF ( RC /= HCO_SUCCESS ) THEN
-        CALL HCO_ERROR( 'ERROR 2', RC, THISLOC=LOC )
-        RETURN
+    ! Initialize
+    RC      = HCO_SUCCESS
+    errMsg  = ''
+    thisLoc = 'HCO_ArrInit_2D_I (hco_arr_mod.F90)'
+
+    Arr => NULL()
+
+    ! Initialize the Arr object
+    IF ( .not. ASSOCIATED( Arr ) ) THEN
+       ALLOCATE( Arr, STAT=RC )
+       IF ( RC /= HCO_SUCCESS ) THEN
+          errMsg = 'Could not allocate the "Arr" object!'
+          CALL HCO_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+       Arr%Val   => NULL()
+       Arr%Alloc = .FALSE.
     ENDIF
 
-    ! Leave
-    RC = HCO_SUCCESS
+    ! Initialize the Arr%Val array
+    CALL HCO_ValInit( Arr%Val, nx, ny, Arr%Alloc, RC )
+    IF ( RC /= HCO_SUCCESS ) THEN
+       errMsg = 'Could not allocate the "Arr%Val" array!'
+       CALL HCO_ERROR( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
 
   END SUBROUTINE HCO_ArrInit_2D_I
 !EOC
@@ -360,14 +413,17 @@ CONTAINS
 !
 ! !INPUT PARAMETERS:
 !
-    TYPE(Arr3D_Hp), POINTER       :: Arr   ! Array
-    INTEGER,        INTENT(IN)    :: nx        ! x-dim
-    INTEGER,        INTENT(IN)    :: ny        ! y-dim
-    INTEGER,        INTENT(IN)    :: nz        ! z-dim
+    INTEGER,        INTENT(IN)  :: nx        ! x-dim
+    INTEGER,        INTENT(IN)  :: ny        ! y-dim
+    INTEGER,        INTENT(IN)  :: nz        ! z-dim
 !
-! !INPUT/OUTPUT PARAMETERS:
+! INPUT/OUTPUT PARAMETERS:
 !
-    INTEGER,        INTENT(INOUT) :: RC        ! Return code
+    TYPE(Arr3D_Hp), POINTER     :: Arr       ! Array
+!
+! !OUTPUT PARAMETERS:
+!
+    INTEGER,        INTENT(OUT) :: RC        ! Success or failure?
 !
 ! !REVISION HISTORY:
 !  20 Apr 2013 - C. Keller - Initial version
@@ -378,22 +434,36 @@ CONTAINS
 !
 ! !LOCAL VARIABLES:
 !
-    CHARACTER(LEN=255)  :: LOC
+    CHARACTER(LEN=255)  :: errMsg, thisLoc
+
     ! ================================================================
     ! HCO_ArrInit_3D_Hp begins here
     ! ================================================================
-    LOC = 'HCO_ArrInit_3D_Hp (HCO_ARR_MOD.F90)'
 
-    NULLIFY (Arr)
-    ALLOCATE(Arr)
-    CALL HCO_ValInit( Arr%Val, nx, ny, nz, Arr%Alloc, RC )
-    IF ( RC /= HCO_SUCCESS ) THEN
-        CALL HCO_ERROR( 'ERROR 3', RC, THISLOC=LOC )
-        RETURN
+    ! Initialize
+    RC      = HCO_SUCCESS
+    errMsg  = ''
+    thisLoc = 'HCO_ArrInit_3D_Hp (hco_arr_mod.F90)'
+
+    ! Initialize the Arr object
+    IF ( .not. ASSOCIATED( Arr ) ) THEN
+       ALLOCATE( Arr, STAT=RC )
+       IF ( RC /= HCO_SUCCESS ) THEN
+          errMsg = 'Could not allocate the Arr object!'
+          CALL HCO_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+       Arr%Val   => NULL()
+       Arr%Alloc = .FALSE.
     ENDIF
 
-    ! Leave
-    RC = HCO_SUCCESS
+    ! Initialize the Arr%Val array
+    CALL HCO_ValInit( Arr%Val, nx, ny, nz, Arr%Alloc, RC )
+    IF ( RC /= HCO_SUCCESS ) THEN
+       errMsg = 'Could not allocate the "Arr%Val" array!'
+       CALL HCO_Error( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
 
   END SUBROUTINE HCO_ArrInit_3D_Hp
 !EOC
@@ -416,14 +486,17 @@ CONTAINS
 !
 ! !INPUT PARAMETERS:
 !
-    TYPE(Arr3D_Sp), POINTER       :: Arr   ! Array
-    INTEGER,        INTENT(IN)    :: nx        ! x-dim
-    INTEGER,        INTENT(IN)    :: ny        ! y-dim
-    INTEGER,        INTENT(IN)    :: nz        ! z-dim
+    INTEGER,        INTENT(IN)  :: nx        ! x-dim
+    INTEGER,        INTENT(IN)  :: ny        ! y-dim
+    INTEGER,        INTENT(IN)  :: nz        ! z-dim
 !
-! !INPUT/OUTPUT PARAMETERS:
+! INPUT/OUTPUT PARAMETERS:
 !
-    INTEGER,        INTENT(INOUT) :: RC        ! Return code
+    TYPE(Arr3D_Sp), POINTER     :: Arr       ! Array
+!
+! !OUTPUT PARAMETERS:
+!
+    INTEGER,        INTENT(OUT) :: RC        ! Success or failure?
 !
 ! !REVISION HISTORY:
 !  20 Apr 2013 - C. Keller - Initial version
@@ -434,22 +507,40 @@ CONTAINS
 !
 ! !LOCAL VARIABLES:
 !
-    CHARACTER(LEN=255)  :: LOC
-    ! ================================================================
-    ! HCO_ArrInit_3D_Hp begins here
-    ! ================================================================
-    LOC = 'HCO_ArrInit_3D_Hp (HCO_ARR_MOD.F90)'
+    ! Scalars
+    INTEGER            :: I
 
-    NULLIFY (Arr)
-    ALLOCATE(Arr)
+    ! Strings
+    CHARACTER(LEN=255) :: errMsg, thisLoc
+
+    ! ================================================================
+    ! HCO_ArrInit_3D_Sp begins here
+    ! ================================================================
+
+    ! Initialize
+    RC      = HCO_SUCCESS
+    errMsg  = ''
+    thisLoc = 'HCO_ArrInit_3D_Sp (hco_arr_mod.F90)'
+
+    Arr => NULL()
+
+    ! Initialize the Arr object
+    !IF ( .not. ASSOCIATED( Arr ) ) THEN
+       ALLOCATE( Arr, STAT=RC )
+       IF ( RC /= HCO_SUCCESS ) THEN
+          errMsg = 'Could not allocate the Arr object!'
+          CALL HCO_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+    !ENDIF
+
+    ! Initialize the Arr%Val array
     CALL HCO_ValInit( Arr%Val, nx, ny, nz, Arr%Alloc, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
-        CALL HCO_ERROR( 'ERROR 4', RC, THISLOC=LOC )
-        RETURN
+       errMsg = 'Could not allocate the "Arr%Val" array!'
+       CALL HCO_Error( errMsg, RC, thisLoc )
+       RETURN
     ENDIF
-
-    ! Leave
-    RC = HCO_SUCCESS
 
   END SUBROUTINE HCO_ArrInit_3D_Sp
 !EOC
@@ -472,14 +563,17 @@ CONTAINS
 !
 ! !INPUT PARAMETERS:
 !
-    TYPE(Arr2D_Hp),   POINTER       :: ArrVec(:) ! Array vector
-    INTEGER,          INTENT(IN)    :: nn        ! vector length
-    INTEGER,          INTENT(IN)    :: nx        ! x-dim
-    INTEGER,          INTENT(IN)    :: ny        ! y-dim
+    INTEGER,          INTENT(IN)  :: nn           ! vector length
+    INTEGER,          INTENT(IN)  :: nx           ! x-dim
+    INTEGER,          INTENT(IN)  :: ny           ! y-dim
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
-    INTEGER,          INTENT(INOUT) :: RC        ! Return code
+    TYPE(Arr2D_Hp),   POINTER     :: ArrVec(:)    ! Array vector
+!
+! !INPUT/OUTPUT PARAMETERS:
+!
+    INTEGER,          INTENT(OUT) :: RC           ! Success or failure?
 !
 ! !REVISION HISTORY:
 !  20 Apr 2013 - C. Keller - Initial version
@@ -490,25 +584,46 @@ CONTAINS
 !
 ! !LOCAL VARIABLES:
 !
-    INTEGER :: I
+    ! Scalars
+    INTEGER            :: I
+
+    ! Strings
+    CHARACTER(LEN=255) :: errMsg, thisLoc
 
     ! ================================================================
     ! HCO_ArrVecInit_2D_Hp begins here
     ! ================================================================
 
-    ! Init
-    NULLIFY(ArrVec)
+    ! Initialize
+    RC      = HCO_SUCCESS
+    errMsg  = ''
+    thisLoc = 'HCO_ArrVecInit_2D_Hp (hco_arr_mod.F90)'
 
-    IF ( nn > 0 ) THEN
-       IF ( .NOT. ASSOCIATED(ArrVec) ) ALLOCATE(ArrVec(nn))
-       DO I = 1, nn
-          CALL HCO_ValInit( ArrVec(I)%Val, nx, ny, ArrVec(I)%Alloc, RC )
-          IF ( RC/=HCO_SUCCESS ) RETURN
-       ENDDO
+    ! If dimension is zero, return a null pointer
+    IF ( nn < 1 ) THEN
+       ArrVec => NULL()
+       RETURN
     ENDIF
 
-    ! Leave
-    RC = HCO_SUCCESS
+    ! Allocate ArrVec if necessary
+    IF ( .not. ASSOCIATED( ArrVec ) ) THEN
+       ALLOCATE( ArrVec( nn ), STAT=RC )
+       IF ( RC /= HCO_SUCCESS ) THEN
+          errMsg = 'Could not allocate "ArrVec"!'
+          CALL HCO_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+    ENDIF
+
+    ! Reset values in ArrVec
+    DO I = 1, nn
+       CALL HCO_ValInit( ArrVec(I)%Val, nx, ny, ArrVec(I)%Alloc, RC )
+       IF ( RC /= HCO_SUCCESS ) THEN
+          errMsg = 'Error encountered in "HCO_ValInit"!'
+          CALL HCO_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+    ENDDO
 
   END SUBROUTINE HCO_ArrVecInit_2D_Hp
 !EOC
@@ -531,14 +646,17 @@ CONTAINS
 !
 ! !INPUT PARAMETERS:
 !
-    TYPE(Arr2D_Sp),   POINTER       :: ArrVec(:) ! Array vector
-    INTEGER,          INTENT(IN)    :: nn        ! vector length
-    INTEGER,          INTENT(IN)    :: nx        ! x-dim
-    INTEGER,          INTENT(IN)    :: ny        ! y-dim
+    INTEGER,          INTENT(IN)  :: nn           ! vector length
+    INTEGER,          INTENT(IN)  :: nx           ! x-dim
+    INTEGER,          INTENT(IN)  :: ny           ! y-dim
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
-    INTEGER,          INTENT(INOUT) :: RC        ! Return code
+    TYPE(Arr2D_Sp),   POINTER     :: ArrVec(:)    ! Array vector
+!
+! !INPUT/OUTPUT PARAMETERS:
+!
+    INTEGER,          INTENT(OUT) :: RC           ! Success or failure?
 !
 ! !REVISION HISTORY:
 !  20 Apr 2013 - C. Keller - Initial version
@@ -549,25 +667,46 @@ CONTAINS
 !
 ! !LOCAL VARIABLES:
 !
-    INTEGER :: I
+    ! Scalars
+    INTEGER            :: I
+
+    ! Strings
+    CHARACTER(LEN=255) :: errMsg, thisLoc
 
     ! ================================================================
     ! HCO_ArrVecInit_2D_Sp begins here
     ! ================================================================
 
-    ! Init
-    NULLIFY(ArrVec)
+    ! Initialize
+    RC      = HCO_SUCCESS
+    errMsg  = ''
+    thisLoc = 'HCO_ArrVecInit_2D_Sp (hco_arr_mod.F90)'
 
-    IF ( nn > 0 ) THEN
-       IF ( .NOT. ASSOCIATED(ArrVec) ) ALLOCATE(ArrVec(nn))
-       DO I = 1, nn
-          CALL HCO_ValInit( ArrVec(I)%Val, nx, ny, ArrVec(I)%Alloc, RC )
-          IF ( RC/=HCO_SUCCESS ) RETURN
-       ENDDO
+    ! If dimension is zero, return a null pointer
+    IF ( nn < 1 ) THEN
+       ArrVec => NULL()
+       RETURN
     ENDIF
 
-    ! Leave
-    RC = HCO_SUCCESS
+    ! Allocate ArrVec if necessary
+    IF ( .not. ASSOCIATED( ArrVec ) ) THEN
+       ALLOCATE( ArrVec( nn ), STAT=RC )
+       IF ( RC /= HCO_SUCCESS ) THEN
+          errMsg = 'Could not allocate "ArrVec"!'
+          CALL HCO_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+    ENDIF
+
+    ! Reset values in ArrVec
+    DO I = 1, nn
+       CALL HCO_ValInit( ArrVec(I)%Val, nx, ny, ArrVec(I)%Alloc, RC )
+       IF ( RC /= HCO_SUCCESS ) THEN
+          errMsg = 'Error encountered in "HCO_ValInit"!'
+          CALL HCO_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+    ENDDO
 
   END SUBROUTINE HCO_ArrVecInit_2D_Sp
 !EOC
@@ -590,15 +729,18 @@ CONTAINS
 !
 ! !INPUT PARAMETERS:
 !
-    TYPE(Arr3D_Hp),   POINTER       :: ArrVec(:) ! Array vector
-    INTEGER,          INTENT(IN)    :: nn        ! vector length
-    INTEGER,          INTENT(IN)    :: nx        ! x-dim
-    INTEGER,          INTENT(IN)    :: ny        ! y-dim
-    INTEGER,          INTENT(IN)    :: nz        ! z-dim
+    INTEGER,          INTENT(IN)  :: nn           ! vector length
+    INTEGER,          INTENT(IN)  :: nx           ! x-dim
+    INTEGER,          INTENT(IN)  :: ny           ! y-dim
+    INTEGER,          INTENT(IN)  :: nz           ! z-dim
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
-    INTEGER,          INTENT(INOUT) :: RC        ! Return code
+    TYPE(Arr3D_Hp),   POINTER     :: ArrVec(:)    ! Array vector
+!
+! !INPUT/OUTPUT PARAMETERS:
+!
+    INTEGER,          INTENT(OUT) :: RC           ! Success or failure?
 !
 ! !REVISION HISTORY:
 !  20 Apr 2013 - C. Keller - Initial version
@@ -609,25 +751,46 @@ CONTAINS
 !
 ! !LOCAL VARIABLES:
 !
-    INTEGER :: I
+    ! Scalars
+    INTEGER            :: I
+
+    ! Strings
+    CHARACTER(LEN=255) :: errMsg, thisLoc
 
     ! ================================================================
     ! HCO_ArrVecInit_3D_Hp begins here
     ! ================================================================
 
-    ! Init
-    NULLIFY( ArrVec )
+    ! Initialize
+    RC      = HCO_SUCCESS
+    errMsg  = ''
+    thisLoc = 'HCO_ArrVecInit_3D_Hp (hco_arr_mod.F90)'
 
-    IF ( nn > 0 ) THEN
-       IF ( .NOT. ASSOCIATED(ArrVec) ) ALLOCATE(ArrVec(nn))
-       DO I = 1, nn
-          CALL HCO_ValInit( ArrVec(I)%Val, nx, ny, nz, ArrVec(I)%Alloc, RC )
-          IF ( RC/=HCO_SUCCESS ) RETURN
-       ENDDO
+    ! If dimension is zero, return a null pointer
+    IF ( nn < 1 ) THEN
+       ArrVec => NULL()
+       RETURN
     ENDIF
 
-    ! Leave
-    RC = HCO_SUCCESS
+    ! Allocate ArrVec if necessary
+    IF ( .not. ASSOCIATED( ArrVec ) ) THEN
+       ALLOCATE( ArrVec( nn ), STAT=RC )
+       IF ( RC /= HCO_SUCCESS ) THEN
+          errMsg = 'Could not allocate "ArrVec"!'
+          CALL HCO_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+    ENDIF
+
+    ! Reset values of ArrVec
+    DO I = 1, nn
+       CALL HCO_ValInit( ArrVec(I)%Val, nx, ny, nz, ArrVec(I)%Alloc, RC )
+       IF ( RC /= HCO_SUCCESS ) THEN
+          errMsg = 'Error encountered in "HCO_ValInit"!'
+          CALL HCO_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+    ENDDO
 
   END SUBROUTINE HCO_ArrVecInit_3D_Hp
 !EOC
@@ -650,15 +813,18 @@ CONTAINS
 !
 ! !INPUT PARAMETERS:
 !
-    TYPE(Arr3D_Sp),   POINTER       :: ArrVec(:) ! Array vector
-    INTEGER,          INTENT(IN)    :: nn        ! vector length
-    INTEGER,          INTENT(IN)    :: nx        ! x-dim
-    INTEGER,          INTENT(IN)    :: ny        ! y-dim
-    INTEGER,          INTENT(IN)    :: nz        ! z-dim
+    INTEGER,          INTENT(IN)  :: nn           ! vector length
+    INTEGER,          INTENT(IN)  :: nx           ! x-dim
+    INTEGER,          INTENT(IN)  :: ny           ! y-dim
+    INTEGER,          INTENT(IN)  :: nz           ! z-dim
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
-    INTEGER,          INTENT(INOUT) :: RC        ! Return code
+    TYPE(Arr3D_Sp),   POINTER     :: ArrVec(:)    ! Array vector
+!
+! !INPUT/OUTPUT PARAMETERS:
+!
+    INTEGER,          INTENT(OUT) :: RC           ! Success or failure?
 !
 ! !REVISION HISTORY:
 !  20 Apr 2013 - C. Keller - Initial version
@@ -669,25 +835,46 @@ CONTAINS
 !
 ! !LOCAL VARIABLES:
 !
-    INTEGER :: I
+    ! Scalars
+    INTEGER            :: I
+
+    ! Strings
+    CHARACTER(LEN=255) :: errMsg, thisLoc
 
     ! ================================================================
     ! HCO_ArrVecInit_3D_Sp begins here
     ! ================================================================
 
-    ! Init
-    NULLIFY( ArrVec )
+    ! Initialize
+    RC      = HCO_SUCCESS
+    errMsg  = ''
+    thisLoc = 'HCO_ArrVecInit_3D_Sp (hco_arr_mod.F90)'
 
-    IF ( nn > 0 ) THEN
-       IF ( .NOT. ASSOCIATED(ArrVec) ) ALLOCATE(ArrVec(nn))
-       DO I = 1, nn
-          CALL HCO_ValInit( ArrVec(I)%Val, nx, ny, nz, ArrVec(I)%Alloc, RC )
-          IF ( RC/=HCO_SUCCESS ) RETURN
-       ENDDO
+    ! If dimension is zero, return a null pointer
+    IF ( nn < 1 ) THEN
+       ArrVec => NULL()
+       RETURN
     ENDIF
 
-    ! Leave
-    RC = HCO_SUCCESS
+    ! Allocate ArrVec if necessary
+    IF ( .not. ASSOCIATED( ArrVec ) ) THEN
+       ALLOCATE( ArrVec( nn ), STAT=RC )
+       IF ( RC /= HCO_SUCCESS ) THEN
+          errMsg = 'Could not allocate "ArrVec"!'
+          CALL HCO_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+    ENDIF
+
+    ! Reset values of ArrVec
+    DO I = 1, nn
+       CALL HCO_ValInit( ArrVec(I)%Val, nx, ny, nz, ArrVec(I)%Alloc, RC )
+       IF ( RC /= HCO_SUCCESS ) THEN
+          errMsg = 'Error encountered in "HCO_ValInit"!'
+          CALL HCO_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+    ENDDO
 
   END SUBROUTINE HCO_ArrVecInit_3D_Sp
 !EOC
@@ -710,14 +897,17 @@ CONTAINS
 !
 ! !INPUT PARAMETERS:
 !
-    REAL(sp),       POINTER       :: Val(:,:)  ! Array
-    INTEGER,        INTENT(IN)    :: nx        ! x-dim
-    INTEGER,        INTENT(IN)    :: ny        ! y-dim
+    INTEGER,  INTENT(IN)  :: nx             ! x-dim
+    INTEGER,  INTENT(IN)  :: ny             ! y-dim
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
-    LOGICAL,        INTENT(  OUT) :: Alloc     ! allocated?
-    INTEGER,        INTENT(INOUT) :: RC        ! Return code
+    REAL(sp), POINTER     :: Val(:,:)       ! Array
+!
+! !INPUT/OUTPUT PARAMETERS:
+!
+    LOGICAL,  INTENT(OUT) :: Alloc          ! allocated?
+    INTEGER,  INTENT(OUT) :: RC             ! Success or failure?
 !
 ! !REVISION HISTORY:
 !  20 Apr 2013 - C. Keller - Initial version
@@ -728,28 +918,36 @@ CONTAINS
 !
 ! !LOCAL VARIABLES:
 !
-    INTEGER :: AS
+    ! Strings
+    CHARACTER(LEN=255) :: errMsg, thisLoc
 
     ! ================================================================
     ! HCO_ValInit_2D_Sp begins here
     ! ================================================================
 
-    Val   => NULL()
-    ALLOC =  .FALSE.
+    ! Initialize
+    RC      =  HCO_SUCCESS
+    errMsg  =  ''
+    thisLoc =  'HCO_ValInit_2D_Sp (hco_arr_mod.F90)'
 
-    IF ( nx>0 ) THEN
-       ALLOCATE(Val(nx,ny),STAT=AS)
-       IF(AS/=0) THEN
-          WRITE(*,*) 'Arr2D value allocation error'
-          RC = HCO_FAIL
-          RETURN
-       ENDIF
-       Val(:,:) = 0.0_sp
-       ALLOC    = .TRUE.
+    ! If dimensions are zero, just return a null pointer to Val
+    IF ( nx == 0 .and. ny == 0 ) THEN
+       Val   => NULL()
+       Alloc = .FALSE.
+       RETURN
     ENDIF
 
-    ! Leave
-    RC = HCO_SUCCESS
+    ! Initialize Val if dimensions are nonzero
+    IF ( .not. ASSOCIATED( Val ) ) THEN
+       ALLOCATE( Val( nx, ny ), STAT=RC )
+       IF ( RC /= HCO_SUCCESS ) THEN
+          errMsg = 'Could not allocate Val!'
+          CALL HCO_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+    ENDIF
+    Val   = 0.0_dp
+    alloc = .TRUE.
 
   END SUBROUTINE HCO_ValInit_2D_Sp
 !EOC
@@ -772,14 +970,17 @@ CONTAINS
 !
 ! !INPUT PARAMETERS:
 !
-    REAL(dp),       POINTER       :: Val(:,:)  ! Array
-    INTEGER,        INTENT(IN)    :: nx        ! x-dim
-    INTEGER,        INTENT(IN)    :: ny        ! y-dim
+    INTEGER,  INTENT(IN)  :: nx             ! x-dim
+    INTEGER,  INTENT(IN)  :: ny             ! y-dim
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
-    LOGICAL,        INTENT(  OUT) :: Alloc     ! allocated?
-    INTEGER,        INTENT(INOUT) :: RC        ! Return code
+    REAL(dp), POINTER     :: Val(:,:)       ! Array
+!
+! !INPUT/OUTPUT PARAMETERS:
+!
+    LOGICAL,  INTENT(OUT) :: Alloc          ! allocated?
+    INTEGER,  INTENT(OUT) :: RC             ! Success or failure?!
 !
 ! !REVISION HISTORY:
 !  20 Apr 2013 - C. Keller - Initial version
@@ -790,27 +991,36 @@ CONTAINS
 !
 ! !LOCAL VARIABLES:
 !
-    INTEGER :: AS
+    ! Strings
+    CHARACTER(LEN=255) :: errMsg, thisLoc
 
     ! ================================================================
-    ! HCO_ValInit_2D_Dp begins here
+    ! HCO_ValInit_2D_Sp begins here
     ! ================================================================
 
-    Val => NULL()
-    Alloc = .FALSE.
-    IF ( nx>0 ) THEN
-       ALLOCATE(Val(nx,ny),STAT=AS)
-       IF(AS/=0) THEN
-          WRITE(*,*) 'Arr2D value allocation error'
-          RC = HCO_FAIL
-          RETURN
-       ENDIF
-       Val(:,:) = 0.0_dp
-       Alloc = .TRUE.
+    ! Initialize
+    RC      =  HCO_SUCCESS
+    errMsg  =  ''
+    thisLoc =  'HCO_ValInit_2D_Dp (hco_arr_mod.F90)'
+
+    ! If dimensions are zero, just return a null pointer to Val
+    IF ( nx == 0 .and. ny == 0 ) THEN
+       Val     => NULL()
+       Alloc   = .FALSE.
+       RETURN
     ENDIF
 
-    ! Leave
-    RC = HCO_SUCCESS
+    ! Initialize Val if dimensions are nonzero
+    IF ( .not. ASSOCIATED( Val ) ) THEN
+       ALLOCATE( Val( nx, ny ), STAT=RC )
+       IF ( RC /= HCO_SUCCESS ) THEN
+          errMsg = 'Could not allocate Val!'
+          CALL HCO_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+    ENDIF
+    Val   = 0.0_sp
+    alloc = .TRUE.
 
   END SUBROUTINE HCO_ValInit_2D_Dp
 !EOC
@@ -829,18 +1039,21 @@ CONTAINS
 !\\
 ! !INTERFACE:
 !
-  SUBROUTINE HCO_ValInit_2D_I( Val, nx, ny, Alloc, RC )
+  SUBROUTINE HCO_ValInit_2D_I( Val, nx, ny, alloc, RC )
 !
 ! !INPUT PARAMETERS:
 !
-    INTEGER,        POINTER       :: Val(:,:)  ! Array
-    INTEGER,        INTENT(IN)    :: nx        ! x-dim
-    INTEGER,        INTENT(IN)    :: ny        ! y-dim
+    INTEGER,  INTENT(IN)  :: nx             ! x-dim
+    INTEGER,  INTENT(IN)  :: ny             ! y-dim
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
-    LOGICAL,        INTENT(  OUT) :: Alloc     ! allocated?
-    INTEGER,        INTENT(INOUT) :: RC        ! Return code
+    INTEGER,  POINTER     :: Val(:,:)       ! Array
+!
+! !INPUT/OUTPUT PARAMETERS:
+!
+    LOGICAL,  INTENT(OUT) :: Alloc          ! allocated?
+    INTEGER,  INTENT(OUT) :: RC             ! Success or failure?
 !
 ! !REVISION HISTORY:
 !  20 Apr 2013 - C. Keller - Initial version
@@ -851,27 +1064,36 @@ CONTAINS
 !
 ! !LOCAL VARIABLES:
 !
-    INTEGER :: AS
+    ! Strings
+    CHARACTER(LEN=255) :: errMsg, thisLoc
 
     ! ================================================================
     ! HCO_ValInit_2D_I begins here
     ! ================================================================
 
-    Val => NULL()
-    Alloc = .FALSE.
-    IF ( nx > 0 ) THEN
-       ALLOCATE(Val(nx,ny),STAT=AS)
-       IF(AS/=0) THEN
-          WRITE(*,*) 'Arr2D value allocation error'
-          RC = HCO_FAIL
-          RETURN
-       ENDIF
-       Val(:,:) = 0
-       Alloc = .TRUE.
+    ! Initialize
+    RC      =  HCO_SUCCESS
+    errMsg  =  ''
+    thisLoc =  'HCO_ValInit_2D_I (hco_arr_mod.F90)'
+
+    ! If dimensions are zero, just return a null pointer to Val
+    IF ( nx == 0 .and. ny == 0 ) THEN
+       Val     => NULL()
+       Alloc   = .FALSE.
+       RETURN
     ENDIF
 
-    ! Leave
-    RC = HCO_SUCCESS
+    ! Initialize Val if dimensions are nonzero
+    IF ( .not. ASSOCIATED( Val ) ) THEN
+       ALLOCATE( Val( nx, ny ), STAT=RC )
+       IF ( RC /= HCO_SUCCESS ) THEN
+          errMsg = 'Could not allocate Val!'
+          CALL HCO_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+    ENDIF
+    Val   = 0
+    alloc = .TRUE.
 
   END SUBROUTINE HCO_ValInit_2D_I
 !EOC
@@ -894,15 +1116,18 @@ CONTAINS
 !
 ! !INPUT PARAMETERS:
 !
-    REAL(dp),       POINTER       :: Val(:,:,:)! Array
-    INTEGER,        INTENT(IN)    :: nx        ! x-dim
-    INTEGER,        INTENT(IN)    :: ny        ! y-dim
-    INTEGER,        INTENT(IN)    :: nz        ! z-dim
+    INTEGER,  INTENT(IN)  :: nx             ! x-dim
+    INTEGER,  INTENT(IN)  :: ny             ! y-dim
+    INTEGER,  INTENT(IN)  :: nz             ! z-dim
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
-    LOGICAL,        INTENT(  OUT) :: Alloc     ! allocated?
-    INTEGER,        INTENT(INOUT) :: RC        ! Return code
+    REAL(dp), POINTER     :: Val(:,:,:)     ! Array
+!
+! !INPUT/OUTPUT PARAMETERS:
+!
+    LOGICAL,  INTENT(OUT) :: Alloc          ! allocated?
+    INTEGER,  INTENT(OUT) :: RC             ! Success or failure?
 !
 ! !REVISION HISTORY:
 !  20 Apr 2013 - C. Keller - Initial version
@@ -913,27 +1138,36 @@ CONTAINS
 !
 ! !LOCAL VARIABLES:
 !
-    INTEGER :: AS
+    ! Strings
+    CHARACTER(LEN=255) :: errMsg, thisLoc
 
     ! ================================================================
     ! HCO_ValInit_3D_Dp begins here
     ! ================================================================
 
-    Val => NULL()
-    Alloc = .FALSE.
-    IF ( nx>0 ) THEN
-       ALLOCATE(Val(nx,ny,nz),STAT=AS)
-       IF(AS/=0) THEN
-          WRITE(*,*) 'Arr3D value allocation error'
-          RC = HCO_FAIL
-          RETURN
-       ENDIF
-       Val(:,:,:) = 0.0_dp
-       Alloc = .TRUE.
+    ! Initialize
+    RC      =  HCO_SUCCESS
+    errMsg  =  ''
+    thisLoc =  'HCO_ValInit_3D_Dp (hco_arr_mod.F90)'
+
+    ! If dimensions are zero, return a null pointer
+    IF ( nx == 0 .and. ny == 0 .and. nz == 0 ) THEN
+       Val   => NULL()
+       Alloc = .FALSE.
+       RETURN
     ENDIF
 
-    ! Leave
-    RC = HCO_SUCCESS
+    ! Initialize Val if dimensions are nonzero
+    IF ( .not. ASSOCIATED( Val ) ) THEN
+       ALLOCATE( Val( nx, ny, nz ), STAT=RC )
+       IF ( RC /= HCO_SUCCESS ) THEN
+          errMsg = 'Could not allocate Val!'
+          CALL HCO_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+    ENDIF
+    Val   = 0.0_dp
+    alloc = .TRUE.
 
   END SUBROUTINE HCO_ValInit_3D_Dp
 !EOC
@@ -956,15 +1190,18 @@ CONTAINS
 !
 ! !INPUT PARAMETERS:
 !
-    REAL(sp),       POINTER       :: Val(:,:,:)! Array
-    INTEGER,        INTENT(IN)    :: nx        ! x-dim
-    INTEGER,        INTENT(IN)    :: ny        ! y-dim
-    INTEGER,        INTENT(IN)    :: nz        ! z-dim
+    INTEGER,  INTENT(IN)  :: nx             ! x-dim
+    INTEGER,  INTENT(IN)  :: ny             ! y-dim
+    INTEGER,  INTENT(IN)  :: nz             ! z-dim
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
-    LOGICAL,        INTENT(  OUT) :: Alloc     ! allocated?
-    INTEGER,        INTENT(INOUT) :: RC        ! Return code
+    REAL(sp), POINTER     :: Val(:,:,:)     ! Array
+!
+! !INPUT/OUTPUT PARAMETERS:
+!
+    LOGICAL,  INTENT(OUT) :: Alloc          ! allocated?
+    INTEGER,  INTENT(OUT) :: RC             ! Success or failure?
 !
 ! !REVISION HISTORY:
 !  20 Apr 2013 - C. Keller - Initial version
@@ -975,27 +1212,36 @@ CONTAINS
 !
 ! !LOCAL VARIABLES:
 !
-    INTEGER :: AS
+     ! Strings
+    CHARACTER(LEN=255) :: errMsg, thisLoc
 
     ! ================================================================
     ! HCO_ValInit_3D_Sp begins here
     ! ================================================================
 
-    Val => NULL()
-    Alloc = .FALSE.
-    IF ( nx>0 ) THEN
-       ALLOCATE(Val(nx,ny,nz),STAT=AS)
-       IF(AS/=0) THEN
-          WRITE(*,*) 'Arr3D value allocation error'
-          RC = HCO_FAIL
-          RETURN
-       ENDIF
-       Val(:,:,:) = 0.0_sp
-       Alloc = .TRUE.
+    ! Initialize
+    RC      = HCO_SUCCESS
+    errMsg  = ''
+    thisLoc = 'HCO_ValInit_3D_Sp (hco_arr_mod.F90)'
+
+    ! If dimensions are zero, return a null pointer
+    IF ( nx == 0 .and. ny == 0 .and. nz == 0 ) THEN
+       Val     => NULL()
+       Alloc   = .FALSE.
+       RETURN
     ENDIF
 
-    ! Leave
-    RC = HCO_SUCCESS
+    ! Initialize Val if dimensions are nonzero
+    IF ( .not. ASSOCIATED( Val ) ) THEN
+       ALLOCATE( Val( nx, ny, nz ), STAT=RC )
+       IF ( RC /= HCO_SUCCESS ) THEN
+          errMsg = 'Could not allocate Val!'
+          CALL HCO_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+    ENDIF
+    Val   = 0.0_sp
+    alloc = .TRUE.
 
   END SUBROUTINE HCO_ValInit_3D_Sp
 !EOC
@@ -1016,15 +1262,15 @@ CONTAINS
 !
 ! !INPUT PARAMETERS:
 !
-    TYPE(Arr3D_Hp),  POINTER         :: ThisArr3D ! 3D array
-    INTEGER,         INTENT(IN   )   :: I, J, L   ! Array dims
+    INTEGER,         INTENT(IN)  :: I, J, L       ! Array dims
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
-
-    INTEGER,         INTENT(INOUT)   :: RC        ! Return code
+    TYPE(Arr3D_Hp),  POINTER     :: ThisArr3D     ! 3D array
 !
-! !REMARKS:
+! !OUTPUT PARAMETERS:
+!
+    INTEGER,         INTENT(OUT) :: RC            ! Success or failure?
 !
 ! !REVISION HISTORY:
 !  01 May 2013 - C. Keller - Initial version
@@ -1032,22 +1278,39 @@ CONTAINS
 !EOP
 !------------------------------------------------------------------------------
 !BOC
+!
+! !LOCAL VARIABLES:
+!
+    ! Strings
+    CHARACTER(LEN=255) :: errMsg, thisLoc
 
     !=====================================================================
     ! HCO_ArrAssert_3D_Hp begins here!
     !=====================================================================
 
-    ! Check flux array
-    IF ( .NOT. ASSOCIATED ( ThisArr3D ) ) THEN
-       CALL HCO_ArrInit( ThisArr3D, I, J, L, RC )
-       IF ( RC/= HCO_SUCCESS ) RETURN
-    ELSEIF ( .NOT. ASSOCIATED ( ThisArr3D%Val ) ) THEN
-       CALL HCO_ValInit ( ThisArr3D%Val, I, J, L, ThisArr3D%Alloc, RC )
-       IF ( RC/= HCO_SUCCESS ) RETURN
-    ENDIF
+    ! Initialize
+    RC      = HCO_SUCCESS
+    errMsg  = ''
+    thisLoc = 'HCO_ArrAssert_3D_Hp (hco_arr_mod.F90)'
 
-    ! Return w/ success
-    RC = HCO_SUCCESS
+    ! Check flux array
+    IF ( .not. ASSOCIATED ( ThisArr3D ) ) THEN
+       CALL HCO_ArrInit( ThisArr3D, I, J, L, RC )
+       IF ( RC /= HCO_SUCCESS ) THEN
+          errMsg = 'Error encountered in "HCO_ArrInit"!'
+          CALL HCO_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+
+    ELSE IF ( .not. ASSOCIATED ( ThisArr3D%Val ) ) THEN
+       CALL HCO_ValInit( ThisArr3D%Val, I, J, L, ThisArr3D%Alloc, RC )
+       IF ( RC /= HCO_SUCCESS ) THEN
+          errMsg = 'Error encountered in "HCO_ValInit"!'
+          CALL HCO_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+
+    ENDIF
 
   END SUBROUTINE HCO_ArrAssert_3D_Hp
 !EOC
@@ -1068,15 +1331,15 @@ CONTAINS
 !
 ! !INPUT PARAMETERS:
 !
-    TYPE(Arr3D_Sp),  POINTER         :: ThisArr3D ! 3D array
-    INTEGER,         INTENT(IN   )   :: I, J, L   ! Array dims
+    INTEGER,         INTENT(IN)  :: I, J, L       ! Array dims
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
-
-    INTEGER,         INTENT(INOUT)   :: RC        ! Return code
+    TYPE(Arr3D_Sp),  POINTER     :: ThisArr3D     ! 3D array
 !
-! !REMARKS:
+! !OUTPUT PARAMETERS:
+!
+    INTEGER,         INTENT(OUT) :: RC            ! Success or failure?
 !
 ! !REVISION HISTORY:
 !  01 May 2013 - C. Keller - Initial version
@@ -1084,22 +1347,39 @@ CONTAINS
 !EOP
 !------------------------------------------------------------------------------
 !BOC
+!
+! !LOCAL VARIABLES:
+!
+    ! Strings
+    CHARACTER(LEN=255) :: errMsg, thisLoc
 
     !=====================================================================
     ! HCO_ArrAssert_3D_Sp begins here!
     !=====================================================================
 
-    ! Check flux array
-    IF ( .NOT. ASSOCIATED ( ThisArr3D ) ) THEN
-       CALL HCO_ArrInit( ThisArr3D, I, J, L, RC )
-       IF ( RC/= HCO_SUCCESS ) RETURN
-    ELSEIF ( .NOT. ASSOCIATED ( ThisArr3D%Val ) ) THEN
-       CALL HCO_ValInit ( ThisArr3D%Val, I, J, L, ThisArr3D%Alloc, RC )
-       IF ( RC/= HCO_SUCCESS ) RETURN
-    ENDIF
+    ! Initialize
+    RC      = HCO_SUCCESS
+    errMsg  = ''
+    thisLoc = 'HCO_ArrAssert_3D_Sp (hco_arr_mod.F90)'
 
-    ! Return w/ success
-    RC = HCO_SUCCESS
+    ! Check flux array
+    IF ( .not. ASSOCIATED ( ThisArr3D ) ) THEN
+       CALL HCO_ArrInit( ThisArr3D, I, J, L, RC )
+       IF ( RC /= HCO_SUCCESS ) THEN
+          errMsg = 'Error encountered in "HCO_ArrInit"!'
+          CALL HCO_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+
+    ELSE IF ( .not. ASSOCIATED ( ThisArr3D%Val ) ) THEN
+       CALL HCO_ValInit ( ThisArr3D%Val, I, J, L, ThisArr3D%Alloc, RC )
+       IF ( RC /= HCO_SUCCESS ) THEN
+          errMsg = 'Error encountered in "HCO_ValInit"!'
+          CALL HCO_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+
+    ENDIF
 
   END SUBROUTINE HCO_ArrAssert_3D_Sp
 !EOC
@@ -1120,14 +1400,15 @@ CONTAINS
 !
 ! !INPUT PARAMETERS:
 !
-    TYPE(Arr2D_Hp),  POINTER         :: ThisArr2D ! 2D array
-    INTEGER,         INTENT(IN   )   :: I, J      ! Array dims
+    INTEGER,         INTENT(IN)  :: I, J          ! Array dims
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
-    INTEGER,         INTENT(INOUT)   :: RC        ! Return code
+    TYPE(Arr2D_Hp),  POINTER     :: ThisArr2D     ! 2D array
 !
-! !REMARKS:
+! !OUTPUT PARAMETERS:
+!
+    INTEGER,         INTENT(OUT) :: RC            ! Success or failure?
 !
 ! !REVISION HISTORY:
 !  01 May 2013 - C. Keller - Initial version
@@ -1135,22 +1416,39 @@ CONTAINS
 !EOP
 !------------------------------------------------------------------------------
 !BOC
+!
+! !LOCAL VARIABLES:
+!
+    ! Strings
+    CHARACTER(LEN=255) :: errMsg, thisLoc
 
     !=====================================================================
     ! HCO_ArrAssert_2D_Hp begins here!
     !=====================================================================
 
-    ! Check flux array
-    IF ( .NOT. ASSOCIATED ( ThisArr2D ) ) THEN
-       CALL HCO_ArrInit( ThisArr2D, I, J, RC )
-       IF ( RC/= HCO_SUCCESS ) RETURN
-    ELSEIF ( .NOT. ASSOCIATED ( ThisArr2D%Val ) ) THEN
-       CALL HCO_ValInit ( ThisArr2D%Val, I, J, ThisArr2D%Alloc, RC )
-       IF ( RC/= HCO_SUCCESS ) RETURN
-    ENDIF
+    ! Initialize
+    RC      = HCO_SUCCESS
+    errMsg  = ''
+    thisLoc = 'HCO_ArrAssert_2D_Hp (hco_arr_mod.F90)'
 
-    ! Return w/ success
-    RC = HCO_SUCCESS
+    ! Check flux array
+    IF ( .not. ASSOCIATED ( ThisArr2D ) ) THEN
+       CALL HCO_ArrInit( ThisArr2D, I, J, RC )
+       IF ( RC /= HCO_SUCCESS ) THEN
+          errMsg = 'Error encountered in "HCO_ArrInit"!'
+          CALL HCO_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+
+    ELSE IF ( .not. ASSOCIATED ( ThisArr2D%Val ) ) THEN
+       CALL HCO_ValInit( ThisArr2D%Val, I, J, ThisArr2D%Alloc, RC )
+       IF ( RC /= HCO_SUCCESS ) THEN
+          errMsg = 'Error encountered in "HCO_ValInit"!'
+          CALL HCO_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+
+    ENDIF
 
   END SUBROUTINE HCO_ArrAssert_2D_Hp
 !EOC
@@ -1171,14 +1469,15 @@ CONTAINS
 !
 ! !INPUT PARAMETERS:
 !
-    TYPE(Arr2D_Sp),  POINTER         :: ThisArr2D ! 2D array
-    INTEGER,         INTENT(IN   )   :: I, J      ! Array dims
+    INTEGER,         INTENT(IN)  :: I, J          ! Array dims
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
-    INTEGER,         INTENT(INOUT)   :: RC        ! Return code
+    TYPE(Arr2D_Sp),  POINTER     :: ThisArr2D     ! 2D array
 !
-! !REMARKS:
+! !OUTPUT PARAMETERS:
+!
+    INTEGER,         INTENT(OUT) :: RC            ! Success or failure?
 !
 ! !REVISION HISTORY:
 !  01 May 2013 - C. Keller - Initial version
@@ -1186,22 +1485,39 @@ CONTAINS
 !EOP
 !------------------------------------------------------------------------------
 !BOC
+!
+! !LOCAL VARIABLES:
+!
+    ! Strings
+    CHARACTER(LEN=255) :: errMsg, thisLoc
 
     !=====================================================================
     ! HCO_ArrAssert_2D_Sp begins here!
     !=====================================================================
 
-    ! Check flux array
-    IF ( .NOT. ASSOCIATED ( ThisArr2D ) ) THEN
-       CALL HCO_ArrInit( ThisArr2D, I, J, RC )
-       IF ( RC/= HCO_SUCCESS ) RETURN
-    ELSEIF ( .NOT. ASSOCIATED ( ThisArr2D%Val ) ) THEN
-       CALL HCO_ValInit ( ThisArr2D%Val, I, J, ThisArr2D%Alloc, RC )
-       IF ( RC/= HCO_SUCCESS ) RETURN
-    ENDIF
+    ! Initialize
+    RC      = HCO_SUCCESS
+    errMsg  = ''
+    thisLoc = 'HCO_ArrAssert_2D_Sp (hco_arr_mod.F90)'
 
-    ! Return w/ success
-    RC = HCO_SUCCESS
+    ! Check flux array
+    IF ( .not. ASSOCIATED ( ThisArr2D ) ) THEN
+       CALL HCO_ArrInit( ThisArr2D, I, J, RC )
+       IF ( RC /= HCO_SUCCESS ) THEN
+          errMsg = 'Error encountered in "HCO_ArrInit"!'
+          CALL HCO_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+
+    ELSE IF ( .not. ASSOCIATED ( ThisArr2D%Val ) ) THEN
+       CALL HCO_ValInit ( ThisArr2D%Val, I, J, ThisArr2D%Alloc, RC )
+       IF ( RC /= HCO_SUCCESS ) THEN
+          errMsg = 'Error encountered in "HCO_ValInit"!'
+          CALL HCO_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+
+    ENDIF
 
   END SUBROUTINE HCO_ArrAssert_2D_Sp
 !EOC
@@ -1222,14 +1538,15 @@ CONTAINS
 !
 ! !INPUT PARAMETERS:
 !
-    TYPE(Arr2D_I),   POINTER         :: ThisArr2D ! 2D array
-    INTEGER,         INTENT(IN   )   :: I, J      ! Array dims
+    INTEGER,         INTENT(IN)  :: I, J          ! Array dims
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
-    INTEGER,         INTENT(INOUT)   :: RC        ! Return code
+    TYPE(Arr2D_I),   POINTER     :: ThisArr2D     ! 2D array
 !
-! !REMARKS:
+! !OUTPUT PARAMETERS:
+!
+    INTEGER,         INTENT(OUT) :: RC            ! Success or failure?
 !
 ! !REVISION HISTORY:
 !  01 May 2013 - C. Keller - Initial version
@@ -1237,22 +1554,39 @@ CONTAINS
 !EOP
 !------------------------------------------------------------------------------
 !BOC
+!
+! !LOCAL VARIABLES:
+!
+    ! Strings
+    CHARACTER(LEN=255) :: errMsg, thisLoc
 
     !=====================================================================
     ! HCO_ArrAssert_2D_I begins here!
     !=====================================================================
 
-    ! Check flux array
-    IF ( .NOT. ASSOCIATED ( ThisArr2D ) ) THEN
-       CALL HCO_ArrInit( ThisArr2D, I, J, RC )
-       IF ( RC/= HCO_SUCCESS ) RETURN
-    ELSEIF ( .NOT. ASSOCIATED ( ThisArr2D%Val ) ) THEN
-       CALL HCO_ValInit ( ThisArr2D%Val, I, J, ThisArr2D%Alloc, RC )
-       IF ( RC/= HCO_SUCCESS ) RETURN
-    ENDIF
+    ! Initialize
+    RC      = HCO_SUCCESS
+    errMsg  = ''
+    thisLoc = 'HCO_ArrAssert_2D_I (hco_arr_mod.F90)'
 
-    ! Return w/ success
-    RC = HCO_SUCCESS
+    ! Check flux array
+    IF ( .not. ASSOCIATED ( ThisArr2D ) ) THEN
+       CALL HCO_ArrInit( ThisArr2D, I, J, RC )
+       IF ( RC /= HCO_SUCCESS ) THEN
+          errMsg = 'Error encountered in "HCO_ArrInit"!'
+          CALL HCO_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+
+    ELSE IF ( .not. ASSOCIATED ( ThisArr2D%Val ) ) THEN
+       CALL HCO_ValInit ( ThisArr2D%Val, I, J, ThisArr2D%Alloc, RC )
+       IF ( RC /= HCO_SUCCESS ) THEN
+          errMsg = 'Error encountered in "HCO_ValInit"!'
+          CALL HCO_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+
+    ENDIF
 
   END SUBROUTINE HCO_ArrAssert_2D_I
 !EOC
@@ -1290,16 +1624,15 @@ CONTAINS
     ! ================================================================
     ! HCO_ArrCleanup_2D_Hp begins here
     ! ================================================================
+    IF ( ASSOCIATED( Arr ) ) THEN
 
-    IF ( PRESENT(DeepClean) ) THEN
-       DC = DeepClean
-    ELSE
+       ! Optional argument handling
        DC = .TRUE.
-    ENDIF
+       IF ( PRESENT( DeepClean ) ) DC = DeepClean
 
-    IF ( ASSOCIATED(Arr) ) THEN
-       CALL HCO_ValCleanup( Arr%Val, Arr%Alloc, DC )
-       DEALLOCATE ( Arr )
+       ! Finalize Arr%Val and Arr
+       CALL HCO_ValCleanup( Arr%Val, Arr%Alloc, DeepClean=DC )
+       DEALLOCATE( Arr )
     ENDIF
 
   END SUBROUTINE HCO_ArrCleanup_2D_Hp
@@ -1338,16 +1671,15 @@ CONTAINS
     ! ================================================================
     ! HCO_ArrCleanup_2D_Sp begins here
     ! ================================================================
+    IF ( ASSOCIATED( Arr ) ) THEN
 
-    IF ( PRESENT(DeepClean) ) THEN
-       DC = DeepClean
-    ELSE
+       ! Optional argument handling
        DC = .TRUE.
-    ENDIF
+       IF ( PRESENT( DeepClean ) ) DC = DeepClean
 
-    IF ( ASSOCIATED(Arr) ) THEN
-       CALL HCO_ValCleanup( Arr%Val, Arr%Alloc, DC )
-       DEALLOCATE ( Arr )
+       ! Finalize Arr%Val and Arr
+       CALL HCO_ValCleanup( Arr%Val, Arr%Alloc, DeepClean=DC )
+       DEALLOCATE( Arr )
     ENDIF
 
   END SUBROUTINE HCO_ArrCleanup_2D_Sp
@@ -1386,16 +1718,15 @@ CONTAINS
     ! ================================================================
     ! HCO_ArrCleanup_2D_I begins here
     ! ================================================================
+    IF ( ASSOCIATED( Arr ) ) THEN
 
-    IF ( PRESENT(DeepClean) ) THEN
-       DC = DeepClean
-    ELSE
+       ! Optional argument handling
        DC = .TRUE.
-    ENDIF
+       IF ( PRESENT( DeepClean ) ) DC = DeepClean
 
-    IF ( ASSOCIATED(Arr) ) THEN
-       CALL HCO_ValCleanup( Arr%Val, Arr%Alloc, DC )
-       DEALLOCATE ( Arr )
+       ! Finalize Arr%Val and Arr
+       CALL HCO_ValCleanup( Arr%Val, Arr%Alloc, DeepClean=DC )
+       DEALLOCATE( Arr )
     ENDIF
 
   END SUBROUTINE HCO_ArrCleanup_2D_I
@@ -1434,18 +1765,16 @@ CONTAINS
     ! ================================================================
     ! HCO_ArrCleanup_3D_Hp begins here
     ! ================================================================
+    IF ( ASSOCIATED( Arr ) ) THEN
 
-    IF ( PRESENT(DeepClean) ) THEN
-       DC = DeepClean
-    ELSE
+       ! Optional argument handling
        DC = .TRUE.
-    ENDIF
+       IF ( PRESENT( DeepClean ) ) DC = DeepClean
 
-    IF ( ASSOCIATED(Arr) ) THEN
-       CALL HCO_ValCleanup( Arr%Val, Arr%Alloc, DC )
-       DEALLOCATE ( Arr )
+       ! Finalize Arr%Val and Arr
+       CALL HCO_ValCleanup( Arr%Val, Arr%Alloc, DeepClean=DC )
+       DEALLOCATE( Arr )
     ENDIF
-
   END SUBROUTINE HCO_ArrCleanup_3D_Hp
 !EOC
 !------------------------------------------------------------------------------
@@ -1482,16 +1811,15 @@ CONTAINS
     ! ================================================================
     ! HCO_ArrCleanup_3D_Sp begins here
     ! ================================================================
+    IF ( ASSOCIATED( Arr ) ) THEN
 
-    IF ( PRESENT(DeepClean) ) THEN
-       DC = DeepClean
-    ELSE
+       ! Optional argument handling
        DC = .TRUE.
-    ENDIF
+       IF ( PRESENT( DeepClean ) ) DC = DeepClean
 
-    IF ( ASSOCIATED(Arr) ) THEN
-       CALL HCO_ValCleanup( Arr%Val, Arr%Alloc, DC )
-       DEALLOCATE ( Arr )
+       ! Finalize Arr%Val and Arr
+       CALL HCO_ValCleanup( Arr%Val, Arr%Alloc, DeepClean=DC )
+       DEALLOCATE( Arr )
     ENDIF
 
   END SUBROUTINE HCO_ArrCleanup_3D_Sp
@@ -1531,19 +1859,18 @@ CONTAINS
     ! ================================================================
     ! HCO_ArrVecCleanup_2D_Hp begins here
     ! ================================================================
+    IF ( ASSOCIATED( ArrVec ) ) THEN
 
-    IF ( PRESENT(DeepClean) ) THEN
-       DC = DeepClean
-    ELSE
+       ! Optional argument handling
        DC = .TRUE.
-    ENDIF
+       IF ( PRESENT(DeepClean) ) DC = DeepClean
 
-    IF ( ASSOCIATED(ArrVec) ) THEN
+       ! Finalize ArrVec
        DO I = 1, SIZE(ArrVec,1)
           CALL HCO_ValCleanup( ArrVec(I)%Val, ArrVec(I)%Alloc, DC )
        ENDDO
+       DEALLOCATE( ArrVec )
 
-       DEALLOCATE ( ArrVec )
     ENDIF
 
   END SUBROUTINE HCO_ArrVecCleanup_2D_Hp
@@ -1583,19 +1910,18 @@ CONTAINS
     ! ================================================================
     ! HCO_ArrVecCleanup_2D_Sp begins here
     ! ================================================================
-
-    IF ( PRESENT(DeepClean) ) THEN
-       DC = DeepClean
-    ELSE
-       DC = .TRUE.
-    ENDIF
-
     IF ( ASSOCIATED(ArrVec) ) THEN
+
+       ! Optional argument handling
+       DC = .TRUE.
+       IF ( PRESENT( DeepClean) ) DC = DeepClean
+
+       ! Finalize ArrVec
        DO I = 1, SIZE(ArrVec,1)
           CALL HCO_ValCleanup( ArrVec(I)%Val, ArrVec(I)%Alloc, DC )
        ENDDO
-
        DEALLOCATE ( ArrVec )
+
     ENDIF
 
   END SUBROUTINE HCO_ArrVecCleanup_2D_Sp
@@ -1635,19 +1961,18 @@ CONTAINS
     ! ================================================================
     ! HCO_ArrVecCleanup_3D_Hp begins here
     ! ================================================================
+    IF ( ASSOCIATED( ArrVec ) ) THEN
 
-    IF ( PRESENT(DeepClean) ) THEN
-       DC = DeepClean
-    ELSE
+       ! Optional argument handling
        DC = .TRUE.
-    ENDIF
+       IF ( PRESENT(DeepClean) ) DC = DeepClean
 
-    IF ( ASSOCIATED(ArrVec) ) THEN
+       ! Finalize ArrVec
        DO I = 1, SIZE(ArrVec,1)
           CALL HCO_ValCleanup( ArrVec(I)%Val, ArrVec(I)%Alloc, DC )
        ENDDO
-
        DEALLOCATE ( ArrVec )
+
     ENDIF
 
   END SUBROUTINE HCO_ArrVecCleanup_3D_Hp
@@ -1687,19 +2012,18 @@ CONTAINS
     ! ================================================================
     ! HCO_ArrVecCleanup_3D_Sp begins here
     ! ================================================================
+    IF ( ASSOCIATED( ArrVec ) ) THEN
 
-    IF ( PRESENT(DeepClean) ) THEN
-       DC = DeepClean
-    ELSE
+       ! Optional argument handling
        DC = .TRUE.
-    ENDIF
+       IF ( PRESENT(DeepClean) ) DC = DeepClean
 
-    IF ( ASSOCIATED(ArrVec) ) THEN
+       ! Finalize ArrVec
        DO I = 1, SIZE(ArrVec,1)
           CALL HCO_ValCleanup( ArrVec(I)%Val, ArrVec(I)%Alloc, DC )
        ENDDO
-
        DEALLOCATE ( ArrVec )
+
     ENDIF
 
   END SUBROUTINE HCO_ArrVecCleanup_3D_Sp
@@ -1723,9 +2047,12 @@ CONTAINS
 !
 ! !INPUT PARAMETERS:
 !
-    REAL(dp),            POINTER  :: Val(:,:)  ! Array
-    LOGICAL, INTENT(IN)           :: Alloc     ! Allocated?
-    LOGICAL, INTENT(IN)           :: DeepClean ! Deallocate array?
+    LOGICAL, INTENT(IN) :: Alloc     ! Allocated?
+    LOGICAL, INTENT(IN) :: DeepClean ! Deallocate array?
+!
+! !INPUT/OUTPUT PARAMETERS:
+!
+    REAL(dp), POINTER   :: Val(:,:)  ! Array
 !
 ! !REVISION HISTORY:
 !  20 Apr 2013 - C. Keller - Initial version
@@ -1759,9 +2086,12 @@ CONTAINS
 !
 ! !INPUT PARAMETERS:
 !
-    REAL(sp), POINTER    :: Val(:,:)  ! Array
     LOGICAL,  INTENT(IN) :: Alloc     ! Allocated?
     LOGICAL,  INTENT(IN) :: DeepClean ! Deallocate array?
+!
+! !INPUT/OUTPUT PARAMETERS:
+!
+    REAL(sp), POINTER    :: Val(:,:)  ! Array
 !
 ! !REVISION HISTORY:
 !  20 Apr 2013 - C. Keller - Initial version
@@ -1795,9 +2125,12 @@ CONTAINS
 !
 ! !INPUT PARAMETERS:
 !
-    INTEGER, POINTER    :: Val(:,:)  ! Array
     LOGICAL, INTENT(IN) :: Alloc     ! Allocated?
     LOGICAL, INTENT(IN) :: DeepClean ! Deallocate array?
+!
+! !INPUT/OUTPUT PARAMETERS:
+!
+    INTEGER, POINTER    :: Val(:,:)  ! Array
 !
 ! !REVISION HISTORY:
 !  20 Apr 2013 - C. Keller - Initial version
@@ -1805,9 +2138,6 @@ CONTAINS
 !EOP
 !------------------------------------------------------------------------------
 !BOC
-!
-! !LOCAL VARIABLES:
-!
     IF ( DeepClean .AND. ASSOCIATED(Val) .AND. Alloc ) THEN
        DEALLOCATE( Val )
     ENDIF
@@ -1834,9 +2164,12 @@ CONTAINS
 !
 ! !INPUT PARAMETERS:
 !
-    REAL(dp), POINTER    :: Val(:,:,:) ! Array
     LOGICAL,  INTENT(IN) :: Alloc      ! Allocated?
     LOGICAL,  INTENT(IN) :: DeepClean  ! Deallocate array?
+!
+! !INPUT/OUTPUT PARAMETERS:
+!
+    REAL(dp), POINTER    :: Val(:,:,:) ! Array
 !
 ! !REVISION HISTORY:
 !  20 Apr 2013 - C. Keller - Initial version
@@ -1870,9 +2203,12 @@ CONTAINS
 !
 ! !INPUT PARAMETERS:
 !
-    REAL(sp), POINTER    :: Val(:,:,:) ! Array
     LOGICAL,  INTENT(IN) :: Alloc      ! Allocated?
     LOGICAL,  INTENT(IN) :: DeepClean  ! Deallocate array?
+!
+! !INPUT/OUTPUT PARAMETERS:
+!
+    REAL(sp), POINTER    :: Val(:,:,:) ! Array
 !
 ! !REVISION HISTORY:
 !  20 Apr 2013 - C. Keller - Initial version

--- a/src/Core/hco_arr_mod.F90
+++ b/src/Core/hco_arr_mod.F90
@@ -224,8 +224,11 @@ CONTAINS
     errMsg  = ''
     thisLoc = 'HCO_ArrInit_2D_Hp (HCO_ARR_MOD.F90)'
 
+    ! NOTE: This may cause a memory leak
+    Arr => NULL()
+
     ! Initialize the Arr object
-    IF ( .not. ASSOCIATED( Arr ) ) THEN
+    !IF ( .not. ASSOCIATED( Arr ) ) THEN
        ALLOCATE( Arr, STAT=RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           errMsg = 'Could not allocate the "Arr" object!'
@@ -234,7 +237,7 @@ CONTAINS
        ENDIF
        Arr%Val   => NULL()
        Arr%Alloc = .FALSE.
-    ENDIF
+    !ENDIF
 
     ! Initialize the Arr%Val array
     CALL HCO_ValInit( Arr%Val, nx, ny, Arr%Alloc, RC )
@@ -297,8 +300,11 @@ CONTAINS
     errMsg  = ''
     thisLoc = 'HCO_ArrInit_2D_Sp (HCO_ARR_MOD.F90)'
 
+    ! NOTE: This may cause a memory leak
+    Arr => NULL()
+
     ! Initialize the Arr object
-    IF ( .not. ASSOCIATED( Arr ) ) THEN
+    !IF ( .not. ASSOCIATED( Arr ) ) THEN
        ALLOCATE( Arr, STAT=RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           errMsg = 'Could not allocate the "Arr" object!'
@@ -307,7 +313,7 @@ CONTAINS
        ENDIF
        Arr%Val   => NULL()
        Arr%Alloc = .FALSE.
-    ENDIF
+    !ENDIF
 
     ! Initialize the Arr%Val array
     CALL HCO_ValInit( Arr%Val, nx, ny, Arr%Alloc, RC )
@@ -370,10 +376,11 @@ CONTAINS
     errMsg  = ''
     thisLoc = 'HCO_ArrInit_2D_I (hco_arr_mod.F90)'
 
+    ! NOTE: This may cause a memory leak
     Arr => NULL()
 
     ! Initialize the Arr object
-    IF ( .not. ASSOCIATED( Arr ) ) THEN
+    !IF ( .not. ASSOCIATED( Arr ) ) THEN
        ALLOCATE( Arr, STAT=RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           errMsg = 'Could not allocate the "Arr" object!'
@@ -382,7 +389,7 @@ CONTAINS
        ENDIF
        Arr%Val   => NULL()
        Arr%Alloc = .FALSE.
-    ENDIF
+    !ENDIF
 
     ! Initialize the Arr%Val array
     CALL HCO_ValInit( Arr%Val, nx, ny, Arr%Alloc, RC )
@@ -445,8 +452,11 @@ CONTAINS
     errMsg  = ''
     thisLoc = 'HCO_ArrInit_3D_Hp (hco_arr_mod.F90)'
 
+    ! NOTE: This may cause a memory leak
+    Arr => NULL()
+
     ! Initialize the Arr object
-    IF ( .not. ASSOCIATED( Arr ) ) THEN
+    !IF ( .not. ASSOCIATED( Arr ) ) THEN
        ALLOCATE( Arr, STAT=RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           errMsg = 'Could not allocate the Arr object!'
@@ -455,7 +465,7 @@ CONTAINS
        ENDIF
        Arr%Val   => NULL()
        Arr%Alloc = .FALSE.
-    ENDIF
+    !ENDIF
 
     ! Initialize the Arr%Val array
     CALL HCO_ValInit( Arr%Val, nx, ny, nz, Arr%Alloc, RC )
@@ -522,6 +532,7 @@ CONTAINS
     errMsg  = ''
     thisLoc = 'HCO_ArrInit_3D_Sp (hco_arr_mod.F90)'
 
+    ! NOTE: This may cause a memory leak
     Arr => NULL()
 
     ! Initialize the Arr object
@@ -532,6 +543,8 @@ CONTAINS
           CALL HCO_Error( errMsg, RC, thisLoc )
           RETURN
        ENDIF
+       Arr%Val   => NULL()
+       Arr%Alloc = .FALSE.
     !ENDIF
 
     ! Initialize the Arr%Val array
@@ -931,22 +944,20 @@ CONTAINS
     thisLoc =  'HCO_ValInit_2D_Sp (hco_arr_mod.F90)'
 
     ! If dimensions are zero, just return a null pointer to Val
-    IF ( nx == 0 .and. ny == 0 ) THEN
+    IF ( nx == 0 .or. ny == 0 ) THEN
        Val   => NULL()
        Alloc = .FALSE.
        RETURN
     ENDIF
 
     ! Initialize Val if dimensions are nonzero
-    IF ( .not. ASSOCIATED( Val ) ) THEN
-       ALLOCATE( Val( nx, ny ), STAT=RC )
-       IF ( RC /= HCO_SUCCESS ) THEN
-          errMsg = 'Could not allocate Val!'
-          CALL HCO_Error( errMsg, RC, thisLoc )
-          RETURN
-       ENDIF
+    ALLOCATE( Val( nx, ny ), STAT=RC )
+    IF ( RC /= HCO_SUCCESS ) THEN
+       errMsg = 'Could not allocate Val!'
+       CALL HCO_Error( errMsg, RC, thisLoc )
+       RETURN
     ENDIF
-    Val   = 0.0_dp
+    Val   = 0.0_sp
     alloc = .TRUE.
 
   END SUBROUTINE HCO_ValInit_2D_Sp
@@ -995,7 +1006,7 @@ CONTAINS
     CHARACTER(LEN=255) :: errMsg, thisLoc
 
     ! ================================================================
-    ! HCO_ValInit_2D_Sp begins here
+    ! HCO_ValInit_2D_Dp begins here
     ! ================================================================
 
     ! Initialize
@@ -1004,22 +1015,20 @@ CONTAINS
     thisLoc =  'HCO_ValInit_2D_Dp (hco_arr_mod.F90)'
 
     ! If dimensions are zero, just return a null pointer to Val
-    IF ( nx == 0 .and. ny == 0 ) THEN
+    IF ( nx == 0 .or. ny == 0 ) THEN
        Val     => NULL()
        Alloc   = .FALSE.
        RETURN
     ENDIF
 
     ! Initialize Val if dimensions are nonzero
-    IF ( .not. ASSOCIATED( Val ) ) THEN
-       ALLOCATE( Val( nx, ny ), STAT=RC )
-       IF ( RC /= HCO_SUCCESS ) THEN
-          errMsg = 'Could not allocate Val!'
-          CALL HCO_Error( errMsg, RC, thisLoc )
-          RETURN
-       ENDIF
+    ALLOCATE( Val( nx, ny ), STAT=RC )
+    IF ( RC /= HCO_SUCCESS ) THEN
+       errMsg = 'Could not allocate Val!'
+       CALL HCO_Error( errMsg, RC, thisLoc )
+       RETURN
     ENDIF
-    Val   = 0.0_sp
+    Val   = 0.0_dp
     alloc = .TRUE.
 
   END SUBROUTINE HCO_ValInit_2D_Dp
@@ -1077,20 +1086,18 @@ CONTAINS
     thisLoc =  'HCO_ValInit_2D_I (hco_arr_mod.F90)'
 
     ! If dimensions are zero, just return a null pointer to Val
-    IF ( nx == 0 .and. ny == 0 ) THEN
+    IF ( nx == 0 .or. ny == 0 ) THEN
        Val     => NULL()
        Alloc   = .FALSE.
        RETURN
     ENDIF
 
     ! Initialize Val if dimensions are nonzero
-    IF ( .not. ASSOCIATED( Val ) ) THEN
-       ALLOCATE( Val( nx, ny ), STAT=RC )
-       IF ( RC /= HCO_SUCCESS ) THEN
-          errMsg = 'Could not allocate Val!'
-          CALL HCO_Error( errMsg, RC, thisLoc )
-          RETURN
-       ENDIF
+    ALLOCATE( Val( nx, ny ), STAT=RC )
+    IF ( RC /= HCO_SUCCESS ) THEN
+       errMsg = 'Could not allocate Val!'
+       CALL HCO_Error( errMsg, RC, thisLoc )
+       RETURN
     ENDIF
     Val   = 0
     alloc = .TRUE.
@@ -1151,20 +1158,18 @@ CONTAINS
     thisLoc =  'HCO_ValInit_3D_Dp (hco_arr_mod.F90)'
 
     ! If dimensions are zero, return a null pointer
-    IF ( nx == 0 .and. ny == 0 .and. nz == 0 ) THEN
+    IF ( nx == 0 .or. ny == 0 .or. nz == 0 ) THEN
        Val   => NULL()
        Alloc = .FALSE.
        RETURN
     ENDIF
 
     ! Initialize Val if dimensions are nonzero
-    IF ( .not. ASSOCIATED( Val ) ) THEN
-       ALLOCATE( Val( nx, ny, nz ), STAT=RC )
-       IF ( RC /= HCO_SUCCESS ) THEN
-          errMsg = 'Could not allocate Val!'
-          CALL HCO_Error( errMsg, RC, thisLoc )
-          RETURN
-       ENDIF
+    ALLOCATE( Val( nx, ny, nz ), STAT=RC )
+    IF ( RC /= HCO_SUCCESS ) THEN
+       errMsg = 'Could not allocate Val!'
+       CALL HCO_Error( errMsg, RC, thisLoc )
+       RETURN
     ENDIF
     Val   = 0.0_dp
     alloc = .TRUE.
@@ -1225,20 +1230,18 @@ CONTAINS
     thisLoc = 'HCO_ValInit_3D_Sp (hco_arr_mod.F90)'
 
     ! If dimensions are zero, return a null pointer
-    IF ( nx == 0 .and. ny == 0 .and. nz == 0 ) THEN
+    IF ( nx == 0 .or. ny == 0 .or. nz == 0 ) THEN
        Val     => NULL()
        Alloc   = .FALSE.
        RETURN
     ENDIF
 
     ! Initialize Val if dimensions are nonzero
-    IF ( .not. ASSOCIATED( Val ) ) THEN
-       ALLOCATE( Val( nx, ny, nz ), STAT=RC )
-       IF ( RC /= HCO_SUCCESS ) THEN
-          errMsg = 'Could not allocate Val!'
-          CALL HCO_Error( errMsg, RC, thisLoc )
-          RETURN
-       ENDIF
+    ALLOCATE( Val( nx, ny, nz ), STAT=RC )
+    IF ( RC /= HCO_SUCCESS ) THEN
+       errMsg = 'Could not allocate Val!'
+       CALL HCO_Error( errMsg, RC, thisLoc )
+       RETURN
     ENDIF
     Val   = 0.0_sp
     alloc = .TRUE.

--- a/src/Core/hco_datacont_mod.F90
+++ b/src/Core/hco_datacont_mod.F90
@@ -156,6 +156,10 @@ CONTAINS
 !
   SUBROUTINE DataCont_Init( Dct, cID )
 !
+! !USES:
+!
+    USE HCO_FileData_Mod, ONLY : FileData_Init
+!
 ! !INPUT PARAMETERS:
 !
     TYPE(DataCont),  POINTER       :: Dct
@@ -176,7 +180,6 @@ CONTAINS
     IF ( .NOT. ASSOCIATED( Dct) ) ALLOCATE( Dct )
 
     ! Nullify pointers
-    Dct%Dta         => NULL()
     Dct%Scal_cID    => NULL()
 
     ! Set default values
@@ -199,6 +202,9 @@ CONTAINS
     ! Set default target ID to cont. ID.
     Dct%cID          = cID
     Dct%targetID     = Dct%cID
+
+    ! Also initialize the FileData object within the DataCont object
+    CALL FileData_Init( Dct%Dta )
 
   END SUBROUTINE DataCont_Init
 !EOC
@@ -242,28 +248,19 @@ CONTAINS
     !======================================================================
     ! DataCont_Cleanup begins here!
     !======================================================================
-
-    IF ( PRESENT(ArrOnly) ) THEN
-       DeepClean = .NOT. ArrOnly
-    ELSE
-       DeepClean = .TRUE.
-    ENDIF
-
-    ! Only if associated...
     IF ( ASSOCIATED( Dct ) ) THEN
 
+       ! Optional argument handling
+       DeepClean = .TRUE.
+       IF ( PRESENT( ArrOnly ) DeepClean = ( .not. ArrOnly )
+
        ! Clean up FileData object. If DeepClean is true, this
-       ! will entirely erase the file data object. Otherwise, only the
-       ! data arrays will be removed.
-       ! Note: do only if this is the home container of the file data
-       ! object.
-       IF ( Dct%DtaHome == 1 ) THEN
-          CALL FileData_Cleanup( Dct%Dta, DeepClean )
-       ENDIF
+       ! will entirely erase the file data object. Otherwise,
+       ! only the data arrays will be removed.
+       CALL FileData_Cleanup( Dct%Dta, DeepClean )
 
        ! Clean up data container if DeepClean option is enabled.
        IF ( DeepClean ) THEN
-          Dct%Dta => NULL()
           IF( ASSOCIATED( Dct%Scal_cID ) ) DEALLOCATE( Dct%Scal_cID )
           Dct%Scal_cID => NULL()
           DEALLOCATE( Dct )

--- a/src/Core/hco_datacont_mod.F90
+++ b/src/Core/hco_datacont_mod.F90
@@ -252,7 +252,7 @@ CONTAINS
 
        ! Optional argument handling
        DeepClean = .TRUE.
-       IF ( PRESENT( ArrOnly ) DeepClean = ( .not. ArrOnly )
+       IF ( PRESENT( ArrOnly ) ) DeepClean = ( .not. ArrOnly )
 
        ! Clean up FileData object. If DeepClean is true, this
        ! will entirely erase the file data object. Otherwise,

--- a/src/Core/hco_datacont_mod.F90
+++ b/src/Core/hco_datacont_mod.F90
@@ -181,6 +181,7 @@ CONTAINS
 
     ! Nullify pointers
     Dct%Scal_cID    => NULL()
+    Dct%Dta         => NULL()
 
     ! Set default values
     Dct%DtaHome      = -999
@@ -202,9 +203,6 @@ CONTAINS
     ! Set default target ID to cont. ID.
     Dct%cID          = cID
     Dct%targetID     = Dct%cID
-
-    ! Also initialize the FileData object within the DataCont object
-    CALL FileData_Init( Dct%Dta )
 
   END SUBROUTINE DataCont_Init
 !EOC
@@ -257,7 +255,12 @@ CONTAINS
        ! Clean up FileData object. If DeepClean is true, this
        ! will entirely erase the file data object. Otherwise,
        ! only the data arrays will be removed.
-       CALL FileData_Cleanup( Dct%Dta, DeepClean )
+       !
+       ! Note: do only if this is the home container of 
+       ! the file data object.
+       IF ( Dct%DtaHome == 1 ) THEN
+          CALL FileData_Cleanup( Dct%Dta, DeepClean )
+       ENDIF
 
        ! Clean up data container if DeepClean option is enabled.
        IF ( DeepClean ) THEN

--- a/src/Core/hco_filedata_mod.F90
+++ b/src/Core/hco_filedata_mod.F90
@@ -170,12 +170,10 @@ CONTAINS
     ! FileData_Init begins here!
     !======================================================================
 
-    FileDta => NULL()
-    ALLOCATE( FileDta )
+    ! Allocate memory to the FileData object
+    IF ( .not. ASSOCIATED( FileDta ) ) ALLOCATE( FileDta )
 
     ! Nullify all pointers and initialize variables
-    ! NOTE: Avoid memory leaks by working on the argument FileDta instead
-    ! of pointing to a local object NewFDta (Bob Yantosca, 22 Aug 2022)
     FileDta%V3          => NULL()
     FileDta%V2          => NULL()
     FileDta%tIDx        => NULL()
@@ -244,8 +242,6 @@ CONTAINS
     !======================================================================
     ! FileData_Cleanup begins here!
     !======================================================================
-
-    ! Only if associated
     IF ( ASSOCIATED( FileDta ) ) THEN
 
        ! Deallocate data arrays

--- a/src/Core/hco_filedata_mod.F90
+++ b/src/Core/hco_filedata_mod.F90
@@ -171,7 +171,7 @@ CONTAINS
     !======================================================================
 
     ! Allocate memory to the FileData object
-    IF ( .not. ASSOCIATED( FileDta ) ) ALLOCATE( FileDta )
+    ALLOCATE( FileDta )
 
     ! Nullify all pointers and initialize variables
     FileDta%V3          => NULL()

--- a/src/Core/hco_geotools_mod.F90
+++ b/src/Core/hco_geotools_mod.F90
@@ -767,7 +767,7 @@ CONTAINS
 !
 ! !USES
 !
-    USE HCO_Arr_Mod,      ONLY : HCO_ArrAssert
+    USE HCO_Arr_Mod,      ONLY : HCO_ArrAssert, HCO_ArrCleanup
     USE HCO_STATE_MOD,    ONLY : HCO_STATE
     USE HCO_CALC_MOD,     ONLY : HCO_EvalFld
 !
@@ -1123,9 +1123,10 @@ CONTAINS
        ENDIF
     ENDIF
 
-    ! If Box height not available make sure it is not associated
+    ! If Box height isn't available, free its memory
+    ! NOTE: Using NULL instead of deallocate here causes a memory leak! 
     IF ( .NOT. EVAL_BXHEIGHT .OR. .NOT. FoundBXHEIGHT ) THEN
-       HcoState%Grid%BXHEIGHT_M%Val => NULL()
+       CALL HCO_ArrCleanup( HcoState%Grid%BXHEIGHT_M, DeepClean=.TRUE. )
     ENDIF
 
     ! ------------------------------------------------------------------

--- a/src/Core/hco_readlist_mod.F90
+++ b/src/Core/hco_readlist_mod.F90
@@ -698,34 +698,31 @@ CONTAINS
 !------------------------------------------------------------------------------
 !BOC
 
+    CHARACTER(LEN=255) :: errMsg, thisLoc
+
     ! ================================================================
     ! ReadList_Init begins here
     ! ================================================================
 
-    ! Allocate ReadList and all internal lists. Make sure all internal
-    ! lists are defined (nullified).
-    ALLOCATE ( ReadLists )
+    ! Initialize
+    RC = HCO_SUCCESS
 
-    ALLOCATE ( ReadLists%Once )
-    NULLIFY ( ReadLists%Once  )
+    ! Allocate the ReadLists object (which is really HcoState%ReadLists).
+    ALLOCATE( ReadLists, STAT=RC )
+    IF ( RC /= HCO_SUCCESS ) THEN
+       errMsg = 'Could not allocate ReadLists (=> HcoState%ReadLists)!'
+       CALL HCO_Error( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
 
-    ALLOCATE ( ReadLists%Year )
-    NULLIFY ( ReadLists%Year  )
-
-    ALLOCATE ( ReadLists%Month )
-    NULLIFY ( ReadLists%Month )
-
-    ALLOCATE ( ReadLists%Day )
-    NULLIFY ( ReadLists%Day   )
-
-    ALLOCATE ( ReadLists%Hour )
-    NULLIFY ( ReadLists%Hour  )
-
-    ALLOCATE ( ReadLists%Hour3 )
-    NULLIFY ( ReadLists%Hour3  )
-
-    ALLOCATE ( ReadLists%Always )
-    NULLIFY ( ReadLists%Always  )
+    ! Nullify pointer fields
+    ReadLists%Once          => NULL()
+    ReadLists%Year          => NULL()
+    ReadLists%Month         => NULL()
+    ReadLists%Day           => NULL()
+    ReadLists%Hour          => NULL()
+    ReadLists%Hour3         => NULL()
+    ReadLists%Always        => NULL()
 
     ! No file in buffer yet
     ReadLists%FileInArchive = ''

--- a/src/Extensions/hcox_dustdead_mod.F
+++ b/src/Extensions/hcox_dustdead_mod.F
@@ -98,7 +98,6 @@
        REAL(hp), POINTER          :: MSS_FRC_CLY  (:,:) => NULL()
        REAL(hp), POINTER          :: MSS_FRC_SND  (:,:) => NULL()
        REAL(hp), POINTER          :: SFC_TYP      (:,:) => NULL()
-
        REAL(hp), POINTER          :: VAI_DST(:,:) => NULL()
 
        ! Time-varying surface info from CTM
@@ -748,27 +747,69 @@
       ! Init module arrays
       !-----------------------------------------------------------------
 
-      ALLOCATE ( Inst%ERD_FCT_GEO   ( HcoState%NX, HcoState%NY),
-     &           Inst%SRCE_FUNC     ( HcoState%NX, HcoState%NY),
-     &           Inst%LND_FRC_DRY   ( HcoState%NX, HcoState%NY),
-     &           Inst%MSS_FRC_CACO3 ( HcoState%NX, HcoState%NY),
-     &           Inst%MSS_FRC_CLY   ( HcoState%NX, HcoState%NY),
-     &           Inst%MSS_FRC_SND   ( HcoState%NX, HcoState%NY),
-     &           Inst%SFC_TYP       ( HcoState%NX, HcoState%NY),
-     &           Inst%VAI_DST       ( HcoState%NX, HcoState%NY),
-     &           STAT=AS )
+      ALLOCATE( Inst%ERD_FCT_GEO( HcoState%NX, HcoState%NY), STAT=AS )
       IF ( AS /= 0 ) THEN
-        CALL HCO_ERROR ( 'Allocation error', RC )
-        RETURN
+         msg = 'Could not allocate Inst%ERD_FCT_GEO!'
+         CALL HCO_ERROR( msg, RC, thisLoc=loc )
+         RETURN
       ENDIF
-      Inst%ERD_FCT_GEO    = 0.0_hp
-      Inst%SRCE_FUNC      = 0.0_hp
-      Inst%LND_FRC_DRY    = 0.0_hp
-      Inst%MSS_FRC_CACO3  = 0.0_hp
-      Inst%MSS_FRC_CLY    = 0.0_hp
-      Inst%MSS_FRC_SND    = 0.0_hp
-      Inst%SFC_TYP        = 0.0_hp
-      Inst%VAI_DST        = 0.0_hp
+      Inst%ERD_FCT_GEO = 0.0_hp
+
+      ALLOCATE( Inst%SRCE_FUNC( HcoState%NX, HcoState%NY), STAT=AS )
+      IF ( AS /= 0 ) THEN
+         msg = 'Could not allocate Inst%SRCE_FUNC!'
+         CALL HCO_ERROR( msg, RC, thisLoc=loc )
+         RETURN
+      ENDIF
+      Inst%SRCE_FUNC = 0.0_hp
+
+      ALLOCATE( Inst%LND_FRC_DRY( HcoState%NX, HcoState%NY), STAT=AS )
+      IF ( AS /= 0 ) THEN
+         msg = 'Could not allocate Inst%LND_FRC_DRY!'
+         CALL HCO_ERROR( msg, RC, thisLoc=loc )
+         RETURN
+      ENDIF
+      Inst%LND_FRC_DRY = 0.0_hp
+
+      ALLOCATE( Inst%MSS_FRC_CACO3( HcoState%NX, HcoState%NY), STAT=AS )
+      IF ( AS /= 0 ) THEN
+         msg = 'Could not allocate Inst%MSS_FRC_CACO3!'
+         CALL HCO_ERROR( msg, RC, thisLoc=loc )
+         RETURN
+      ENDIF
+      Inst%MSS_FRC_CACO3 = 0.0_hp
+
+      ALLOCATE( Inst%MSS_FRC_CLY( HcoState%NX, HcoState%NY), STAT=AS )
+      IF ( AS /= 0 ) THEN
+         msg = 'Could not allocate Inst%MSS_FRC_CLY!'
+         CALL HCO_ERROR( msg, RC, thisLoc=loc )
+         RETURN
+      ENDIF
+      Inst%MSS_FRC_CLY = 0.0_hp
+
+      ALLOCATE( Inst%MSS_FRC_SND( HcoState%NX, HcoState%NY), STAT=AS )
+      IF ( AS /= 0 ) THEN
+         msg = 'Could not allocate Inst%MSS_FRC_SND!'
+         CALL HCO_ERROR( msg, RC, thisLoc=loc )
+         RETURN
+      ENDIF
+      Inst%MSS_FRC_SND = 0.0_hp
+
+      ALLOCATE( Inst%SFC_TYP( HcoState%NX, HcoState%NY), STAT=AS )
+      IF ( AS /= 0 ) THEN
+         msg = 'Could not allocate Inst%SFC_TYP!'
+         CALL HCO_ERROR( msg, RC, thisLoc=loc )
+         RETURN
+      ENDIF
+      Inst%SFC_TYP = 0.0_hp
+
+      ALLOCATE( Inst%VAI_DST( HcoState%NX, HcoState%NY), STAT=AS )
+      IF ( AS /= 0 ) THEN
+         msg = 'Could not allocate Inst%VAI_DST!'
+         CALL HCO_ERROR( msg, RC, thisLoc=loc )
+         RETURN
+      ENDIF
+      Inst%VAI_DST = 0.0_hp
 
 !      ! Allocate arrays
 !      ALLOCATE( Inst%FLX_LW_DWN_SFC( I, J ), STAT=AS )
@@ -5689,6 +5730,11 @@ c Fix up for negative argument, erf, etc.
             DEALLOCATE(Inst%MSS_FRC_CACO3)
          ENDIF
          Inst%MSS_FRC_CACO3 => NULL()
+
+         IF ( ASSOCIATED( Inst%MSS_FRC_CLY ) ) THEN
+            DEALLOCATE(Inst%MSS_FRC_CLY)
+         ENDIF
+         Inst%MSS_FRC_CLY => NULL()
 
          IF ( ASSOCIATED( Inst%MSS_FRC_SND ) ) THEN
             DEALLOCATE(Inst%MSS_FRC_SND )

--- a/src/Extensions/hcox_tomas_dustdead_mod.F
+++ b/src/Extensions/hcox_tomas_dustdead_mod.F
@@ -96,8 +96,7 @@
        REAL(hp), POINTER          :: MSS_FRC_CLY  (:,:) => NULL()
        REAL(hp), POINTER          :: MSS_FRC_SND  (:,:) => NULL()
        REAL(hp), POINTER          :: SFC_TYP      (:,:) => NULL()
-
-       REAL(hp), POINTER          :: VAI_DST(:,:) => NULL()
+       REAL(hp), POINTER          :: VAI_DST      (:,:) => NULL()
 
        ! Time-varying surface info from CTM
 !       REAL*8,  ALLOCATABLE :: FLX_LW_DWN_SFC(:,:)
@@ -729,27 +728,140 @@
       ! Init module arrays
       !-----------------------------------------------------------------
 
-      ALLOCATE ( Inst%ERD_FCT_GEO   ( HcoState%NX, HcoState%NY),
-     &           Inst%SRCE_FUNC     ( HcoState%NX, HcoState%NY),
-     &           Inst%LND_FRC_DRY   ( HcoState%NX, HcoState%NY),
-     &           Inst%MSS_FRC_CACO3 ( HcoState%NX, HcoState%NY),
-     &           Inst%MSS_FRC_CLY   ( HcoState%NX, HcoState%NY),
-     &           Inst%MSS_FRC_SND   ( HcoState%NX, HcoState%NY),
-     &           Inst%SFC_TYP       ( HcoState%NX, HcoState%NY),
-     &           Inst%VAI_DST       ( HcoState%NX, HcoState%NY),
-     &           STAT=AS )
+      !-----------------------------------------------------------------
+      ! Init module arrays
+      !-----------------------------------------------------------------
+
+      ALLOCATE( Inst%ERD_FCT_GEO( HcoState%NX, HcoState%NY), STAT=AS )
       IF ( AS /= 0 ) THEN
-        CALL HCO_ERROR ( 'Allocation error', RC )
-        RETURN
+         msg = 'Could not allocate Inst%ERD_FCT_GEO!'
+         CALL HCO_ERROR( msg, RC, thisLoc=loc )
+         RETURN
       ENDIF
-      Inst%ERD_FCT_GEO    = 0.0_hp
-      Inst%SRCE_FUNC      = 0.0_hp
-      Inst%LND_FRC_DRY    = 0.0_hp
-      Inst%MSS_FRC_CACO3  = 0.0_hp
-      Inst%MSS_FRC_CLY    = 0.0_hp
-      Inst%MSS_FRC_SND    = 0.0_hp
-      Inst%SFC_TYP        = 0.0_hp
-      Inst%VAI_DST        = 0.0_hp
+      Inst%ERD_FCT_GEO = 0.0_hp
+
+      ALLOCATE( Inst%SRCE_FUNC( HcoState%NX, HcoState%NY), STAT=AS )
+      IF ( AS /= 0 ) THEN
+         msg = 'Could not allocate Inst%SRCE_FUNC!'
+         CALL HCO_ERROR( msg, RC, thisLoc=loc )
+         RETURN
+      ENDIF
+      Inst%SRCE_FUNC = 0.0_hp
+
+      ALLOCATE( Inst%LND_FRC_DRY( HcoState%NX, HcoState%NY), STAT=AS )
+      IF ( AS /= 0 ) THEN
+         msg = 'Could not allocate Inst%LND_FRC_DRY!'
+         CALL HCO_ERROR( msg, RC, thisLoc=loc )
+         RETURN
+      ENDIF
+      Inst%LND_FRC_DRY = 0.0_hp
+
+      ALLOCATE( Inst%MSS_FRC_CACO3( HcoState%NX, HcoState%NY), STAT=AS )
+      IF ( AS /= 0 ) THEN
+         msg = 'Could not allocate Inst%MSS_FRC_CACO3!'
+         CALL HCO_ERROR( msg, RC, thisLoc=loc )
+         RETURN
+      ENDIF
+      Inst%MSS_FRC_CACO3 = 0.0_hp
+
+      ALLOCATE( Inst%MSS_FRC_CLY( HcoState%NX, HcoState%NY), STAT=AS )
+      IF ( AS /= 0 ) THEN
+         msg = 'Could not allocate Inst%MSS_FRC_CLY!'
+         CALL HCO_ERROR( msg, RC, thisLoc=loc )
+         RETURN
+      ENDIF
+      Inst%MSS_FRC_CLY = 0.0_hp
+
+      ALLOCATE( Inst%MSS_FRC_SND( HcoState%NX, HcoState%NY), STAT=AS )
+      IF ( AS /= 0 ) THEN
+         msg = 'Could not allocate Inst%MSS_FRC_SND!'
+         CALL HCO_ERROR( msg, RC, thisLoc=loc )
+         RETURN
+      ENDIF
+      Inst%MSS_FRC_SND = 0.0_hp
+
+      ALLOCATE( Inst%SFC_TYP( HcoState%NX, HcoState%NY), STAT=AS )
+      IF ( AS /= 0 ) THEN
+         msg = 'Could not allocate Inst%SFC_TYP!'
+         CALL HCO_ERROR( msg, RC, thisLoc=loc )
+         RETURN
+      ENDIF
+      Inst%SFC_TYP = 0.0_hp
+
+      ALLOCATE( Inst%VAI_DST( HcoState%NX, HcoState%NY), STAT=AS )
+      IF ( AS /= 0 ) THEN
+         msg = 'Could not allocate Inst%VAI_DST!'
+      !-----------------------------------------------------------------
+      ! Init module arrays
+      !-----------------------------------------------------------------
+
+      ALLOCATE( Inst%ERD_FCT_GEO( HcoState%NX, HcoState%NY), STAT=AS )
+      IF ( AS /= 0 ) THEN
+         msg = 'Could not allocate Inst%ERD_FCT_GEO!'
+         CALL HCO_ERROR( msg, RC, thisLoc=loc )
+         RETURN
+      ENDIF
+      Inst%ERD_FCT_GEO = 0.0_hp
+
+      ALLOCATE( Inst%SRCE_FUNC( HcoState%NX, HcoState%NY), STAT=AS )
+      IF ( AS /= 0 ) THEN
+         msg = 'Could not allocate Inst%SRCE_FUNC!'
+         CALL HCO_ERROR( msg, RC, thisLoc=loc )
+         RETURN
+      ENDIF
+      Inst%SRCE_FUNC = 0.0_hp
+
+      ALLOCATE( Inst%LND_FRC_DRY( HcoState%NX, HcoState%NY), STAT=AS )
+      IF ( AS /= 0 ) THEN
+         msg = 'Could not allocate Inst%LND_FRC_DRY!'
+         CALL HCO_ERROR( msg, RC, thisLoc=loc )
+         RETURN
+      ENDIF
+      Inst%LND_FRC_DRY = 0.0_hp
+
+      ALLOCATE( Inst%MSS_FRC_CACO3( HcoState%NX, HcoState%NY), STAT=AS )
+      IF ( AS /= 0 ) THEN
+         msg = 'Could not allocate Inst%MSS_FRC_CACO3!'
+         CALL HCO_ERROR( msg, RC, thisLoc=loc )
+         RETURN
+      ENDIF
+      Inst%MSS_FRC_CACO3 = 0.0_hp
+
+      ALLOCATE( Inst%MSS_FRC_CLY( HcoState%NX, HcoState%NY), STAT=AS )
+      IF ( AS /= 0 ) THEN
+         msg = 'Could not allocate Inst%MSS_FRC_CLY!'
+         CALL HCO_ERROR( msg, RC, thisLoc=loc )
+         RETURN
+      ENDIF
+      Inst%MSS_FRC_CLY = 0.0_hp
+
+      ALLOCATE( Inst%MSS_FRC_SND( HcoState%NX, HcoState%NY), STAT=AS )
+      IF ( AS /= 0 ) THEN
+         msg = 'Could not allocate Inst%MSS_FRC_SND!'
+         CALL HCO_ERROR( msg, RC, thisLoc=loc )
+         RETURN
+      ENDIF
+      Inst%MSS_FRC_SND = 0.0_hp
+
+      ALLOCATE( Inst%SFC_TYP( HcoState%NX, HcoState%NY), STAT=AS ) 
+      IF ( AS /= 0 ) THEN
+         msg = 'Could not allocate Inst%SFC_TYP!'
+         CALL HCO_ERROR( msg, RC, thisLoc=loc )
+         RETURN
+      ENDIF
+      Inst%SFC_TYP = 0.0_hp
+      
+      ALLOCATE( Inst%VAI_DST( HcoState%NX, HcoState%NY), STAT=AS )
+      IF ( AS /= 0 ) THEN
+         msg = 'Could not allocate Inst%VAI_DST!'
+         CALL HCO_ERROR( msg, RC, thisLoc=loc )
+         RETURN
+      ENDIF
+      Inst%VAI_DST = 0.0_hp
+         CALL HCO_ERROR( msg, RC, thisLoc=loc )
+         RETURN
+      ENDIF
+      Inst%VAI_DST = 0.0_hp
 
 !      ! Allocate arrays
 !      ALLOCATE( Inst%FLX_LW_DWN_SFC( I, J ), STAT=AS )
@@ -5701,6 +5813,11 @@ c Fix up for negative argument, erf, etc.
             DEALLOCATE(Inst%MSS_FRC_CACO3)
          ENDIF
          Inst%MSS_FRC_CACO3 => NULL()
+
+         IF ( ASSOCIATED( Inst%MSS_FRC_CLY ) ) THEN
+            DEALLOCATE(Inst%MSS_FRC_CLY)
+         ENDIF
+         Inst%MSS_FRC_CLY => NULL()
 
          IF ( ASSOCIATED( Inst%MSS_FRC_SND ) ) THEN
             DEALLOCATE(Inst%MSS_FRC_SND )

--- a/src/Interfaces/Standalone/hcoi_standalone_mod.F90
+++ b/src/Interfaces/Standalone/hcoi_standalone_mod.F90
@@ -538,13 +538,15 @@ CONTAINS
                               DYS(1),    HRS(1), MNS(1), SCS(1), &
                               IsEmisTime=.TRUE., RC=RC)
           IF ( RC /= HCO_SUCCESS ) THEN
-              CALL HCO_ERROR ( 'ERROR 0', RC, THISLOC=LOC )
-              RETURN
+             errMsg = 'Error encountered in "HcoClock_Set"!'
+             CALL HCO_ERROR ( errMsg, RC, THISLOC=LOC )
+             RETURN
           ENDIF
        ELSE
           CALL HcoClock_Increase ( HcoState, HcoState%TS_EMIS, .TRUE., RC=RC )
           IF ( RC /= HCO_SUCCESS ) THEN
-              CALL HCO_ERROR ( 'ERROR 1', RC, THISLOC=LOC )
+             errMsg = 'Error encountered in "HcoClock_Increase"!'
+             CALL HCO_ERROR ( msg, RC, THISLOC=LOC )
           ENDIF
        ENDIF
 
@@ -1512,8 +1514,9 @@ CONTAINS
                                  HcoState%Grid%zGrid, NZ, RC=RC )
     ENDIF
     IF ( RC /= HCO_SUCCESS ) THEN
-        CALL HCO_ERROR( 'ERROR 2', RC, THISLOC=LOC )
-        RETURN
+       errMsg = 'Error encountered in "HCO_VertGrid_Define"!'
+       CALL HCO_ERROR( errMsg, RC, THISLOC=LOC )
+       RETURN
     ENDIF
 
     ! Set pointers to grid variables
@@ -2150,8 +2153,9 @@ CONTAINS
     ! Enter
     CALL HCO_ENTER( HcoState%Config%Err, LOC, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
-        CALL HCO_ERROR( 'ERROR 3', RC, THISLOC=LOC )
-        RETURN
+       errMsg = 'Error encountered in "HCO_Enter"!'
+       CALL HCO_ERROR( errMsg, RC, THISLOC=LOC )
+       RETURN
     ENDIF
 
     ! First call?
@@ -2754,13 +2758,12 @@ CONTAINS
     ! quantities read from disk.
     !-----------------------------------------------------------------
 
-
-
     ! Attempt to calculate vertical grid quantities
     CALL HCO_CalcVertGrid( HcoState, PSFC, ZSFC, TK, BXHEIGHT, PEDGE, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
-        CALL HCO_ERROR( 'ERROR 4', RC, THISLOC=LOC )
-        RETURN
+       errMsg = 'Error encountered in "Hco_CalcVertGrid"!'
+       CALL HCO_ERROR( errMsg, RC, thisLoc )
+       RETURN
     ENDIF
 
     ! Reset pointers
@@ -3029,8 +3032,9 @@ CONTAINS
     ! Enter
     CALL HCO_ENTER( HcoState%Config%Err, LOC, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
-        CALL HCO_ERROR( 'ERROR 5', RC, THISLOC=LOC )
-        RETURN
+       errMsg = 'Error encountered in "HCO_Enter"!'
+       CALL HCO_ERROR( errMsg, RC, THISLOC=LOC )
+       RETURN
     ENDIF
 
     !=======================================================================
@@ -3115,7 +3119,8 @@ CONTAINS
     ! Enter
     CALL HCO_ENTER( HcoState%Config%Err, LOC, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
-        CALL HCO_ERROR( 'ERROR 6', RC, THISLOC=LOC )
+       errMsg = 'Error encountered in "HCO_Enter"!'
+        CALL HCO_ERROR( errMsg, RC, THISLOC=LOC )
         RETURN
     ENDIF
 


### PR DESCRIPTION
This is the companion PR to #190.  We have rewritten code in several HEMCO modules to remove memory leaks (which were diagnosed with -DSANITIZE=y).

NOTE: The memory leak in hco_config_mod.F90 (due to the FileData object) has not been solved, despite what the comments say.

Closes #190