### PR TITLE
Bug fix: Allow mask files ending in ".$NC" not to be interpreted as a mask having no file

### DIFF
--- a/src/Core/hco_config_mod.F90
+++ b/src/Core/hco_config_mod.F90
@@ -2423,9 +2423,15 @@ CONTAINS
           ! IsLocTime flag to TRUE.  This should fix Github issue
           ! https://github.com/geoschem/HEMCO/issues/153.
           !  -- Bob Yantosca (12 Jul 2022)
-          IF ( INDEX( Lct%Dct%Dta%ncFile, ".nc" ) == 0 ) THEN
-             Lct%Dct%Dta%ncRead    = .FALSE.
-             Lct%Dct%Dta%IsLocTime = .TRUE.
+          !
+          ! Also allow for the .$NC replaceable token, see:
+          ! https://github.com/geoschem/HEMCO/issues/204
+          !  -- Melissa Sulprizio & Bob Yantosca (11 Apr 2023)
+          IF ( INDEX( Lct%Dct%Dta%ncFile,   ".nc" ) == 0 ) THEN
+             IF ( INDEX( Lct%Dct%Dta%ncFile, ".$NC" ) == 0 ) THEN
+                Lct%Dct%Dta%ncRead    = .FALSE.
+                Lct%Dct%Dta%IsLocTime = .TRUE.
+             ENDIF
           ENDIF
 
           ThisCover = CALC_COVERAGE( lon1,  lon2,  lat1,  lat2,              &


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://hemco.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

This is the companion PR to #204.  It prevents an error that halted TransportTracers simulations containing an ocean mask whose entry in `HEMCO_Config.rc` ending in `.$NC`.

### Expected changes

Without this fix, we get this error:

```console
At line 139 of file /n/holylfs05/LABS/jacob_lab/ryantosca/tests/tt/test_tt/CodeDir/src/HEMCO/src/Core/hco_chartools_mod.F90
Fortran runtime error: Bad real number in item 1 of list input

Error termination. Backtrace:
#0  0x2b3f00bc3c77 in read_real
        at /tmp/ryantosca/spack-stage/spack-stage-gcc-11.2.0-hbazyfn6aayq2jlpog7uck7w5xa5nmm4/spack-src/libgfortran/io/list_read.c:2026
#1  0x2b3f00bc4fec in list_formatted_read_scalar
        at /tmp/ryantosca/spack-stage/spack-stage-gcc-11.2.0-hbazyfn6aayq2jlpog7uck7w5xa5nmm4/spack-src/libgfortran/io/list_read.c:2180
#2  0x11f5ed8 in __hco_chartools_mod_MOD_hco_charsplit_r8
        at /n/holylfs05/LABS/jacob_lab/ryantosca/tests/tt/test_tt/CodeDir/src/HEMCO/src/Core/hco_chartools_mod.F90:139
#3  0x12a8103 in __hcoio_util_mod_MOD_getdatavals
        at /n/holylfs05/LABS/jacob_lab/ryantosca/tests/tt/test_tt/CodeDir/src/HEMCO/src/Core/hcoio_util_mod.F90:2779
#4  0x12acfab in __hcoio_util_mod_MOD_hcoio_readfromconfig
        at /n/holylfs05/LABS/jacob_lab/ryantosca/tests/tt/test_tt/CodeDir/src/HEMCO/src/Core/hcoio_util_mod.F90:2489
#5  0x12b4d76 in __hcoio_util_mod_MOD_hcoio_readother
        at /n/holylfs05/LABS/jacob_lab/ryantosca/tests/tt/test_tt/CodeDir/src/HEMCO/src/Core/hcoio_util_mod.F90:2188
#6  0x128bce5 in readlist_fill
        at /n/holylfs05/LABS/jacob_lab/ryantosca/tests/tt/test_tt/CodeDir/src/HEMCO/src/Core/hco_readlist_mod.F90:491
#7  0x128c8ee in __hco_readlist_mod_MOD_readlist_read
        at /n/holylfs05/LABS/jacob_lab/ryantosca/tests/tt/test_tt/CodeDir/src/HEMCO/src/Core/hco_readlist_mod.F90:288
#8  0x1234e8a in __hco_driver_mod_MOD_hco_run
        at /n/holylfs05/LABS/jacob_lab/ryantosca/tests/tt/test_tt/CodeDir/src/HEMCO/src/Core/hco_driver_mod.F90:165
#9  0x59c290 in __hco_interface_gc_mod_MOD_hcoi_gc_run
        at /n/holylfs05/LABS/jacob_lab/ryantosca/tests/tt/test_tt/CodeDir/src/GEOS-Chem/GeosCore/hco_interface_gc_mod.F90:999
#10  0x4e8795 in __emissions_mod_MOD_emissions_run
        at /n/holylfs05/LABS/jacob_lab/ryantosca/tests/tt/test_tt/CodeDir/src/GEOS-Chem/GeosCore/emissions_mod.F90:204
#11  0x406472 in geos_chem
        at /n/holylfs05/LABS/jacob_lab/ryantosca/tests/tt/test_tt/CodeDir/src/GEOS-Chem/Interfaces/GCClassic/main.F90:701
#12  0x40bde7 in main
        at /n/holylfs05/LABS/jacob_lab/ryantosca/tests/tt/test_tt/CodeDir/src/GEOS-Chem/Interfaces/GCClassic/main.F90:32
```

With this fix, we avoid the error.

### Reference(s)

If this is a science update, please provide a literature citation.

### Related Github Issue(s)

Closes #204 