### PR TITLE
Print HEMCO verbose status and volcano extension on root thread only

### DIFF
--- a/src/Core/hco_config_mod.F90
+++ b/src/Core/hco_config_mod.F90
@@ -2177,7 +2177,7 @@ CONTAINS
        ELSE
           msg = NEW_LINE( 'A' ) // 'HEMCO verbose output is OFF'
        ENDIF
-       CALL HCO_Msg( msg, verb=.TRUE. )
+       IF ( HcoConfig%amIRoot ) CALL HCO_Msg( msg, verb=.TRUE. )
 
        ! Logfile to write into
        CALL GetExtOpt( HcoConfig, CoreNr, 'Logfile', &

--- a/src/Extensions/hcox_volcano_mod.F90
+++ b/src/Extensions/hcox_volcano_mod.F90
@@ -355,18 +355,21 @@ CONTAINS
     ! Extension Nr.
     ExtNr = GetExtNr( HcoState%Config%ExtList, TRIM(ExtName) )
 
-    IF ( ExtNr > 0 ) THEN
-       ! Write the name of the extension regardless of the verbose setting
-       msg = 'Using HEMCO extension: Volcano (volcanic SO2 emissions)'
-       IF ( HCO_IsVerb( HcoState%Config%Err ) ) THEN
-          CALL HCO_Msg( HcoState%Config%Err, msg, sep1='-' ) ! with separator
+    ! Print to log
+    IF ( HcoState%amIRoot ) THEN
+       IF ( ExtNr > 0 ) THEN
+          ! Write the name of the extension regardless of the verbose setting
+          msg = 'Using HEMCO extension: Volcano (volcanic SO2 emissions)'
+          IF ( HCO_IsVerb( HcoState%Config%Err ) ) THEN
+             CALL HCO_Msg( HcoState%Config%Err, msg, sep1='-' ) ! with separator
+          ELSE
+             CALL HCO_Msg( msg, verb=.TRUE.                   ) ! w/o separator
+          ENDIF
        ELSE
-          CALL HCO_Msg( msg, verb=.TRUE.                   ) ! w/o separator
+          MSG = 'The Volcano extension is turned off.'
+          CALL HCO_MSG( HcoState%Config%Err,  MSG )
+          RETURN
        ENDIF
-    ELSE
-       MSG = 'The Volcano extension is turned off.'
-       CALL HCO_MSG( HcoState%Config%Err,  MSG )
-       RETURN
     ENDIF
 
     ! Enter


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Confirm you have reviewed the following documentation

- [X] [Contributing guidelines](https://hemco.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

The message "HEMCO verbose output is OFF" is printed by every thread by default. This leads to excessive prints in the log file when running with lots of cores, such as in CESM , GCHP, and GEOS. This PR limits the status message to root thread only.

### Expected changes

Shorter log file.

### Reference(s)

None.

### Related Github Issue(s)

None. This bug is not present in any releases since it came in during 14.2.0 development.
