### PR TITLE
Update tracer names in RnPbBe extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated GFED4 emission factors for VOCs to Andreae et al. (2019)
 - Refactored `hco_calc_mod.F90` to avoid computational bottlenecks (PR #201)
 - Restart files are now written to the rundir `Restarts/` subdirectory
-- Create a `Restarts/` subdirectory in HEMCO standalone run directories
+- Created a `Restarts/` subdirectory in HEMCO standalone run directories
+- Renamed Be7Strat and Be10Strat to Be7s and Be10s for consistency with GMAO's TR_GridComp
 
 ### Fixed
 - Do not read masks if the filename is `-` (non-ESMF environments only)

--- a/src/Extensions/hcox_gc_RnPbBe_mod.F90
+++ b/src/Extensions/hcox_gc_RnPbBe_mod.F90
@@ -75,16 +75,16 @@ MODULE HCOX_GC_RnPbBe_Mod
    INTEGER               :: ExtNrZhang    ! ZHANG_Rn222 extension number
    INTEGER               :: IDTRn222      ! Index # for Rn222
    INTEGER               :: IDTBe7        ! Index # for Be7
-   INTEGER               :: IDTBe7Strat   ! Index # for Be7Strat
+   INTEGER               :: IDTBe7s       ! Index # for Be7s
    INTEGER               :: IDTBe10       ! Index # for Be10
-   INTEGER               :: IDTBe10Strat  ! Index # for Be10Strat
+   INTEGER               :: IDTBe10s      ! Index # for Be10s
 
    ! For tracking Rn222, Be7, and Be10 emissions
-   REAL(hp), POINTER     :: EmissRn222    (:,:  )
-   REAL(hp), POINTER     :: EmissBe7      (:,:,:)
-   REAL(hp), POINTER     :: EmissBe7Strat (:,:,:)
-   REAL(hp), POINTER     :: EmissBe10     (:,:,:)
-   REAL(hp), POINTER     :: EmissBe10Strat(:,:,:)
+   REAL(hp), POINTER     :: EmissRn222(:,:  )
+   REAL(hp), POINTER     :: EmissBe7  (:,:,:)
+   REAL(hp), POINTER     :: EmissBe7s (:,:,:)
+   REAL(hp), POINTER     :: EmissBe10 (:,:,:)
+   REAL(hp), POINTER     :: EmissBe10s(:,:,:)
 
    ! For Lal & Peters 7Be emissions input data
    REAL(hp), POINTER     :: LATSOU(:    ) ! Array for latitudes
@@ -421,18 +421,18 @@ CONTAINS
           Inst%EmissBe7 (I,J,L) = ADD_Be7
           Inst%EmissBe10(I,J,L) = ADD_Be10
           IF ( L > ExtState%TropLev%Arr%Val(I,J) ) THEN
-             IF ( Inst%IDTBe7Strat > 0 ) THEN
-                Inst%EmissBe7Strat (I,J,L) = Add_Be7
+             IF ( Inst%IDTBe7s > 0 ) THEN
+                Inst%EmissBe7s (I,J,L) = Add_Be7
              ENDIF
-             IF ( Inst%IDTBe10Strat > 0 ) THEN
-                Inst%EmissBe10Strat(I,J,L) = Add_Be10
+             IF ( Inst%IDTBe10s > 0 ) THEN
+                Inst%EmissBe10s(I,J,L) = Add_Be10
              ENDIF
           ELSE
-             IF ( Inst%IDTBe7Strat > 0 ) THEN
-                Inst%EmissBe7Strat (I,J,L) = 0d0
+             IF ( Inst%IDTBe7s > 0 ) THEN
+                Inst%EmissBe7s (I,J,L) = 0d0
              ENDIF
-             IF ( Inst%IDTBe10Strat > 0 ) THEN
-                Inst%EmissBe10Strat(I,J,L) = 0d0
+             IF ( Inst%IDTBe10s > 0 ) THEN
+                Inst%EmissBe10s(I,J,L) = 0d0
              ENDIF
           ENDIF
 
@@ -459,14 +459,14 @@ CONTAINS
        ENDIF
 
        ! Add emissions
-       IF ( Inst%IDTBe7Strat > 0 ) THEN
-          Arr3D => Inst%EmissBe7Strat(:,:,:)
-          CALL HCO_EmisAdd( HcoState, Arr3D, Inst%IDTBe7Strat, &
+       IF ( Inst%IDTBe7s > 0 ) THEN
+          Arr3D => Inst%EmissBe7s(:,:,:)
+          CALL HCO_EmisAdd( HcoState, Arr3D, Inst%IDTBe7s, &
                             RC,       ExtNr=Inst%ExtNr )
           Arr3D => NULL()
           IF ( RC /= HCO_SUCCESS ) THEN
              CALL HCO_ERROR( &
-                             'HCO_EmisAdd error: EmissBe7Strat', RC )
+                             'HCO_EmisAdd error: EmissBe7s', RC )
              RETURN
           ENDIF
        ENDIF
@@ -485,14 +485,14 @@ CONTAINS
        ENDIF
 
        ! Add emissions
-       IF ( Inst%IDTBe10Strat > 0 ) THEN
-          Arr3D => Inst%EmissBe10Strat(:,:,:)
-          CALL HCO_EmisAdd( HcoState, Arr3D, Inst%IDTBe10Strat, &
+       IF ( Inst%IDTBe10s > 0 ) THEN
+          Arr3D => Inst%EmissBe10s(:,:,:)
+          CALL HCO_EmisAdd( HcoState, Arr3D, Inst%IDTBe10s, &
                             RC,       ExtNr=Inst%ExtNr )
           Arr3D => NULL()
           IF ( RC /= HCO_SUCCESS ) THEN
              CALL HCO_ERROR( &
-                             'HCO_EmisAdd error: EmissBe10Strat', RC )
+                             'HCO_EmisAdd error: EmissBe10s', RC )
              RETURN
           ENDIF
        ENDIF
@@ -626,12 +626,12 @@ CONTAINS
              Inst%IDTRn222     = HcoIDs(N)
           CASE( 'Be', 'Be7', '7Be' )
              Inst%IDTBe7       = HcoIDs(N)
-          CASE( 'Be7Strat', '7BeStrat' )
-             Inst%IDTBe7Strat  = HcoIDs(N)
+          CASE( 'Be7s', '7Bes' )
+             Inst%IDTBe7s  = HcoIDs(N)
           CASE( 'Be10', '10Be' )
              Inst%IDTBe10      = HcoIDs(N)
-          CASE( 'Be10Strat', '10BeStrat' )
-             Inst%IDTBe10Strat = HcoIDs(N)
+          CASE( 'Be10s', '10Bes' )
+             Inst%IDTBe10s = HcoIDs(N)
           CASE DEFAULT
              ! Do nothing
        END SELECT
@@ -718,15 +718,15 @@ CONTAINS
        CALL Init_7Be_Emissions( Inst )
     ENDIF
 
-    IF ( Inst%IDTBe7Strat > 0 ) THEN
-       ALLOCATE( Inst%EmissBe7Strat( HcoState%Nx, HcoState%NY, HcoState%NZ ), &
+    IF ( Inst%IDTBe7s > 0 ) THEN
+       ALLOCATE( Inst%EmissBe7s( HcoState%Nx, HcoState%NY, HcoState%NZ ), &
                  STAT=RC )
        IF ( RC /= 0 ) THEN
           CALL HCO_ERROR ( &
-                           'Cannot allocate EmissBe7Strat', RC )
+                           'Cannot allocate EmissBe7s', RC )
           RETURN
        ENDIF
-       Inst%EmissBe7Strat = 0.0_hp
+       Inst%EmissBe7s = 0.0_hp
     ENDIF
 
     IF ( Inst%IDTBe10 > 0 ) THEN
@@ -739,15 +739,15 @@ CONTAINS
        ENDIF
     ENDIF
 
-    IF ( Inst%IDTBe10Strat > 0 ) THEN
-       ALLOCATE( Inst%EmissBe10Strat( HcoState%Nx, HcoState%NY, HcoState%NZ ), &
+    IF ( Inst%IDTBe10s > 0 ) THEN
+       ALLOCATE( Inst%EmissBe10s( HcoState%Nx, HcoState%NY, HcoState%NZ ), &
                  STAT=RC )
        IF ( RC /= 0 ) THEN
           CALL HCO_ERROR ( &
-                           'Cannot allocate EmissBe10Strat', RC )
+                           'Cannot allocate EmissBe10s', RC )
           RETURN
        ENDIF
-       Inst%EmissBe10Strat = 0.0_hp
+       Inst%EmissBe10s = 0.0_hp
     ENDIF
 
     !=======================================================================
@@ -1318,20 +1318,20 @@ CONTAINS
        ENDIF
        Inst%EmissBe7 => NULL()
 
-       IF ( ASSOCIATED( Inst%EmissBe7Strat  ) ) THEN
-          DEALLOCATE( Inst%EmissBe7Strat )
+       IF ( ASSOCIATED( Inst%EmissBe7s  ) ) THEN
+          DEALLOCATE( Inst%EmissBe7s )
        ENDIF
-       Inst%EmissBe7Strat  => NULL()
+       Inst%EmissBe7s  => NULL()
 
        IF ( ASSOCIATED( Inst%EmissBe10 ) ) THEN
           DEALLOCATE(Inst%EmissBe10 )
        ENDIF
        Inst%EmissBe10  => NULL()
 
-       IF ( ASSOCIATED( Inst%EmissBe10Strat ) ) THEN
-          DEALLOCATE( Inst%EmissBe10Strat )
+       IF ( ASSOCIATED( Inst%EmissBe10s ) ) THEN
+          DEALLOCATE( Inst%EmissBe10s )
        ENDIF
-       Inst%EmissBe10Strat => NULL()
+       Inst%EmissBe10s => NULL()
 
        IF ( ASSOCIATED( Inst%LATSOU ) ) THEN
           DEALLOCATE( Inst%LATSOU  )


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard / GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://hemco.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

This is the companion pull request for https://github.com/geoschem/geos-chem/pull/1816 and should be merged in at the same time.

The Be7Strat and Be10Strat tracers are renamed to Be7s and Be10s for consistency with GMAO's tracer gridded component (TR_GridComp). These changes are also made in GEOS-Chem in the feature/update-transport-tracers branch.

### Expected changes

This is a zero difference update, simply renaming the stratospheric Be species.

### Related Github Issue(s)

- https://github.com/geoschem/geos-chem/pull/1816