### PR TITLE
Prevent run-time crash if using GEOSIT meteorolology directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - HEMCO extensions now display a first-time message, whether `Verbose` is `true` or `false`.
 - Added 'src/Shared/NcdfUtil/README.md` file directing users to look for netCDF utility scripts at https://github.com/geoschem/netcdf-scripts
 - Added GFED4 biomass burning emissions for furans, PHEN, MVK, ISOP, ACTA, MGLY, MYLX, RCHO
+- Add GEOSIT as an allowable meteorology directory name in HEMCO_Config.rc
 
 # Changed
 - `Verbose` is now a `true/false` variable in `run/HEMCO_sa_Config.rc` and `run/HEMCO_Config.rc.sample`

--- a/src/Core/hco_extlist_mod.F90
+++ b/src/Core/hco_extlist_mod.F90
@@ -1500,6 +1500,11 @@ CONTAINS
        DEF_MET_LC = 'merra2'
        DEF_CN_YR  = '2015'  ! Constant met fld year
        DEF_NC_VER = 'nc4'   ! NetCDF extension
+    ELSE IF ( TRIM(CF%MetField) == 'GEOSIT' ) THEN
+       DEF_MET_UC = 'GEOSIT'
+       DEF_MET_LC = 'geosit'
+       DEF_CN_YR  = '2011'  ! Constant met fld year
+       DEF_NC_VER = 'nc'   ! NetCDF extension
     ENDIF
 
     IF ( TRIM(CF%GridRes) == '4.0x5.0' ) THEN


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Confirm you have reviewed the following documentation

- [X] [Contributing guidelines](https://hemco.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

This PR makes updates to allow setting GEOSIT as possible met directory in `HEMCO_Config.rc` without the model crashing. This update facilitates in progress development to include GEOS-IT as a standard GEOS-Chem meteorology option.

### Expected changes

None

### Reference(s)

None

### Related Github Issue(s)

https://github.com/geoschem/geos-chem/pull/1846
