### PR TITLE
Deprecate HEMCO_CESM preprocessor constant. Now use MODEL_CESM

### DIFF
--- a/src/Core/hco_types_mod.F90
+++ b/src/Core/hco_types_mod.F90
@@ -94,9 +94,9 @@ MODULE HCO_TYPES_MOD
      INTEGER                 :: HcoID      ! HEMCO species ID
      INTEGER                 :: ModID      ! Model species ID
      CHARACTER(LEN= 31)      :: SpcName    ! species names
-#ifdef HEMCO_CESM
+#ifdef MODEL_CESM
      INTEGER                 :: DimMax     ! Maximum dimensions supported: 2 (2-D), 3 (3-D)
-                                           ! HEMCO_CESM only, as 3-D emissions must be listed
+                                           ! CESM model only, as 3-D emissions must be listed
                                            ! in extfrc_list to be supported by CESM/CAM.
 #endif
   END TYPE ModSpc

--- a/src/Core/hcoio_read_std_mod.F90
+++ b/src/Core/hcoio_read_std_mod.F90
@@ -1354,7 +1354,7 @@ CONTAINS
 
        ! Note: This seems to be a soft restriction - removing this
        ! does not conflict with MESSy regridding. Need to check (hplin, 5/30/20)
-       ! This has to be used for WRF-GC and HEMCO_CESM so ifdefd out
+       ! This has to be used for WRF-GC and CESM so ifdefd out
 #endif
 
 #if defined( MODEL_WRF ) || defined( MODEL_CESM )


### PR DESCRIPTION
### Name and Institution (Required)

Name: Haipeng Lin
Institution: Harvard Univ.

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://hemco.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

Changes `HEMCO_CESM` pre-processor constant to `MODEL_CESM`.
We are deprecating the `HEMCO_CESM` pre-processor constant in preparation for merge of HEMCO into CESM. Now only `MODEL_CESM` is used.

### Expected changes

No model output changes are expected.

Thanks!
Haipeng