### PR TITLE
Fixed bugs in HEMCO issue templates; also point to proper commit of geos-chem-shared-docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-feature-or-discussion.md
+++ b/.github/ISSUE_TEMPLATE/new-feature-or-discussion.md
@@ -1,5 +1,8 @@
 ---
 name: Request a new HEMCO feature or start a discussion
+description: Request a new HEMCO feature or start a discussion
+body:
+  - type: markdown
 ---
 
 ### Name and Institution (Required)

--- a/.github/ISSUE_TEMPLATE/question-issue.md
+++ b/.github/ISSUE_TEMPLATE/question-issue.md
@@ -1,5 +1,8 @@
 ---
 name: Ask a question about or report an issue with HEMCO
+description: Ask a question about or report an issue with HEMCO
+body:
+  - type: markdown
 ---
 
 ### Name and Institution (Required)

--- a/.github/PULL_REQUEST_TEMPLATE/pull-request.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull-request.md
@@ -1,7 +1,9 @@
 ---
 name: Submit updates to HEMCO with a pull request
+description: Submit updates to HEMCO with a pull request
 labels: 'never stale'
-
+body:
+  - type: markdown
 ---
 
 ### Name and Institution (Required)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [3.6.2] - 2023-03-02
 ### Fixed
 - Add extra YAML tags to GitHub issue and PR templates to avoid errors
+- Now point to proper commit of geos-chem-shaed-docs submodule
 
 ## [3.6.1] - 2023-03-01
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.2] - 2023-03-02
+### Fixed
+- Add extra YAML tags to GitHub issue and PR templates to avoid errors
+
 ## [3.6.1] - 2023-03-01
 ### Added
   - GEOS-only updates


### PR DESCRIPTION
This PR addresses a couple of non-scientific bugs in the HEMCO 3.6.1 release:

1. Adds a "description" tag to the issue and PR templates
2. Points to the proper commit of the geos-chem-shared-docs documentation submodule.

This will be a zero-diff update.