### PR TITLE
Update HCO_WARNING arguments in MODEL_GEOS block to avoid GEOS build …

### DIFF
--- a/src/Extensions/hcox_dustdead_mod.F
+++ b/src/Extensions/hcox_dustdead_mod.F
@@ -5868,7 +5868,7 @@ c Fix up for negative argument, erf, etc.
       FNDLABEL = TRIM(CSLABEL) 
       IF ( .NOT. HcoState%Grid%AREA_M2%Alloc ) THEN
          MSG = 'Warning: AREA_M2 not found, will use default number'
-         CALL HCO_WARNING( MSG, RC, 1, LOC )
+         CALL HCO_WARNING( MSG, RC, .TRUE., LOC )
       ELSE
          AM2 = SUM(HcoState%Grid%AREA_M2%Val)/(HcoState%NX*HcoState%NY)
          RES = SQRT(AM2)


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Confirm you have reviewed the following documentation

- [X] [Contributing guidelines](https://hemco.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

This PR contains a change in a MODEL_GEOS block required for compatibility with HEMCO 3.7.0. The bug went under the radar during earlier testing because GEOS was not yet built with the updates. Note that the bug was introduced in 3.7.0 so the changelog does not need to be updated.

### Expected changes

This update is zero diff.

### Related Github Issue(s) and PRs

None since this PR fixes a bug before the official release in which it appears.

Somewhat related GEOS-Chem PR here, since GEOS-Chem 14.2.0 is meant to be used with HEMCO 3.7.0: https://github.com/geoschem/geos-chem/pull/1842
