### PR TITLE
Update netCDF code (in src/Shared/NcdfUtil) to use the netCDF-F90 interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- NetCDF routines in `src/Shared/NcdfUtil` now use the Fortran-90 API
+
 ## [Unreleased 3.7.1] - TBD
 ### Changed
 - Updated version numbers to 3.7.1

--- a/src/Core/hcoio_write_std_mod.F90
+++ b/src/Core/hcoio_write_std_mod.F90
@@ -547,7 +547,7 @@ CONTAINS
                            VarUnit     = 'Pa',                            &
                            DataType    = dp,                              &
                            VarCt       = VarCt,                           &
-                           Compress    = .TRUE.                          )
+                           Compress    = .FALSE.                         )
           CALL NC_Var_Write( fId, 'P0', P0 )
 
           ! Deallocate arrays

--- a/src/Shared/NcdfUtil/hco_m_netcdf_io_checks.F90
+++ b/src/Shared/NcdfUtil/hco_m_netcdf_io_checks.F90
@@ -1,5 +1,5 @@
 !------------------------------------------------------------------------------
-!       NcdfUtilities: by Harvard Atmospheric Chemistry Modeling Group        !
+!       Ncdfutilities: by Harvard Atmospheric Chemistry Modeling Group        !
 !                      and NASA/GSFC, SIVO, Code 610.3                        !
 !------------------------------------------------------------------------------
 !BOP
@@ -44,9 +44,7 @@ CONTAINS
 !
   function Ncdoes_Udim_Exist (ncid)
 !
-    implicit none
-!
-    include "netcdf.inc"
+    use netCDF
 !
 ! !INPUT PARAMETERS:
 !!  ncid : netCDF file id to check
@@ -69,19 +67,12 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-    integer :: ierr
-    integer :: udimid
-!
-    ierr = Nf_Inq_Unlimdim (ncid, udimid)
+    integer :: ierr, udim_id
 
-    if (ierr == NF_NOERR) then
-       Ncdoes_Udim_Exist = .true.
-    else
-       Ncdoes_Udim_Exist = .false.
-    end if
-
-    return
-
+    Ncdoes_Udim_Exist = .false.
+    ierr = NF90_Inquire(ncid, unlimitedDimId=udim_id)
+    IF ( ierr /= NF90_NOERR ) Ncdoes_Udim_Exist = .true.
+       
   end function Ncdoes_Udim_Exist
 !EOC
 !------------------------------------------------------------------------------
@@ -96,9 +87,7 @@ CONTAINS
 !
   function Ncdoes_Var_Exist (ncid, varname)
 !
-    implicit none
-!
-    include "netcdf.inc"
+    use netCDF
 !
 ! !INPUT PARAMETERS:
 !!  ncid    : netCDF file id       to check
@@ -126,15 +115,9 @@ CONTAINS
     integer :: ierr
     integer :: varid
 !
-    ierr = Nf_Inq_Varid (ncid, varname, varid)
-
-    if (ierr == NF_NOERR) then
-       Ncdoes_Var_Exist = .true.
-    else
-       Ncdoes_Var_Exist = .false.
-    end if
-
-    return
+    ierr = NF90_Inq_Varid(ncid, varname, varid)
+    Ncdoes_Var_Exist = .false.
+    if (ierr == NF90_NOERR) Ncdoes_Var_Exist = .true.
 
   end function Ncdoes_Var_Exist
 !EOC
@@ -148,11 +131,9 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-  function Ncdoes_Attr_Exist (ncid, varname, attname, attType)
+  function Ncdoes_Attr_Exist(ncid, varname, attname, attType)
 !
-    implicit none
-!
-    include "netcdf.inc"
+    use netCDF
 !
 ! !INPUT PARAMETERS:
 !!  ncid    : netCDF file id       to check
@@ -185,26 +166,23 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-    integer :: ierr
-    integer :: varid
-    INTEGER :: attLen
+    INTEGER :: ierr, varId, attLen, attNum
 
     ! Init
     Ncdoes_Attr_Exist = .false.
     attType           = -1
 
     ! First check the variable
-    ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_Varid (ncid, varname, varid)
 
     ! Check the attribute if variable was found
-    IF ( ierr == NF_NOERR ) THEN
-       ierr = Nf_Inq_Att( ncId, varId, attName, attType, attLen )
-       IF ( ierr == NF_NOERR ) THEN
+    IF ( ierr == NF90_NOERR ) THEN
+       ierr = NF90_Inquire_Attribute( ncId,    varId,  attName,  &
+                                      attType, attLen, attNum   )
+       IF ( ierr == NF90_NOERR ) THEN
           NcDoes_Attr_Exist = .TRUE.
        ENDIF
     ENDIF
-
-    return
 
   end function Ncdoes_Attr_Exist
 !EOC
@@ -220,9 +198,7 @@ CONTAINS
 !
   function Ncdoes_Dim_Exist (ncid, dimname )
 !
-    implicit none
-!
-    include "netcdf.inc"
+    use netCDF
 !
 ! !INPUT PARAMETERS:
 !!  ncid    : netCDF file id        to check
@@ -251,14 +227,11 @@ CONTAINS
     integer :: dimid
 
     ! First check the variable
-    ierr = Nf_Inq_Dimid (ncid, dimname, dimid)
+    ierr = NF90_Inq_Dimid(ncid, dimname, dimid)
 
     ! Check the attribute if variable was found
-    if (ierr == NF_NOERR) then
-       Ncdoes_Dim_Exist = .true.
-    else
-       Ncdoes_Dim_Exist = .false.
-    end if
+    Ncdoes_Dim_Exist = .false.
+    if (ierr == NF90_NOERR) Ncdoes_Dim_Exist = .true.
 
     return
 

--- a/src/Shared/NcdfUtil/hco_m_netcdf_io_close.F90
+++ b/src/Shared/NcdfUtil/hco_m_netcdf_io_close.F90
@@ -44,11 +44,8 @@ CONTAINS
 !
 ! !USES:
 !
+    use netCDF
     use m_do_err_out
-!
-    implicit none
-!
-    include "netcdf.inc"
 !
 ! !INPUT PARAMETERS:
 !!  ncid : netCDF file id
@@ -70,10 +67,10 @@ CONTAINS
     character (len=512) :: err_msg
     integer             :: ierr
 !
-    ierr = Nf_Close (ncid)
+    ierr = Nf90_Close (ncid)
 
-    if (ierr /= NF_NOERR) then
-       err_msg = 'In Nccl:  ' // Nf_Strerror (ierr)
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Nccl:  ' // Nf90_Strerror (ierr)
        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
     end if
 
@@ -93,9 +90,7 @@ CONTAINS
 !
   subroutine Nccl_Noerr (ncid)
 !
-    implicit none
-!
-    include "netcdf.inc"
+    use netCDF
 !
 ! !INPUT PARAMETERS:
 !!  ncid : netCDF file id
@@ -117,7 +112,7 @@ CONTAINS
 ! !LOCAL VARIABLES:
     integer             :: ierr
 !
-    ierr = Nf_Close (ncid)
+    ierr = Nf90_Close (ncid)
 
     return
 

--- a/src/Shared/NcdfUtil/hco_m_netcdf_io_create.F90
+++ b/src/Shared/NcdfUtil/hco_m_netcdf_io_create.F90
@@ -44,18 +44,15 @@ CONTAINS
 !
 ! !USES:
 !
+    use netCDF
     use m_do_err_out
-!
-    implicit none
-!
-    include "netcdf.inc"
 !
 ! !INPUT PARAMETERS:
 !   ncid    : opened netCDF file id
 !   filname : name of netCDF file to open for writing
-    integer          , intent(in)   :: ncid
-    character (len=*), intent(in)   :: filname
-    LOGICAL, OPTIONAL, INTENT(IN)   :: WRITE_NC4
+    integer          , intent(INOUT) :: ncid
+    character (len=*), intent(IN)    :: filname
+    LOGICAL, OPTIONAL, INTENT(IN)    :: WRITE_NC4
 !
 ! !DESCRIPTION: Creates a netCDF file for writing and does some error checking.
 !\\
@@ -64,10 +61,10 @@ CONTAINS
 !  John Tannahill (LLNL) and Jules Kouatchou
 !
 ! !REMARKS:
-!  If the netCDF4 library is used, then the NF_CLOBBER flag will write
+!  If the netCDF4 library is used, then the NF90_CLOBBER flag will write
 !  a classic (i.e. netCDF3) file.  Use OR(NF_NETCDF4,NF_CLASSIC_MODEL) to
-!  create netCDF-4 file that supports compression and uses "classic" netcdf data model
-!  (no groups, no user-defined types)
+!  create netCDF-4 file that supports compression and uses "classic" 
+!  netcdf data model (no groups, no user-defined types)
 !
 ! !REVISION HISTORY:
 !  See https://github.com/geoschem/ncdfutil for complete history
@@ -91,17 +88,17 @@ CONTAINS
 
     IF ( TMP_NC4 ) THEN
 #if defined( NC_HAS_COMPRESSION )
-       mode = IOR( NF_NETCDF4, NF_CLASSIC_MODEL )         ! netCDF4 file
-       ierr = Nf_Create (filname, mode, ncid)             !  w/ compression
+       mode = IOR( NF90_NETCDF4, NF90_CLASSIC_MODEL )       ! netCDF4 file
+       ierr = NF90_Create(filname, mode, ncid)              !  w/ compression
 #else
-       ierr = Nf_Create (filname, NF_64BIT_OFFSET, ncid)  ! netCDF4 file
-                                                          !  w/o compression
+       ierr = NF90_Create(filname, NF90_64BIT_OFFSET, ncid) ! netCDF4 file
+                                                            !  w/o compression
 #endif
     ELSE
-       ierr = Nf_Create (filname, NF_CLOBBER, ncid)       ! netCDF3 file
+       ierr = NF90_Create(filname, NF90_CLOBBER, ncid)      ! netCDF3 file
     ENDIF
 
-    if (ierr /= NF_NOERR) then
+    if (ierr /= NF90_NOERR) then
        err_msg = 'In Nccr_Wr, cannot create:  ' // Trim (filname)
        call Do_Err_Out (err_msg, .true., 0, 0, 0, 0 , 0.0d0, 0.0d0)
     end if
@@ -120,15 +117,12 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-  subroutine Ncdo_Sync (ncid)
+  subroutine Ncdo_Sync(ncid)
 !
 ! !USES:
 !
+    use netCDF
     use m_do_err_out
-!
-    implicit none
-!
-    include "netcdf.inc"
 !
 ! !INPUT PARAMETERS:
 !!  ncid : netCDF file id
@@ -150,14 +144,12 @@ CONTAINS
     character (len=128) :: err_msg
     integer             :: ierr
 !
-    ierr = Nf_Sync (ncid)
+    ierr = Nf90_Sync (ncid)
 
-    if (ierr /= NF_NOERR) then
-       err_msg = 'In Ncdo_Sync:  ' // Nf_Strerror (ierr)
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncdo_Sync:  ' // Nf90_Strerror (ierr)
        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
     end if
-
-    return
 
   end subroutine Ncdo_Sync
 !EOC

--- a/src/Shared/NcdfUtil/hco_m_netcdf_io_get_dimlen.F90
+++ b/src/Shared/NcdfUtil/hco_m_netcdf_io_get_dimlen.F90
@@ -40,15 +40,12 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-  subroutine Ncget_Dimlen (ncid, dim_name, dim_len )
+  subroutine Ncget_Dimlen(ncid, dim_name, dim_len)
 !
 ! !USES:
 !
+    use netCDF
     use m_do_err_out
-!
-    implicit none
-!
-    include 'netcdf.inc'
 !
 ! !INPUT PARAMETERS:
 !!  dim_name : netCDF dimension name
@@ -80,18 +77,18 @@ CONTAINS
     integer             :: dimid
     integer             :: ierr
 
-    ierr = Nf_Inq_Dimid  (ncid, dim_name, dimid)
+    ierr = NF90_Inq_Dimid(ncid, dim_name, dimid)
 
-    if (ierr /= NF_NOERR ) then
+    if (ierr /= NF90_NOERR ) then
        err_msg = 'In Ncget_Dimlen #1:  ' // Trim (dim_name) // &
-                 ', ' // Nf_Strerror (ierr)
+                 ', ' // NF90_Strerror (ierr)
        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
     end if
 
-    ierr = Nf_Inq_Dimlen (ncid, dimid, dim_len)
+    ierr = NF90_Inquire_Dimension(ncid, dimid, len=dim_len)
 
-    if (ierr /= NF_NOERR) then
-       err_msg = 'In Ncget_Dimlen #2:  ' // Nf_Strerror (ierr)
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncget_Dimlen #2:  ' // NF90_Strerror (ierr)
        call Do_Err_Out (err_msg, .true., 2, ncid, dimid, 0, 0.0d0, 0.0d0)
     end if
 
@@ -112,11 +109,8 @@ CONTAINS
 !
 ! !USES:
 !
+    use netCDF
     use m_do_err_out
-!
-    implicit none
-!
-    include 'netcdf.inc'
 !
 ! !INPUT PARAMETERS:
 !!  ncid     : netCDF file id
@@ -139,25 +133,14 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-    character (len=512) :: err_msg
-    integer             :: ierr
-    integer             :: udimid
-!
-    ierr = Nf_Inq_Unlimdim (ncid, udimid)
+    character(len=512) :: err_msg
+    integer            :: ierr, udim_id
 
-    if (ierr /= NF_NOERR) then
-       err_msg = 'In Ncget_Unlim_Dimlen #1:  ' // Nf_Strerror (ierr)
-       call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-    end if
-
-    ierr = Nf_Inq_Dimlen (ncid, udimid, udim_len)
-
-    if (ierr /= NF_NOERR) then
-       err_msg = 'In Ncget_Unlim_Dimlen #2:  ' // Nf_Strerror (ierr)
-       call Do_Err_Out (err_msg, .true., 2, ncid, udimid, 0, 0.0d0, 0.0d0)
-    end if
-
-    return
+    udim_len = -1
+    ierr = NF90_Inquire(ncid, unlimitedDimId=udim_id)
+    IF ( ierr /= NF90_NOERR ) THEN
+       ierr = NF90_Inquire_Dimension( ncid, udim_id, len=udim_len )
+    ENDIF
 
   end subroutine Ncget_Unlim_Dimlen
 !EOC

--- a/src/Shared/NcdfUtil/hco_m_netcdf_io_handle_err.F90
+++ b/src/Shared/NcdfUtil/hco_m_netcdf_io_handle_err.F90
@@ -43,11 +43,8 @@ CONTAINS
 !
 ! !USES:
 !
+    use netCDF
     use m_do_err_out
-!
-    implicit none
-!
-    include "netcdf.inc"
 !
 ! !INPUT PARAMETERS:
 !   ierr : netCDF error number
@@ -68,7 +65,7 @@ CONTAINS
 ! !LOCAL VARIABLES:
     character (len=512) :: err_msg
 !
-    err_msg = 'In Nchandle_Err:  ' // Nf_Strerror (ierr)
+    err_msg = 'In Nchandle_Err:  ' // Nf90_Strerror (ierr)
 
     call Do_Err_Out (err_msg, .true., 0, 0, 0, 0, 0.0d0, 0.0d0)
 

--- a/src/Shared/NcdfUtil/hco_m_netcdf_io_open.F90
+++ b/src/Shared/NcdfUtil/hco_m_netcdf_io_open.F90
@@ -40,15 +40,12 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-  subroutine Ncop_Rd (ncid, filname)
+  subroutine Ncop_Rd (ncid, filname, rc)
 !
 ! !USES:
 !
+    USE netCDF
     use m_do_err_out
-!
-    implicit none
-!
-    include "netcdf.inc"
 !
 ! !INPUT PARAMETERS:
 !!  filname : name of netCDF file to open for reading
@@ -57,6 +54,7 @@ CONTAINS
 ! !OUTPUT PARAMETERS:
 !!  ncid    : opened netCDF file id
     integer          , intent (out)   :: ncid
+    integer, optional                 :: rc
 !
 ! !DESCRIPTION: Opens a netCDF file for reading and does some error checking.
 !\\
@@ -71,14 +69,15 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-    character (len=512) :: err_msg
-    integer             :: ierr
+    character(len=512) :: err_msg
+    integer            :: ierr
 !
-    ierr = Nf_Open (filname, NF_NOWRITE, ncid)
+    ierr = Nf90_Open( filname, NF90_NOWRITE, ncid )
 
-    if (ierr /= NF_NOERR) then
+    if (ierr /= NF90_NOERR) then
        err_msg = 'In Ncop_Rd, cannot open:  ' // Trim (filname)
        call Do_Err_Out (err_msg, .true., 0, 0, 0, 0, 0.0d0, 0.0d0)
+       return
     end if
 
     return
@@ -99,11 +98,8 @@ CONTAINS
 !
 ! !USES:
 !
+    USE netCDF
     use m_do_err_out
-!
-    implicit none
-!
-    include "netcdf.inc"
 !
 ! !INPUT PARAMETERS:
 !!  filname : name of netCDF file to open for reading
@@ -130,9 +126,9 @@ CONTAINS
     character (len=512) :: err_msg
     integer             :: ierr
 !
-    ierr = Nf_Open (filname, NF_WRITE, ncid)
+    ierr = Nf90_Open (filname, NF90_WRITE, ncid)
 
-    if (ierr /= NF_NOERR) then
+    if (ierr /= NF90_NOERR) then
        err_msg = 'In Ncop_Rd, cannot open:  ' // Trim (filname)
        call Do_Err_Out (err_msg, .true., 0, 0, 0, 0, 0.0d0, 0.0d0)
     end if

--- a/src/Shared/NcdfUtil/hco_m_netcdf_io_read.F90
+++ b/src/Shared/NcdfUtil/hco_m_netcdf_io_read.F90
@@ -8,44 +8,44 @@
 !
 ! !INTERFACE:
 !
-      MODULE HCO_m_netcdf_io_read
+MODULE HCO_m_netcdf_io_read
 !
 ! !USES:
 !
-      IMPLICIT NONE
-      PRIVATE
+  IMPLICIT NONE
+  PRIVATE
 !
 ! !PUBLIC MEMBER FUNCTIONS:
 !
-      ! Public interface
-      PUBLIC :: NcRd
+  ! Public interface
+  PUBLIC :: NcRd
 
-      ! Private methods overloaded by public interface
-      ! (see below for info about these routines & the arguments they take)
-      INTERFACE NcRd
-         MODULE PROCEDURE Ncrd_Scal
-         MODULE PROCEDURE Ncrd_Scal_Int
-         MODULE PROCEDURE Ncrd_1d_R8
-         MODULE PROCEDURE Ncrd_1d_R4
-         MODULE PROCEDURE Ncrd_1d_Int
-         MODULE PROCEDURE Ncrd_1d_Char
-         MODULE PROCEDURE Ncrd_2d_R8
-         MODULE PROCEDURE Ncrd_2d_R4
-         MODULE PROCEDURE Ncrd_2d_Int
-         MODULE PROCEDURE Ncrd_2d_Char
-         MODULE PROCEDURE Ncrd_3d_R8
-         MODULE PROCEDURE Ncrd_3d_R4
-         MODULE PROCEDURE Ncrd_3d_Int
-         MODULE PROCEDURE Ncrd_4d_R8
-         MODULE PROCEDURE Ncrd_4d_R4
-         MODULE PROCEDURE Ncrd_4d_Int
-         MODULE PROCEDURE Ncrd_5d_R8
-         MODULE PROCEDURE Ncrd_5d_R4
-         MODULE PROCEDURE Ncrd_6d_R8
-         MODULE PROCEDURE Ncrd_6d_R4
-         MODULE PROCEDURE Ncrd_7d_R8
-         MODULE PROCEDURE Ncrd_7d_R4
-      END INTERFACE
+  ! Private methods overloaded by public interface
+  ! (see below for info about these routines & the arguments they take)
+  INTERFACE NcRd
+     MODULE PROCEDURE Ncrd_Scal
+     MODULE PROCEDURE Ncrd_Scal_Int
+     MODULE PROCEDURE Ncrd_1d_R8
+     MODULE PROCEDURE Ncrd_1d_R4
+     MODULE PROCEDURE Ncrd_1d_Int
+     MODULE PROCEDURE Ncrd_1d_Char
+     MODULE PROCEDURE Ncrd_2d_R8
+     MODULE PROCEDURE Ncrd_2d_R4
+     MODULE PROCEDURE Ncrd_2d_Int
+     MODULE PROCEDURE Ncrd_2d_Char
+     MODULE PROCEDURE Ncrd_3d_R8
+     MODULE PROCEDURE Ncrd_3d_R4
+     MODULE PROCEDURE Ncrd_3d_Int
+     MODULE PROCEDURE Ncrd_4d_R8
+     MODULE PROCEDURE Ncrd_4d_R4
+     MODULE PROCEDURE Ncrd_4d_Int
+     MODULE PROCEDURE Ncrd_5d_R8
+     MODULE PROCEDURE Ncrd_5d_R4
+     MODULE PROCEDURE Ncrd_6d_R8
+     MODULE PROCEDURE Ncrd_6d_R4
+     MODULE PROCEDURE Ncrd_7d_R8
+     MODULE PROCEDURE Ncrd_7d_R4
+  END INTERFACE NcRd
 !
 ! !DESCRIPTION: Routines for reading variables in a netCDF file.
 !\\
@@ -67,25 +67,22 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncrd_Scal (varrd_scal, ncid, varname)
+  subroutine Ncrd_Scal(varrd_scal, ncid, varname)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid       : netCDF file id to read variable from
-!!    varname    : netCDF variable name
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
+!!  ncid       : netCDF file id to read variable from
+!!  varname    : netCDF variable name
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
 !
 ! !OUTPUT PARAMETERS:
-!!    varrd_scal : variable to fill
-      real*8           , intent(out)  :: varrd_scal
+!!  varrd_scal : variable to fill
+    real*8           , intent(out)  :: varrd_scal
 !
 ! !DESCRIPTION: Reads in a netCDF scalar variable.
 !\\
@@ -100,31 +97,31 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
-      real*4              :: varrd_scal_tmp
+    character (len=512) :: err_msg
+    integer             :: ierr
+    integer             :: varid
+    real*4              :: varrd_scal_tmp
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_Scal #1:  ' // Trim (varname) // &
-                 ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_Scal #1:  ' // Trim (varname) // &
+            ', ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Get_Var_Real   (ncid, varid, varrd_scal_tmp)
+    ierr = NF90_Get_Var(ncid, varid, varrd_scal_tmp)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_Scal #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_Scal #2:  ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
+    
+    varrd_scal = varrd_scal_tmp
 
-      varrd_scal = varrd_scal_tmp
+    return
 
-      return
-
-      end subroutine Ncrd_Scal
+  end subroutine Ncrd_Scal
 !EOC
 !-------------------------------------------------------------------------
 !BOP
@@ -133,25 +130,22 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncrd_Scal_Int (varrd_scali, ncid, varname)
+  subroutine Ncrd_Scal_Int(varrd_scali, ncid, varname)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid       : netCDF file id to read variable from
-!!    varname    : netCDF variable name
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
+!!  ncid       : netCDF file id to read variable from
+!!  varname    : netCDF variable name
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
 !
 ! !OUTPUT PARAMETERS:
-!!    varrd_scali : integer variable to fill
-      integer          , intent(out)  :: varrd_scali
+!!  varrd_scali : integer variable to fill
+    integer          , intent(out)  :: varrd_scali
 !
 ! !DESCRIPTION: Reads in a netCDF integer scalar variable.
 !\\
@@ -166,28 +160,28 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character (len=512) :: err_msg
+    integer             :: ierr
+    integer             :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_Scal_Int #1:  ' // Trim (varname) // &
-                  ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_Scal_Int #1:  ' // Trim (varname) // &
+                 ', ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
+    
+    ierr = NF90_Get_Var(ncid, varid, varrd_scali)
 
-      ierr = Nf_Get_Var_Int (ncid, varid, varrd_scali)
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_Scal_Int #2:  ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_Scal_Int #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    return
 
-      return
-
-      end subroutine Ncrd_Scal_Int
+  end subroutine Ncrd_Scal_Int
 !EOC
 !-------------------------------------------------------------------------
 !BOP
@@ -196,33 +190,29 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncrd_1d_R8 (varrd_1d, ncid, varname, strt1d, cnt1d,   &
-                             err_stop, stat)
+  subroutine Ncrd_1d_R8(varrd_1d, ncid, varname, strt1d, cnt1d, err_stop, stat)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to read array input data from
-!!    varname  : netCDF variable name for array
-!!    strt1d   : vector specifying the index in varrd_1d where
-!!               the first of the data values will be read
-!!    cnt1d    : varrd_1d dimension
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt1d(1)
-      integer          , intent(in)   :: cnt1d (1)
-      logical, optional, intent(in)   :: err_stop
+!!  ncid     : netCDF file id to read array input data from
+!!  varname  : netCDF variable name for array
+!!  strt1d   : vector specifying the index in varrd_1d where
+!!             the first of the data values will be read
+!!  cnt1d    : varrd_1d dimension
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
+    integer          , intent(in)   :: strt1d(1)
+    integer          , intent(in)   :: cnt1d (1)
+    logical, optional, intent(in)   :: err_stop
 !
 ! !OUTPUT PARAMETERS:
-!!    varrd_1d : array to fill
-      real*8           , intent(out)  :: varrd_1d(cnt1d(1))
-      integer, optional, intent(out)  :: stat
+!!  varrd_1d : array to fill
+    real*8           , intent(out)  :: varrd_1d(cnt1d(1))
+    integer, optional, intent(out)  :: stat
 !
 ! !DESCRIPTION: Reads in a 1D netCDF real array and does some error checking.
 !\\
@@ -238,49 +228,49 @@ CONTAINS
 !
 ! !LOCAL VARIABLES:
 !
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
-      logical             :: dostop
+    character (len=512) :: err_msg
+    integer             :: ierr
+    integer             :: varid
+    logical             :: dostop
 
-      ! set dostop flag
-      if ( present ( err_stop ) ) then
-        dostop = err_stop
-      else
-        dostop = .true.
-      endif
+    ! set dostop flag
+    if ( present ( err_stop ) ) then
+       dostop = err_stop
+    else
+       dostop = .true.
+    endif
 
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        if ( dostop ) then
+    if (ierr /= NF90_NOERR) then
+       if ( dostop ) then
           err_msg = 'In Ncrd_1d_R8 #1:  ' // Trim (varname) // &
-                     ', ' // Nf_Strerror (ierr)
+               ', ' // NF90_Strerror(ierr)
           call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-        else
+       else
           varrd_1d(:) = -999d0
           if ( present ( stat ) ) stat = 1
           return
-        end if
-      end if
-
-      ierr =  Nf_Get_Vara_Double (ncid, varid, strt1d, cnt1d, varrd_1d)
-
-      if (ierr /= NF_NOERR) then
-        if ( dostop ) then
-          err_msg = 'In Ncrd_1d_R8 #2:  ' // Nf_Strerror (ierr)
+       end if
+    end if
+    
+    ierr =  NF90_Get_Var(ncid, varid, varrd_1d, start=strt1d, count=cnt1d)
+    
+    if (ierr /= NF90_NOERR) then
+       if ( dostop ) then
+          err_msg = 'In Ncrd_1d_R8 #2:  ' // NF90_Strerror(ierr)
           call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-        else
+       else
           varrd_1d(:) = -999d0
           if ( present ( stat ) ) stat = 2
           return
-        endif
-      end if
-
-      ! set stat to 0 (= success)
-      if ( present ( stat ) ) stat = 0
-
-      end subroutine Ncrd_1d_R8
+       endif
+    end if
+    
+    ! set stat to 0 (= success)
+    if ( present ( stat ) ) stat = 0
+    
+  end subroutine Ncrd_1d_R8
 !EOC
 !-------------------------------------------------------------------------
 !BOP
@@ -289,33 +279,29 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncrd_1d_R4 (varrd_1d, ncid, varname, strt1d, cnt1d, &
-                             err_stop, stat)
+  subroutine Ncrd_1d_R4(varrd_1d, ncid, varname, strt1d, cnt1d, err_stop, stat)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to read array input data from
-!!    varname  : netCDF variable name for array
-!!    strt1d   : vector specifying the index in varrd_1d where
-!!               the first of the data values will be read
-!!    cnt1d    : varrd_1d dimension
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt1d(1)
-      integer          , intent(in)   :: cnt1d (1)
-      logical, optional, intent(in)   :: err_stop
+!!  ncid     : netCDF file id to read array input data from
+!!  varname  : netCDF variable name for array
+!!  strt1d   : vector specifying the index in varrd_1d where
+!!             the first of the data values will be read
+!!  cnt1d    : varrd_1d dimension
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
+    integer          , intent(in)   :: strt1d(1)
+    integer          , intent(in)   :: cnt1d (1)
+    logical, optional, intent(in)   :: err_stop
 !
 ! !OUTPUT PARAMETERS:
-!!    varrd_1d : array to fill
-      real*4           , intent(out)  :: varrd_1d(cnt1d(1))
-      integer, optional, intent(out)  :: stat
+!!  varrd_1d : array to fill
+    real*4           , intent(out)  :: varrd_1d(cnt1d(1))
+    integer, optional, intent(out)  :: stat
 !
 ! !DESCRIPTION: Reads in a 1D netCDF real array and does some error checking.
 !\\
@@ -331,50 +317,50 @@ CONTAINS
 !
 ! !LOCAL VARIABLES:
 !
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
-      logical             :: dostop
+    character (len=512) :: err_msg
+    integer             :: ierr
+    integer             :: varid
+    logical             :: dostop
 
-      ! set dostop flag
-      if ( present ( err_stop ) ) then
-        dostop = err_stop
-      else
-        dostop = .true.
-      endif
+    ! set dostop flag
+    if ( present ( err_stop ) ) then
+       dostop = err_stop
+    else
+       dostop = .true.
+    endif
 
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        if ( dostop ) then
-           err_msg = 'In Ncrd_1d_R4 #1:  ' // Trim (varname) // &
-                      ', ' // Nf_Strerror (ierr)
-           call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-        else
+    if (ierr /= NF90_NOERR) then
+       if ( dostop ) then
+          err_msg = 'In Ncrd_1d_R4 #1:  ' // Trim (varname) // &
+                     ', ' // NF90_Strerror(ierr)
+          call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+       else
           varrd_1d(:) = -999.0
           if ( present ( stat ) ) stat = 1
           return
-        end if
-      end if
+       end if
+    end if
 
-      ierr =  Nf_Get_Vara_Real (ncid, varid, strt1d, cnt1d, varrd_1d)
+    ierr =  NF90_Get_Var(ncid, varid, varrd_1d, start=strt1d, count=cnt1d)
 
-      if (ierr /= NF_NOERR) then
-        if ( dostop ) then
-          err_msg = 'In Ncrd_1d_R4 #2:  ' // Nf_Strerror (ierr)
+    if (ierr /= NF90_NOERR) then
+       if ( dostop ) then
+          err_msg = 'In Ncrd_1d_R4 #2:  ' // NF90_Strerror(ierr)
           call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-        else
+       else
           varrd_1d(:) = -999.0
           if ( present ( stat ) ) stat = 2
           return
-        endif
-      end if
+       endif
+    end if
 
-      ! set stat to 0 (= success)
-      if ( present ( stat ) ) stat = 0
-      return
+    ! set stat to 0 (= success)
+    if ( present ( stat ) ) stat = 0
+    return
 
-      end subroutine Ncrd_1d_R4
+  end subroutine Ncrd_1d_R4
 !EOC
 !-------------------------------------------------------------------------
 !BOP
@@ -383,34 +369,31 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncrd_1d_Int (varrd_1di, ncid, varname, strt1d, cnt1d, &
-                              err_stop, stat)
+  subroutine Ncrd_1d_Int(varrd_1di, ncid,     varname, strt1d, &
+                         cnt1d,     err_stop, stat)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
 !
-!!    ncid     : netCDF file id to read array input data from
-!!    varname  : netCDF variable name for array
-!!    strt1d   : vector specifying the index in varrd_1di where
-!!               the first of the data values will be read
-!!    cnt1d    : varrd_1di dimension
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt1d(1)
-      integer          , intent(in)   :: cnt1d (1)
-      logical, optional, intent(in)   :: err_stop
+!!  ncid     : netCDF file id to read array input data from
+!!  varname  : netCDF variable name for array
+!!  strt1d   : vector specifying the index in varrd_1di where
+!!             the first of the data values will be read
+!!  cnt1d    : varrd_1di dimension
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
+    integer          , intent(in)   :: strt1d(1)
+    integer          , intent(in)   :: cnt1d (1)
+    logical, optional, intent(in)   :: err_stop
 !
 ! !OUTPUT PARAMETERS:
-!!    varrd_1di : intger array to fill
-      integer          , intent(out)  :: varrd_1di(cnt1d(1))
-      integer, optional, intent(out)  :: stat
+!!  varrd_1di : intger array to fill
+    integer          , intent(out)  :: varrd_1di(cnt1d(1))
+    integer, optional, intent(out)  :: stat
 !
 ! !DESCRIPTION: Reads in a 1D netCDF integer array and does some error
 !  checking.
@@ -427,51 +410,51 @@ CONTAINS
 !
 ! !LOCAL VARIABLES:
 !
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
-      logical             :: dostop
+    character (len=512) :: err_msg
+    integer             :: ierr
+    integer             :: varid
+    logical             :: dostop
 
-      ! set dostop flag
-      if ( present ( err_stop ) ) then
-        dostop = err_stop
-      else
-        dostop = .true.
-      endif
+    ! set dostop flag
+    if ( present ( err_stop ) ) then
+       dostop = err_stop
+    else
+       dostop = .true.
+    endif
 
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        if ( dostop ) then
+    if (ierr /= NF90_NOERR) then
+       if ( dostop ) then
           err_msg = 'In Ncrd_1d_Int #1:  ' // Trim (varname) // &
-                    ', ' // Nf_Strerror (ierr)
+                    ', ' // NF90_Strerror(ierr)
           call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-        else
+       else
           varrd_1di(:) = -999
           if ( present ( stat ) ) stat = 1
           return
-        end if
-      end if
+       end if
+    end if
 
-      ierr = Nf_Get_Vara_Int (ncid, varid, strt1d, cnt1d, varrd_1di)
+    ierr = NF90_Get_Var(ncid, varid, varrd_1di, start=strt1d, count=cnt1d)
 
-      if (ierr /= NF_NOERR) then
-        if ( dostop ) then
-          err_msg = 'In Ncrd_1d_Int #2:  ' // Nf_Strerror (ierr)
+    if (ierr /= NF90_NOERR) then
+       if ( dostop ) then
+          err_msg = 'In Ncrd_1d_Int #2:  ' // NF90_Strerror(ierr)
           call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-        else
+       else
           varrd_1di(:) = -999
           if ( present ( stat ) ) stat = 2
           return
-        endif
-      end if
+       endif
+    end if
 
-      ! set stat to 0 (= success)
-      if ( present ( stat ) ) stat = 0
+    ! set stat to 0 (= success)
+    if ( present ( stat ) ) stat = 0
 
-      return
+    return
 
-      end subroutine Ncrd_1d_Int
+  end subroutine Ncrd_1d_Int
 !EOC
 !-------------------------------------------------------------------------
 !BOP
@@ -480,30 +463,26 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncrd_2d_R8 (varrd_2d, ncid, varname, strt2d, cnt2d)
+  subroutine Ncrd_2d_R8(varrd_2d, ncid, varname, strt2d, cnt2d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
-!
-! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to read array input data from
-!!    varname  : netCDF variable name for array
-!!    strt2d   : vector specifying the index in varrd_2d where
+    use netCDF
+    use m_do_err_out
+
+!!  ncid     : netCDF file id to read array input data from
+!!  varname  : netCDF variable name for array
+!!  strt2d   : vector specifying the index in varrd_2d where
 !!               the first of the data values will be read
-!!    cnt2d    : varrd_2d dimensions
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt2d(2)
-      integer          , intent(in)   :: cnt2d (2)
+!!  cnt2d    : varrd_2d dimensions
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
+    integer          , intent(in)   :: strt2d(2)
+    integer          , intent(in)   :: cnt2d (2)
 !
 ! !OUTPUT PARAMETERS:
-!!    varrd_2d : array to fill
-      real*8           , intent(out)  :: varrd_2d(cnt2d(1), cnt2d(2))
+!!  varrd_2d : array to fill
+    real*8           , intent(out)  :: varrd_2d(cnt2d(1), cnt2d(2))
 !
 ! !DESCRIPTION: Reads in a 2D netCDF real array and does some error checking.
 !\\
@@ -518,26 +497,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character (len=512) :: err_msg
+    integer             :: ierr
+    integer             :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_2d_R8 #1:  ' // Trim (varname) // &
-                  ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_2d_R8 #1:  ' // Trim (varname) // &
+                 ', ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Get_Vara_Double (ncid, varid, strt2d, cnt2d, varrd_2d)
+    ierr = NF90_Get_Var(ncid, varid, varrd_2d, start=strt2d, count=cnt2d)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_2d_R8 #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_2d_R8 #2:  ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      end subroutine Ncrd_2d_R8
+  end subroutine Ncrd_2d_R8
 !EOC
 !-------------------------------------------------------------------------
 !BOP
@@ -546,30 +525,27 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncrd_2d_R4 (varrd_2d, ncid, varname, strt2d, cnt2d)
+  subroutine Ncrd_2d_R4(varrd_2d, ncid, varname, strt2d, cnt2d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to read array input data from
-!!    varname  : netCDF variable name for array
-!!    strt2d   : vector specifying the index in varrd_2d where
-!!               the first of the data values will be read
-!!    cnt2d    : varrd_2d dimensions
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt2d(2)
-      integer          , intent(in)   :: cnt2d (2)
+!!  ncid     : netCDF file id to read array input data from
+!!  varname  : netCDF variable name for array
+!!  strt2d   : vector specifying the index in varrd_2d where
+!!             the first of the data values will be read
+!!  cnt2d    : varrd_2d dimensions
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
+    integer          , intent(in)   :: strt2d(2)
+    integer          , intent(in)   :: cnt2d (2)
 !
 ! !OUTPUT PARAMETERS:
-!!    varrd_2d : array to fill
-      real*4           , intent(out)  :: varrd_2d(cnt2d(1), cnt2d(2))
+!!  varrd_2d : array to fill
+    real*4           , intent(out)  :: varrd_2d(cnt2d(1), cnt2d(2))
 !
 ! !DESCRIPTION: Reads in a 2D netCDF real array and does some error checking.
 !\\
@@ -584,26 +560,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character (len=512) :: err_msg
+    integer             :: ierr
+    integer             :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_2d_R4 #1:  ' // Trim (varname) // &
-                  ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_2d_R4 #1:  ' // Trim (varname) // &
+                  ', ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Get_Vara_Real (ncid, varid, strt2d, cnt2d, varrd_2d)
+    ierr = NF90_Get_Var(ncid, varid, varrd_2d, start=strt2d, count=cnt2d)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_2d_R4 #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_2d_R4 #2:  ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      end subroutine Ncrd_2d_R4
+  end subroutine Ncrd_2d_R4
 !EOC
 !-------------------------------------------------------------------------
 !BOP
@@ -612,30 +588,27 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncrd_2d_Int (varrd_2di, ncid, varname, strt2d, cnt2d)
+  subroutine Ncrd_2d_Int(varrd_2di, ncid, varname, strt2d, cnt2d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to read array input data from
-!!    varname  : netCDF variable name for array
-!!    strt2d   : vector specifying the index in varrd_2d where
-!!               the first of the data values will be read
-!!    cnt2d    : varrd_2di dimensions
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt2d(2)
-      integer          , intent(in)   :: cnt2d (2)
+!!  ncid     : netCDF file id to read array input data from
+!!  varname  : netCDF variable name for array
+!!  strt2d   : vector specifying the index in varrd_2d where
+!!             the first of the data values will be read
+!!  cnt2d    : varrd_2di dimensions
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
+    integer          , intent(in)   :: strt2d(2)
+    integer          , intent(in)   :: cnt2d (2)
 !
 ! !OUTPUT PARAMETERS:
-!!    varrd_2di : intger array to fill
-      integer          , intent(out)  :: varrd_2di(cnt2d(1), cnt2d(2))
+!!  varrd_2di : intger array to fill
+    integer          , intent(out)  :: varrd_2di(cnt2d(1), cnt2d(2))
 !
 ! !DESCRIPTION: Reads in a 2D netCDF integer array and does some error
 !  checking.
@@ -651,26 +624,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character (len=512) :: err_msg
+    integer             :: ierr
+    integer             :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_2d_Int #1:  ' // Trim (varname) // &
-                  ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_2d_Int #1:  ' // Trim (varname) // &
+                  ', ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Get_Vara_Int (ncid, varid, strt2d, cnt2d, varrd_2di)
+    ierr = NF90_Get_Var(ncid, varid, varrd_2di, start=strt2d, count=cnt2d)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_2d_Int #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_2d_Int #2:  ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      end subroutine Ncrd_2d_Int
+  end subroutine Ncrd_2d_Int
 !EOC
 !-------------------------------------------------------------------------
 !BOP
@@ -679,31 +652,28 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncrd_3d_R8 (varrd_3d, ncid, varname, strt3d, cnt3d)
+  subroutine Ncrd_3d_R8(varrd_3d, ncid, varname, strt3d, cnt3d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to read array input data from
-!!    varname  : netCDF variable name for array
-!!    strt3d   : vector specifying the index in varrd_3d where
+!!  ncid     : netCDF file id to read array input data from
+!!  varname  : netCDF variable name for array
+!!  strt3d   : vector specifying the index in varrd_3d where
 !!               the first of the data values will be read
-!!    cnt3d    : varrd_3d dimensions
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt3d(3)
-      integer          , intent(in)   :: cnt3d (3)
+!!  cnt3d    : varrd_3d dimensions
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
+    integer          , intent(in)   :: strt3d(3)
+    integer          , intent(in)   :: cnt3d (3)
 !
 ! !OUTPUT PARAMETERS:
-!!    varrd_3d : array to fill
-      real*8           , intent(out)  :: varrd_3d(cnt3d(1), cnt3d(2), &
-                                                  cnt3d(3))
+!!  varrd_3d : array to fill
+    real*8           , intent(out)  :: varrd_3d(cnt3d(1), cnt3d(2), &
+                                                cnt3d(3))
 !
 ! !DESCRIPTION: Reads in a 3D netCDF real array and does some error checking.
 !\\
@@ -718,26 +688,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character (len=512) :: err_msg
+    integer             :: ierr
+    integer             :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_3d_R8 #1:  ' // Trim (varname) // &
-                 ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_3d_R8 #1:  ' // Trim (varname) // &
+                 ', ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Get_Vara_Double (ncid, varid, strt3d, cnt3d, varrd_3d)
+    ierr = NF90_Get_Var(ncid, varid, varrd_3d, start=strt3d, count=cnt3d)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_3d_R8 #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_3d_R8 #2:  ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      end subroutine Ncrd_3d_R8
+  end subroutine Ncrd_3d_R8
 !EOC
 !-------------------------------------------------------------------------
 !BOP
@@ -746,31 +716,28 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncrd_3d_R4 (varrd_3d, ncid, varname, strt3d, cnt3d)
+  subroutine Ncrd_3d_R4(varrd_3d, ncid, varname, strt3d, cnt3d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to read array input data from
-!!    varname  : netCDF variable name for array
-!!    strt3d   : vector specifying the index in varrd_3d where
-!!               the first of the data values will be read
-!!    cnt3d    : varrd_3d dimensions
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt3d(3)
-      integer          , intent(in)   :: cnt3d (3)
+!!  ncid     : netCDF file id to read array input data from
+!!  varname  : netCDF variable name for array
+!!  strt3d   : vector specifying the index in varrd_3d where
+!!             the first of the data values will be read
+!!  cnt3d    : varrd_3d dimensions
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
+    integer          , intent(in)   :: strt3d(3)
+    integer          , intent(in)   :: cnt3d (3)
 !
 ! !OUTPUT PARAMETERS:
-!!    varrd_3d : array to fill
-      real*4           , intent(out)  :: varrd_3d(cnt3d(1), cnt3d(2), &
-                                                  cnt3d(3))
+!!  varrd_3d : array to fill
+    real*4           , intent(out)  :: varrd_3d(cnt3d(1), cnt3d(2), &
+                                                cnt3d(3))
 !
 ! !DESCRIPTION: Reads in a 3D netCDF real array and does some error checking.
 !\\
@@ -785,26 +752,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character (len=512) :: err_msg
+    integer             :: ierr
+    integer             :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_3d_R4 #1:  ' // Trim (varname) // &
-                 ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_3d_R4 #1:  ' // Trim (varname) // &
+                 ', ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Get_Vara_Real (ncid, varid, strt3d, cnt3d, varrd_3d)
+    ierr = NF90_Get_Var(ncid, varid, varrd_3d, start=strt3d, count=cnt3d)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_3d_R4 #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_3d_R4 #2:  ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      end subroutine Ncrd_3d_R4
+  end subroutine Ncrd_3d_R4
 !EOC
 !-------------------------------------------------------------------------
 !BOP
@@ -813,31 +780,28 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncrd_3d_Int (varrd_3di, ncid, varname, strt3d, cnt3d)
+  subroutine Ncrd_3d_Int(varrd_3di, ncid, varname, strt3d, cnt3d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to read array input data from
-!!    varname  : netCDF variable name for array
-!!    strt3d   : vector specifying the index in varrd_3d where
-!!               the first of the data values will be read
-!!    cnt3d    : varrd_3di dimensions
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt3d(3)
-      integer          , intent(in)   :: cnt3d (3)
+!!  ncid     : netCDF file id to read array input data from
+!!  varname  : netCDF variable name for array
+!!  strt3d   : vector specifying the index in varrd_3d where
+!!             the first of the data values will be read
+!!  cnt3d    : varrd_3di dimensions
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
+    integer          , intent(in)   :: strt3d(3)
+    integer          , intent(in)   :: cnt3d (3)
 !
 ! !OUTPUT PARAMETERS:
-!!    varrd_3di : intger array to fill
-      integer          , intent(out)  :: varrd_3di(cnt3d(1), cnt3d(2), &
-                                                   cnt3d(3))
+!!  varrd_3di : intger array to fill
+    integer          , intent(out)  :: varrd_3di(cnt3d(1), cnt3d(2), &
+                                                 cnt3d(3))
 !
 ! !DESCRIPTION: Reads in a 3D netCDF integer array and does some error
 !  checking.
@@ -853,26 +817,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character (len=512) :: err_msg
+    integer             :: ierr
+    integer             :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_3d_Int #1:  ' // Trim (varname) // &
-                  ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_3d_Int #1:  ' // Trim (varname) // &
+                  ', ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Get_Vara_Int (ncid, varid, strt3d, cnt3d, varrd_3di)
+    ierr = NF90_Get_Var(ncid, varid, varrd_3di, start=strt3d, count=cnt3d)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_3d_Int #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_3d_Int #2:  ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      end subroutine Ncrd_3d_Int
+  end subroutine Ncrd_3d_Int
 !EOC
 !-------------------------------------------------------------------------
 !BOP
@@ -881,31 +845,30 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncrd_4d_R8 (varrd_4d, ncid, varname, strt4d, cnt4d)
+  subroutine Ncrd_4d_R8(varrd_4d, ncid, varname, strt4d, cnt4d)
 !
 ! !USES:
 !
-      use m_do_err_out
+    use netCDF
+    use m_do_err_out
 !
-      implicit none
-!
-      include "netcdf.inc"
+    implicit none
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to read array input data from
-!!    varname  : netCDF variable name for array
-!!    strt4d   : vector specifying the index in varrd_4d where
-!!               the first of the data values will be read
-!!    cnt4d    : varrd_4d dimensions
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt4d(4)
-      integer          , intent(in)   :: cnt4d (4)
+!!  ncid     : netCDF file id to read array input data from
+!!  varname  : netCDF variable name for array
+!!  strt4d   : vector specifying the index in varrd_4d where
+!!             the first of the data values will be read
+!!  cnt4d    : varrd_4d dimensions
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
+    integer          , intent(in)   :: strt4d(4)
+    integer          , intent(in)   :: cnt4d (4)
 !
 ! !OUTPUT PARAMETERS:
-!!    varrd_4d : array to fill
-      real*8           , intent(out)  :: varrd_4d(cnt4d(1), cnt4d(2), &
-                                                  cnt4d(3), cnt4d(4))
+!!  varrd_4d : array to fill
+    real*8           , intent(out)  :: varrd_4d(cnt4d(1), cnt4d(2), &
+                                                cnt4d(3), cnt4d(4))
 !
 ! !DESCRIPTION: Reads in a 4D netCDF real array and does some error checking.
 !\\
@@ -920,27 +883,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character (len=512) :: err_msg
+    integer             :: ierr
+    integer             :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_4d_R8 #1:  ' // Trim (varname) // &
-                    ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_4d_R8 #1:  ' // Trim (varname) // &
+                 ', ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
+    ierr =  NF90_Get_Var(ncid, varid, varrd_4d, start=strt4d, count=cnt4d)
 
-      ierr =  Nf_Get_Vara_Double (ncid, varid, strt4d, cnt4d, varrd_4d)
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_4d_R8 #2:  ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_4d_R8 #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
-
-      end subroutine Ncrd_4d_R8
+  end subroutine Ncrd_4d_R8
 !EOC
 !-------------------------------------------------------------------------
 !BOP
@@ -949,31 +911,28 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncrd_4d_R4 (varrd_4d, ncid, varname, strt4d, cnt4d)
+  subroutine Ncrd_4d_R4(varrd_4d, ncid, varname, strt4d, cnt4d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to read array input data from
-!!    varname  : netCDF variable name for array
-!!    strt4d   : vector specifying the index in varrd_4d where
-!!               the first of the data values will be read
-!!    cnt4d    : varrd_4d dimensions
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt4d(4)
-      integer          , intent(in)   :: cnt4d (4)
+!!  ncid     : netCDF file id to read array input data from
+!!  varname  : netCDF variable name for array
+!!  strt4d   : vector specifying the index in varrd_4d where
+!!             the first of the data values will be read
+!!  cnt4d    : varrd_4d dimensions
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
+    integer          , intent(in)   :: strt4d(4)
+    integer          , intent(in)   :: cnt4d (4)
 !
 ! !OUTPUT PARAMETERS:
-!!    varrd_4d : array to fill
-      real*4           , intent(out)  :: varrd_4d(cnt4d(1), cnt4d(2), &
-                                                  cnt4d(3), cnt4d(4))
+!!  varrd_4d : array to fill
+    real*4           , intent(out)  :: varrd_4d(cnt4d(1), cnt4d(2), &
+                                                cnt4d(3), cnt4d(4))
 !
 ! !DESCRIPTION: Reads in a 4D netCDF real array and does some error checking.
 !\\
@@ -988,26 +947,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character (len=512) :: err_msg
+    integer             :: ierr
+    integer             :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_4d_R4 #1:  ' // Trim (varname) // &
-                    ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_4d_R4 #1:  ' // Trim (varname) // &
+                  ', ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr =  Nf_Get_Vara_Real (ncid, varid, strt4d, cnt4d, varrd_4d)
+    ierr =  NF90_Get_Var(ncid, varid, varrd_4d, start=strt4d, count=cnt4d)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_4d_R4 #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_4d_R4 #2:  ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      end subroutine Ncrd_4d_R4
+  end subroutine Ncrd_4d_R4
 !EOC
 !-------------------------------------------------------------------------
 !BOP
@@ -1016,31 +975,28 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncrd_4d_Int (varrd_4di, ncid, varname, strt4d, cnt4d)
+  subroutine Ncrd_4d_Int(varrd_4di, ncid, varname, strt4d, cnt4d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to read array input data from
-!!    varname  : netCDF variable name for array
-!!    strt3d   : vector specifying the index in varrd_3d where
-!!               the first of the data values will be read
-!!    cnt3d    : varrd_3di dimensions
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt4d(4)
-      integer          , intent(in)   :: cnt4d (4)
+!!  ncid     : netCDF file id to read array input data from
+!!  varname  : netCDF variable name for array
+!!  strt3d   : vector specifying the index in varrd_3d where
+!!             the first of the data values will be read
+!!  cnt3d    : varrd_3di dimensions
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
+    integer          , intent(in)   :: strt4d(4)
+    integer          , intent(in)   :: cnt4d (4)
 !
 ! !OUTPUT PARAMETERS:
-!!    varrd_3di : intger array to fill
-      integer          , intent(out)  :: varrd_4di(cnt4d(1), cnt4d(2), &
-                                                   cnt4d(3), cnt4d(4))
+!!  varrd_3di : intger array to fill
+    integer          , intent(out)  :: varrd_4di(cnt4d(1), cnt4d(2), &
+                                                 cnt4d(3), cnt4d(4))
 !
 ! !DESCRIPTION: Reads in a 3D netCDF integer array and does some error
 !  checking.
@@ -1056,26 +1012,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character (len=512) :: err_msg
+    integer             :: ierr
+    integer             :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_3d_Int #1:  ' // Trim (varname) // &
-                  ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_3d_Int #1:  ' // Trim (varname) // &
+                  ', ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Get_Vara_Int (ncid, varid, strt4d, cnt4d, varrd_4di)
+    ierr = NF90_Get_Var(ncid, varid, varrd_4di, start=strt4d, count=cnt4d)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_3d_Int #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_3d_Int #2:  ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      end subroutine Ncrd_4d_Int
+  end subroutine Ncrd_4d_Int
 !EOC
 !-------------------------------------------------------------------------
 !BOP
@@ -1084,32 +1040,29 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncrd_5d_R8 (varrd_5d, ncid, varname, strt5d, cnt5d)
+  subroutine Ncrd_5d_R8(varrd_5d, ncid, varname, strt5d, cnt5d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to read array input data from
-!!    varname  : netCDF variable name for array
-!!    strt5d   : vector specifying the index in varrd_5d where
-!!               the first of the data values will be read
-!!    cnt5d    : varrd_5d dimensions
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt5d(5)
-      integer          , intent(in)   :: cnt5d (5)
+!!  ncid     : netCDF file id to read array input data from
+!!  varname  : netCDF variable name for array
+!!  strt5d   : vector specifying the index in varrd_5d where
+!!             the first of the data values will be read
+!!  cnt5d    : varrd_5d dimensions
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
+    integer          , intent(in)   :: strt5d(5)
+    integer          , intent(in)   :: cnt5d (5)
 !
 ! !OUTPUT PARAMETERS:
-!!    varrd_5d : array to fill
-      real*8         , intent(out)  :: varrd_5d(cnt5d(1), cnt5d(2), &
-                                                cnt5d(3), cnt5d(4), &
-                                                cnt5d(5))
+!!  varrd_5d : array to fill
+    real*8         , intent(out)  :: varrd_5d(cnt5d(1), cnt5d(2), &
+                                              cnt5d(3), cnt5d(4), &
+                                              cnt5d(5))
 !
 ! !DESCRIPTION: Reads in a 5D netCDF real array and does some error checking.
 !\\
@@ -1124,26 +1077,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character (len=512) :: err_msg
+    integer             :: ierr
+    integer             :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
+    if (ierr /= NF90_NOERR) then
         err_msg = 'In Ncrd_5d_R8 #1:  ' // Trim (varname) // &
-                  ', ' // Nf_Strerror (ierr)
+                  ', ' // NF90_Strerror(ierr)
         call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+     end if
 
-      ierr = Nf_Get_Vara_Double (ncid, varid, strt5d, cnt5d, varrd_5d)
+     ierr = NF90_Get_Var(ncid, varid, varrd_5d, start=strt5d, count=cnt5d)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_5d_R8 #2:  ' // Nf_Strerror (ierr)
+     if (ierr /= NF90_NOERR) then
+        err_msg = 'In Ncrd_5d_R8 #2:  ' // NF90_Strerror(ierr)
         call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+     end if
 
-      end subroutine Ncrd_5d_R8
+  end subroutine Ncrd_5d_R8
 !EOC
 !-------------------------------------------------------------------------
 !BOP
@@ -1152,30 +1105,27 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncrd_5d_R4 (varrd_5d, ncid, varname, strt5d, cnt5d)
+  subroutine Ncrd_5d_R4(varrd_5d, ncid, varname, strt5d, cnt5d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to read array input data from
-!!    varname  : netCDF variable name for array
-!!    strt5d   : vector specifying the index in varrd_5d where
-!!               the first of the data values will be read
-!!    cnt5d    : varrd_5d dimensions
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt5d(5)
-      integer          , intent(in)   :: cnt5d (5)
+!!  ncid     : netCDF file id to read array input data from
+!!  varname  : netCDF variable name for array
+!!  strt5d   : vector specifying the index in varrd_5d where
+!!             the first of the data values will be read
+!!  cnt5d    : varrd_5d dimensions
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
+    integer          , intent(in)   :: strt5d(5)
+    integer          , intent(in)   :: cnt5d (5)
 !
 ! !OUTPUT PARAMETERS:
-!!    varrd_5d : array to fill
-      real*4          , intent(out)  :: varrd_5d(cnt5d(1), cnt5d(2), &
+!!  varrd_5d : array to fill
+    real*4          , intent(out)  :: varrd_5d(cnt5d(1), cnt5d(2), &
                                                 cnt5d(3), cnt5d(4), &
                                                 cnt5d(5))
 !
@@ -1192,26 +1142,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character (len=512) :: err_msg
+    integer             :: ierr
+    integer             :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_5d_R4 #1:  ' // Trim (varname) // &
-                  ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_5d_R4 #1:  ' // Trim (varname) // &
+                  ', ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Get_Vara_Real (ncid, varid, strt5d, cnt5d, varrd_5d)
+    ierr = NF90_Get_Var(ncid, varid, varrd_5d, start=strt5d, count=cnt5d)
+    
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_5d_R4 #2:  ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_5d_R4 #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
-
-      end subroutine Ncrd_5d_R4
+  end subroutine Ncrd_5d_R4
 !EOC
 !-------------------------------------------------------------------------
 !BOP
@@ -1220,32 +1170,29 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncrd_6d_R8 (varrd_6d, ncid, varname, strt6d, cnt6d)
+  subroutine Ncrd_6d_R8(varrd_6d, ncid, varname, strt6d, cnt6d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to read array input data from
-!!    varname  : netCDF variable name for array
-!!    strt5d   : vector specifying the index in varrd_5d where
+!!  ncid     : netCDF file id to read array input data from
+!!  varname  : netCDF variable name for array
+!!  strt5d   : vector specifying the index in varrd_5d where
 !!               the first of the data values will be read
-!!    cnt5d    : varrd_5d dimensions
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt6d(6)
-      integer          , intent(in)   :: cnt6d (6)
+!!  cnt5d    : varrd_5d dimensions
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
+    integer          , intent(in)   :: strt6d(6)
+    integer          , intent(in)   :: cnt6d (6)
 !
 ! !OUTPUT PARAMETERS:
-!!    varrd_5d : array to fill
-      real*8         , intent(out)  :: varrd_6d(cnt6d(1), cnt6d(2), &
-                                                cnt6d(3), cnt6d(4), &
-                                                cnt6d(5), cnt6d(6))
+!!  varrd_5d : array to fill
+    real*8         , intent(out)  :: varrd_6d(cnt6d(1), cnt6d(2), &
+                                              cnt6d(3), cnt6d(4), &
+                                              cnt6d(5), cnt6d(6))
 !
 ! !DESCRIPTION: Reads in a 5D netCDF real array and does some error checking.
 !\\
@@ -1261,26 +1208,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character (len=512) :: err_msg
+    integer             :: ierr
+    integer             :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_6d_R8 #1:  ' // Trim (varname) // &
-                  ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_6d_R8 #1:  ' // Trim (varname) // &
+                 ', ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Get_Vara_Double (ncid, varid, strt6d, cnt6d, varrd_6d)
+    ierr = NF90_Get_Var(ncid, varid, varrd_6d, start=strt6d, count=cnt6d)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_6d_R8 #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_6d_R8 #2:  ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      end subroutine Ncrd_6d_R8
+  end subroutine Ncrd_6d_R8
 !EOC
 !-------------------------------------------------------------------------
 !BOP
@@ -1289,32 +1236,29 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncrd_6d_R4 (varrd_6d, ncid, varname, strt6d, cnt6d)
+  subroutine Ncrd_6d_R4(varrd_6d, ncid, varname, strt6d, cnt6d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to read array input data from
-!!    varname  : netCDF variable name for array
-!!    strt5d   : vector specifying the index in varrd_5d where
-!!               the first of the data values will be read
-!!    cnt5d    : varrd_5d dimensions
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt6d(6)
-      integer          , intent(in)   :: cnt6d (6)
+!!  ncid     : netCDF file id to read array input data from
+!!  varname  : netCDF variable name for array
+!!  strt5d   : vector specifying the index in varrd_5d where
+!!             the first of the data values will be read
+!!  cnt5d    : varrd_5d dimensions
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
+    integer          , intent(in)   :: strt6d(6)
+    integer          , intent(in)   :: cnt6d (6)
 !
 ! !OUTPUT PARAMETERS:
-!!    varrd_5d : array to fill
-      real*4          , intent(out)  :: varrd_6d(cnt6d(1), cnt6d(2), &
-                                                 cnt6d(3), cnt6d(4), &
-                                                 cnt6d(5), cnt6d(6))
+!!  varrd_5d : array to fill
+    real*4          , intent(out)  :: varrd_6d(cnt6d(1), cnt6d(2), &
+                                               cnt6d(3), cnt6d(4), &
+                                               cnt6d(5), cnt6d(6))
 !
 ! !DESCRIPTION: Reads in a 5D netCDF real array and does some error checking.
 !\\
@@ -1329,26 +1273,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character (len=512) :: err_msg
+    integer             :: ierr
+    integer             :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_6d_R4 #1:  ' // Trim (varname) // &
-                  ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if ( ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_6d_R4 #1:  ' // Trim (varname) // &
+                  ', ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Get_Vara_Real   (ncid, varid, strt6d, cnt6d, varrd_6d)
+    ierr = NF90_Get_Var(ncid, varid, varrd_6d, start=strt6d, count=cnt6d)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_6d_R4 #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_6d_R4 #2:  ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      end subroutine Ncrd_6d_R4
+  end subroutine Ncrd_6d_R4
 !EOC
 !-------------------------------------------------------------------------
 !BOP
@@ -1357,33 +1301,30 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncrd_7d_R8 (varrd_7d, ncid, varname, strt7d, cnt7d)
+  subroutine Ncrd_7d_R8(varrd_7d, ncid, varname, strt7d, cnt7d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to read array input data from
-!!    varname  : netCDF variable name for array
-!!    strt7d   : vector specifying the index in varrd_7d where
-!!               the first of the data values will be read
-!!    cnt7d    : varrd_7d dimensions
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt7d(7)
-      integer          , intent(in)   :: cnt7d (7)
+!!  ncid     : netCDF file id to read array input data from
+!!  varname  : netCDF variable name for array
+!!  strt7d   : vector specifying the index in varrd_7d where
+!!             the first of the data values will be read
+!!  cnt7d    : varrd_7d dimensions
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
+    integer          , intent(in)   :: strt7d(7)
+    integer          , intent(in)   :: cnt7d (7)
 !
 ! !OUTPUT PARAMETERS:
-!!    varrd_5d : array to fill
-      real*8         , intent(out)  :: varrd_7d(cnt7d(1), cnt7d(2), &
-                                                cnt7d(3), cnt7d(4), &
-                                                cnt7d(5), cnt7d(6), &
-                                                cnt7d(7))
+!!  varrd_5d : array to fill
+    real*8         , intent(out)  :: varrd_7d(cnt7d(1), cnt7d(2), &
+                                              cnt7d(3), cnt7d(4), &
+                                              cnt7d(5), cnt7d(6), &
+                                              cnt7d(7))
 !
 ! !DESCRIPTION: Reads in a 7D netCDF real array and does some error checking.
 !\\
@@ -1399,26 +1340,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character (len=512) :: err_msg
+    integer             :: ierr
+    integer             :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_7d_R8 #1:  ' // Trim (varname) // &
-                  ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_7d_R8 #1:  ' // Trim (varname) // &
+                  ', ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Get_Vara_Double (ncid, varid, strt7d, cnt7d, varrd_7d)
+    ierr = NF90_Get_Var(ncid, varid, varrd_7d, start=strt7d, count=cnt7d)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_7d_R8 #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_7d_R8 #2:  ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      end subroutine Ncrd_7d_R8
+  end subroutine Ncrd_7d_R8
 !EOC
 !-------------------------------------------------------------------------
 !BOP
@@ -1427,33 +1368,30 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncrd_7d_R4 (varrd_7d, ncid, varname, strt7d, cnt7d)
+  subroutine Ncrd_7d_R4(varrd_7d, ncid, varname, strt7d, cnt7d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to read array input data from
-!!    varname  : netCDF variable name for array
-!!    strt7d   : vector specifying the index in varrd_7d where
-!!               the first of the data values will be read
-!!    cnt7d    : varrd_7d dimensions
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt7d(7)
-      integer          , intent(in)   :: cnt7d (7)
+!!  ncid     : netCDF file id to read array input data from
+!!  varname  : netCDF variable name for array
+!!  strt7d   : vector specifying the index in varrd_7d where
+!!             the first of the data values will be read
+!!  cnt7d    : varrd_7d dimensions
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
+    integer          , intent(in)   :: strt7d(7)
+    integer          , intent(in)   :: cnt7d (7)
 !
 ! !OUTPUT PARAMETERS:
-!!    varrd_7d : array to fill
-      real*4          , intent(out)  :: varrd_7d(cnt7d(1), cnt7d(2), &
-                                                 cnt7d(3), cnt7d(4), &
-                                                 cnt7d(5), cnt7d(6), &
-                                                 cnt7d(7))
+!!  varrd_7d : array to fill
+    real*4          , intent(out)  :: varrd_7d(cnt7d(1), cnt7d(2), &
+                                               cnt7d(3), cnt7d(4), &
+                                               cnt7d(5), cnt7d(6), &
+                                               cnt7d(7))
 !
 ! !DESCRIPTION: Reads in a 7D netCDF real array and does some error checking.
 !\\
@@ -1469,26 +1407,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character (len=512) :: err_msg
+    integer             :: ierr
+    integer             :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_7d_R4 #1:  ' // Trim (varname) // &
-                  ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_7d_R4 #1:  ' // Trim (varname) // &
+                 ', ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Get_Vara_Real (ncid, varid, strt7d, cnt7d, varrd_7d)
+    ierr = NF90_Get_Var(ncid, varid, varrd_7d, start=strt7d, count=cnt7d)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_7d_R4 #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_7d_R4 #2:  ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      end subroutine Ncrd_7d_R4
+  end subroutine Ncrd_7d_R4
 !EOC
 !-------------------------------------------------------------------------
 !BOP
@@ -1497,31 +1435,28 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncrd_1d_Char (varrd_1dc, ncid, varname, strt1d, cnt1d)
+  subroutine Ncrd_1d_Char(varrd_1dc, ncid, varname, strt1d, cnt1d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
 !
-!!    ncid     : netCDF file id to read array input data from
-!!    varname  : netCDF variable name for array
-!!    strt1d   : vector specifying the index in varrd_1dc where
-!!               the first of the data values will be read
-!!    cnt1d    : varrd_1dc dimension
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt1d(1)
-      integer          , intent(in)   :: cnt1d (1)
+!!  ncid     : netCDF file id to read array input data from
+!!  varname  : netCDF variable name for array
+!!  strt1d   : vector specifying the index in varrd_1dc where
+!!             the first of the data values will be read
+!!  cnt1d    : varrd_1dc dimension
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
+    integer          , intent(in)   :: strt1d(1)
+    integer          , intent(in)   :: cnt1d (1)
 !
 ! !OUTPUT PARAMETERS:
-!!    varrd_1dc : intger array to fill
-      character (len=1), intent(out)  :: varrd_1dc(cnt1d(1))
+!!  varrd_1dc : intger array to fill
+    character (len=1), intent(out)  :: varrd_1dc(cnt1d(1))
 !
 ! !DESCRIPTION: Reads in a 1D netCDF character array and does some error
 !  checking.
@@ -1536,26 +1471,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character (len=512) :: err_msg
+    integer             :: ierr
+    integer             :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_1d_Char #1:  ' // Trim (varname) // &
-                  ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_1d_Char #1:  ' // Trim (varname) // &
+                  ', ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Get_Vara_Text (ncid, varid, strt1d, cnt1d, varrd_1dc)
+    ierr = NF90_Get_Var(ncid, varid, varrd_1dc, start=strt1d, count=cnt1d)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_1d_Char #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_1d_Char #2:  ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      end subroutine Ncrd_1d_Char
+  end subroutine Ncrd_1d_Char
 !EOC
 !-------------------------------------------------------------------------
 !BOP
@@ -1564,30 +1499,27 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncrd_2d_Char (varrd_2dc, ncid, varname, strt2d, cnt2d)
+  subroutine Ncrd_2d_Char(varrd_2dc, ncid, varname, strt2d, cnt2d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to read array input data from
-!!    varname  : netCDF variable name for array
-!!    strt2d   : vector specifying the index in varrd_2dc where
-!!               the first of the data values will be read
-!!    cnt2d    : varrd_2dc dimensions
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt2d(2)
-      integer          , intent(in)   :: cnt2d (2)
+!!  ncid     : netCDF file id to read array input data from
+!!  varname  : netCDF variable name for array
+!!  strt2d   : vector specifying the index in varrd_2dc where
+!!             the first of the data values will be read
+!!  cnt2d    : varrd_2dc dimensions
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
+    integer          , intent(in)   :: strt2d(2)
+    integer          , intent(in)   :: cnt2d (2)
 !
 ! !OUTPUT PARAMETERS:
-!!    varrd_2dc : charcter array to fill
-      character        , intent(out)  :: varrd_2dc(cnt2d(1), cnt2d(2))
+!!  varrd_2dc : charcter array to fill
+    character        , intent(out)  :: varrd_2dc(cnt2d(1), cnt2d(2))
 !
 ! !DESCRIPTION: Reads in a 2D netCDF character array and does some error
 !  checking.
@@ -1603,26 +1535,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character (len=512) :: err_msg
+    integer             :: ierr
+    integer             :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_2d_Char #1:  ' // Trim (varname) // &
-                  ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_2d_Char #1:  ' // Trim (varname) // &
+                  ', ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Get_Vara_Text (ncid, varid, strt2d, cnt2d, varrd_2dc)
+    ierr = NF90_Get_Var(ncid, varid, varrd_2dc, start=strt2d, count=cnt2d)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_2d_Char #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_2d_Char #2:  ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      end subroutine Ncrd_2d_Char
+  end subroutine Ncrd_2d_Char
 !EOC
 !------------------------------------------------------------------------
 end module HCO_m_netcdf_io_read

--- a/src/Shared/NcdfUtil/hco_m_netcdf_io_readattr.F90
+++ b/src/Shared/NcdfUtil/hco_m_netcdf_io_readattr.F90
@@ -11,13 +11,9 @@
 MODULE HCO_m_netcdf_io_readattr
 !
 ! !USES:
-
-  USE m_do_err_out
-
+!
   IMPLICIT NONE
   PRIVATE
-
-  INCLUDE "netcdf.inc"
 !
 ! !PUBLIC MEMBER FUNCTIONS:
 !
@@ -93,6 +89,11 @@ CONTAINS
 !
   SUBROUTINE NcGet_Var_Attr_C( fid, varName, attName, attValue )
 !
+! USES:
+!
+    USE netCDF
+    USE m_do_err_out
+!
 ! !INPUT PARAMETERS:
 !
     INTEGER,          INTENT(IN)  :: fId        ! netCDF file ID
@@ -125,20 +126,20 @@ CONTAINS
     attValue = ''
 
     ! Check if VARNAME is a valid variable
-    status = Nf_Inq_Varid ( fId, varName, vId )
+    status = NF90_Inq_VarId( fId, varName, vId )
 
     ! Exit w/ error message if VARNAME is not valid
-    IF ( status /= NF_NOERR ) THEN
+    IF ( status /= NF90_NOERR ) THEN
        errMsg = 'In NcGet_Var_Attr_C: ' // TRIM( varName )        // &
-                 ', '                   // Nf_Strerror( status )
+                 ', '                   // NF90_Strerror( status )
        CALL Do_Err_Out( errMsg, .TRUE., 0, 0, 0, 0, 0.0d0, 0.0d0 )
     ENDIF
 
     !  Get the attribute
-    status = Nf_Get_Att_Text( fId, vId, attName, attValue )
+    status = NF90_Get_Att( fId, vId, attName, attValue )
 
     ! Exit w/ error message if unsuccessful
-    IF ( status /= NF_NOERR ) THEN
+    IF ( status /= NF90_NOERR ) THEN
        errMsg = 'In NcGet_Var_Attr_C: cannot read attribute : ' // &
                  TRIM( attName )
        CALL Do_Err_Out( errMsg, .TRUE., 0, 0, 0, 0, 0.0d0, 0.0d0 )
@@ -160,6 +161,11 @@ CONTAINS
 ! !INTERFACE:
 !
   SUBROUTINE NcGet_Var_Attr_I4( fid, varName, attName, attValue )
+!
+! USES:
+!
+    USE netCDF
+    USE m_do_err_out
 !
 ! !INPUT PARAMETERS:
 !
@@ -193,20 +199,20 @@ CONTAINS
     attValue = 0
 
     ! Check if VARNAME is a valid variable
-    status = Nf_Inq_Varid ( fId, varName, vId )
+    status = NF90_Inq_VarId( fId, varName, vId )
 
     ! Exit w/ error message if VARNAME is not valid
-    IF ( status /= NF_NOERR ) THEN
+    IF ( status /= NF90_NOERR ) THEN
        errMsg = 'In NcGet_Var_Attr_I4: ' // TRIM( varName )        // &
-                 ', '                   // Nf_Strerror( status )
+                 ', '                   // NF90_Strerror( status )
        CALL Do_Err_Out ( errMsg, .TRUE., 1, fId, 0, 0, 0.0d0, 0.0d0)
     ENDIF
 
     ! Get the attribute
-    status = Nf_Get_Att_Int( fId, vId, attName, attValue )
+    status = NF90_Get_Att( fId, vId, attName, attValue )
 
     ! Exit w/ error message if unsuccessful
-    IF ( status /= NF_NOERR ) THEN
+    IF ( status /= NF90_NOERR ) THEN
        errMsg = 'In NcGet_Var_Attr_I4: cannot read attribute : ' // &
                  TRIM( attName )
        CALL Do_Err_Out( errMsg, .TRUE., 0, 0, 0, 0, 0.0d0, 0.0d0 )
@@ -228,6 +234,11 @@ CONTAINS
 ! !INTERFACE:
 !
   SUBROUTINE NcGet_Var_Attr_R4( fid, varName, attName, attValue )
+!
+! USES:
+!
+    USE netCDF
+    USE m_do_err_out
 !
 ! !INPUT PARAMETERS:
 !
@@ -261,20 +272,20 @@ CONTAINS
     attValue = 0e0
 
     ! Check if VARNAME is a valid variable
-    status = Nf_Inq_Varid ( fId, varName, vId )
+    status = NF90_Inq_VarId( fId, varName, vId )
 
     ! Exit w/ error message if VARNAME is not valid
-    IF ( status /= NF_NOERR ) THEN
+    IF ( status /= NF90_NOERR ) THEN
        errMsg = 'In NcGet_Var_Attr_R4: ' // TRIM( varName )        // &
-                 ', '                   // Nf_Strerror( status )
+                 ', '                   // NF90_Strerror( status )
        CALL Do_Err_Out ( errMsg, .TRUE., 1, fId, 0, 0, 0.0d0, 0.0d0)
     ENDIF
 
     ! Get the attribute
-    status = Nf_Get_Att_Real( fId, vId, attName, attValue )
+    status = NF90_Get_Att( fId, vId, attName, attValue )
 
     ! Exit w/ error message if unsuccessful
-    IF ( status /= NF_NOERR ) THEN
+    IF ( status /= NF90_NOERR ) THEN
        errMsg = 'In NcGet_Var_Attr_R4: cannot read attribute : ' // &
                  TRIM( attName )
        CALL Do_Err_Out( errMsg, .TRUE., 0, 0, 0, 0, 0.0d0, 0.0d0 )
@@ -296,6 +307,11 @@ CONTAINS
 ! !INTERFACE:
 !
   SUBROUTINE NcGet_Var_Attr_R8( fid, varName, attName, attValue )
+!
+! USES:
+!
+    USE netCDF
+    USE m_do_err_out
 !
 ! !INPUT PARAMETERS:
 !
@@ -329,20 +345,20 @@ CONTAINS
     attValue = 0d0
 
     ! Check if VARNAME is a valid variable
-    status = Nf_Inq_Varid ( fId, varName, vId )
+    status = NF90_Inq_VarId( fId, varName, vId )
 
     ! Exit w/ error message if VARNAME is not valid
-    IF ( status /= NF_NOERR ) THEN
+    IF ( status /= NF90_NOERR ) THEN
        errMsg = 'In NcGet_Var_Attr_R8: ' // TRIM( varName )        // &
-                 ', '                   // Nf_Strerror( status )
+                 ', '                   // NF90_Strerror( status )
        CALL Do_Err_Out ( errMsg, .TRUE., 1, fId, 0, 0, 0.0d0, 0.0d0)
     ENDIF
 
     ! Get the attribute
-    status = Nf_Get_Att_Double( fId, vId, attName, attValue )
+    status = NF90_Get_Att( fId, vId, attName, attValue )
 
     ! Exit w/ error message if unsuccessful
-    IF ( status /= NF_NOERR ) THEN
+    IF ( status /= NF90_NOERR ) THEN
        errMsg = 'In NcGet_Var_Attr_R8: cannot read attribute : ' // &
                  TRIM( attName )
        CALL Do_Err_Out( errMsg, .TRUE., 0, 0, 0, 0, 0.0d0, 0.0d0 )
@@ -364,6 +380,11 @@ CONTAINS
 ! !INTERFACE:
 !
   SUBROUTINE NcGet_Var_Attr_I4_arr( fid, varName, attName, attValue )
+!
+! USES:
+!
+    USE netCDF
+    USE m_do_err_out
 !
 ! !INPUT PARAMETERS:
 !
@@ -397,20 +418,20 @@ CONTAINS
     attValue = 0
 
     ! Check if VARNAME is a valid variable
-    status = Nf_Inq_Varid ( fId, varName, vId )
+    status = NF90_Inq_VarId( fId, varName, vId )
 
     ! Exit w/ error message if VARNAME is not valid
-    IF ( status /= NF_NOERR ) THEN
+    IF ( status /= NF90_NOERR ) THEN
        errMsg = 'In NcGet_Var_Attr_I4_arr: ' // TRIM( varName )        // &
-                 ', '                        // Nf_Strerror( status )
+                 ', '                        // NF90_Strerror( status )
        CALL Do_Err_Out ( errMsg, .TRUE., 1, fId, 0, 0, 0.0d0, 0.0d0)
     ENDIF
 
     ! Get the attribute
-    status = Nf_Get_Att_Int( fId, vId, attName, attValue )
+    status = NF90_Get_Att( fId, vId, attName, attValue )
 
     ! Exit w/ error message if unsuccessful
-    IF ( status /= NF_NOERR ) THEN
+    IF ( status /= NF90_NOERR ) THEN
        errMsg = 'In NcGet_Var_Attr_I4_arr: cannot read attribute : ' // &
                  TRIM( attName )
        CALL Do_Err_Out( errMsg, .TRUE., 0, 0, 0, 0, 0.0d0, 0.0d0 )
@@ -432,6 +453,11 @@ CONTAINS
 ! !INTERFACE:
 !
   SUBROUTINE NcGet_Var_Attr_R4_arr( fid, varName, attName, attValue )
+!
+! USES:
+!
+    USE netCDF
+    USE m_do_err_out
 !
 ! !INPUT PARAMETERS:
 !
@@ -465,20 +491,20 @@ CONTAINS
     attValue = 0e0
 
     ! Check if VARNAME is a valid variable
-    status = Nf_Inq_Varid ( fId, varName, vId )
+    status = NF90_Inq_VarId( fId, varName, vId )
 
     ! Exit w/ error message if VARNAME is not valid
-    IF ( status /= NF_NOERR ) THEN
+    IF ( status /= NF90_NOERR ) THEN
        errMsg = 'In NcGet_Var_Attr_R4_arr: ' // TRIM( varName )        // &
-                 ', '                        // Nf_Strerror( status )
+                 ', '                        // NF90_Strerror( status )
        CALL Do_Err_Out ( errMsg, .TRUE., 1, fId, 0, 0, 0.0d0, 0.0d0)
     ENDIF
 
     ! Get the attribute
-    status = Nf_Get_Att_Real( fId, vId, attName, attValue )
+    status = NF90_Get_Att( fId, vId, attName, attValue )
 
     ! Exit w/ error message if unsuccessful
-    IF ( status /= NF_NOERR ) THEN
+    IF ( status /= NF90_NOERR ) THEN
        errMsg = 'In NcGet_Var_Attr_R4_arr: cannot read attribute : ' // &
                  TRIM( attName )
        CALL Do_Err_Out( errMsg, .TRUE., 0, 0, 0, 0, 0.0d0, 0.0d0 )
@@ -500,6 +526,11 @@ CONTAINS
 ! !INTERFACE:
 !
   SUBROUTINE NcGet_Var_Attr_R8_arr( fid, varName, attName, attValue )
+!
+! USES:
+!
+    USE netCDF
+    USE m_do_err_out
 !
 ! !INPUT PARAMETERS:
 !
@@ -533,20 +564,20 @@ CONTAINS
     attValue = 0d0
 
     ! Check if VARNAME is a valid variable
-    status = Nf_Inq_Varid ( fId, varName, vId )
+    status = NF90_Inq_VarId( fId, varName, vId )
 
     ! Exit w/ error message if VARNAME is not valid
-    IF ( status /= NF_NOERR ) THEN
+    IF ( status /= NF90_NOERR ) THEN
        errMsg = 'In NcGet_Var_Attr_R8_arr: ' // TRIM( varName )        // &
-                 ', '                        // Nf_Strerror( status )
+                 ', '                        // NF90_Strerror( status )
        CALL Do_Err_Out ( errMsg, .TRUE., 1, fId, 0, 0, 0.0d0, 0.0d0)
     ENDIF
 
     ! Get the attribute
-    status = Nf_Get_Att_Double( fId, vId, attName, attValue )
+    status = NF90_Get_Att( fId, vId, attName, attValue )
 
     ! Exit w/ error message if unsuccessful
-    IF ( status /= NF_NOERR ) THEN
+    IF ( status /= NF90_NOERR ) THEN
        errMsg = 'In NcGet_Var_Attr_R8_arr: cannot read attribute : ' // &
                  TRIM( attName )
        CALL Do_Err_Out( errMsg, .TRUE., 0, 0, 0, 0, 0.0d0, 0.0d0 )
@@ -568,6 +599,11 @@ CONTAINS
 ! !INTERFACE:
 !
   SUBROUTINE NcGet_Glob_Attr_C( fid, attName, attValue )
+!
+! USES:
+!
+    USE netCDF
+    USE m_do_err_out
 !
 ! !INPUT PARAMETERS:
 !
@@ -600,10 +636,10 @@ CONTAINS
     attValue = ''
 
     ! Get the attribute
-    status = Nf_Get_Att_Text( fId, NF_GLOBAL, attName, attValue )
+    status = NF90_Get_Att( fId, NF90_GLOBAL, attName, attValue )
 
     ! Exit w/ error message if unsuccessful
-    IF ( status /= NF_NOERR ) THEN
+    IF ( status /= NF90_NOERR ) THEN
        errMsg = 'In NcGet_Glob_Attr_C: cannot read attribute : ' // &
                  TRIM( attName )
        CALL Do_Err_Out( errMsg, .TRUE., 0, 0, 0, 0, 0.0d0, 0.0d0 )
@@ -625,6 +661,11 @@ CONTAINS
 ! !INTERFACE:
 !
   SUBROUTINE NcGet_Glob_Attr_I4( fid, attName, attValue )
+!
+! USES:
+!
+    USE netCDF
+    USE m_do_err_out
 !
 ! !INPUT PARAMETERS:
 !
@@ -657,10 +698,10 @@ CONTAINS
     attValue = 0
 
     ! Get the attribute
-    status = Nf_Get_Att_Int( fId, NF_GLOBAL, attName, attValue )
+    status = NF90_Get_Att( fId, NF90_GLOBAL, attName, attValue )
 
     ! Exit w/ error message if unsuccessful
-    IF ( status /= NF_NOERR ) THEN
+    IF ( status /= NF90_NOERR ) THEN
        errMsg = 'In NcGet_Glob_Attr_I4: cannot read attribute : ' // &
                  TRIM( attName )
        CALL Do_Err_Out( errMsg, .TRUE., 0, 0, 0, 0, 0.0d0, 0.0d0 )
@@ -682,6 +723,11 @@ CONTAINS
 ! !INTERFACE:
 !
   SUBROUTINE NcGet_Glob_Attr_R4( fid, attName, attValue )
+!
+! USES:
+!
+    USE netCDF
+    USE m_do_err_out
 !
 ! !INPUT PARAMETERS:
 !
@@ -714,10 +760,10 @@ CONTAINS
     attValue = 0e0
 
     ! Get the attribute
-    status = Nf_Get_Att_Real( fId, NF_GLOBAL, attName, attValue )
+    status = NF90_Get_Att( fId, NF90_GLOBAL, attName, attValue )
 
     ! Exit w/ error message if unsuccessful
-    IF ( status /= NF_NOERR ) THEN
+    IF ( status /= NF90_NOERR ) THEN
        errMsg = 'In NcGet_Glob_Attr_R4: cannot read attribute : ' // &
                  TRIM( attName )
        CALL Do_Err_Out( errMsg, .TRUE., 0, 0, 0, 0, 0.0d0, 0.0d0 )
@@ -739,6 +785,11 @@ CONTAINS
 ! !INTERFACE:
 !
   SUBROUTINE NcGet_Glob_Attr_R8( fid, attName, attValue )
+!
+! USES:
+!
+    USE netCDF
+    USE m_do_err_out
 !
 ! !INPUT PARAMETERS:
 !
@@ -771,10 +822,10 @@ CONTAINS
     attValue = 0d0
 
     ! Get the attribute
-    status = Nf_Get_Att_Double( fId, NF_GLOBAL, attName, attValue )
+    status = NF90_Get_Att( fId, NF90_GLOBAL, attName, attValue )
 
     ! Exit w/ error message if unsuccessful
-    IF ( status /= NF_NOERR ) THEN
+    IF ( status /= NF90_NOERR ) THEN
        errMsg = 'In NcGet_Glob_Attr_R8: cannot read attribute : ' // &
                  TRIM( attName )
        CALL Do_Err_Out( errMsg, .TRUE., 0, 0, 0, 0, 0.0d0, 0.0d0 )
@@ -796,6 +847,11 @@ CONTAINS
 ! !INTERFACE:
 !
   SUBROUTINE NcGet_Glob_Attr_I4_arr( fid, attName, attValue )
+!
+! USES:
+!
+    USE netCDF
+    USE m_do_err_out
 !
 ! !INPUT PARAMETERS:
 !
@@ -828,10 +884,10 @@ CONTAINS
     attValue = 0
 
     ! Get the attribute
-    status = Nf_Get_Att_Int( fId, NF_GLOBAL, attName, attValue )
+    status = NF90_Get_Att( fId, NF90_GLOBAL, attName, attValue )
 
     ! Exit w/ error message if unsuccessful
-    IF ( status /= NF_NOERR ) THEN
+    IF ( status /= NF90_NOERR ) THEN
        errMsg = 'In NcGet_Glob_Attr_I4_arr: cannot read attribute : ' // &
                  TRIM( attName )
        CALL Do_Err_Out( errMsg, .TRUE., 0, 0, 0, 0, 0.0d0, 0.0d0 )
@@ -853,6 +909,11 @@ CONTAINS
 ! !INTERFACE:
 !
   SUBROUTINE NcGet_Glob_Attr_R4_arr( fid, attName, attValue )
+!
+! USES:
+!
+    USE netCDF
+    USE m_do_err_out
 !
 ! !INPUT PARAMETERS:
 !
@@ -885,10 +946,10 @@ CONTAINS
     attValue = 0e0
 
     ! Get the attribute
-    status = Nf_Get_Att_Real( fId, NF_GLOBAL, attName, attValue )
+    status = NF90_Get_Att( fId, NF90_GLOBAL, attName, attValue )
 
     ! Exit w/ error message if unsuccessful
-    IF ( status /= NF_NOERR ) THEN
+    IF ( status /= NF90_NOERR ) THEN
        errMsg = 'In NcGet_Glob_Attr_R4_arr: cannot read attribute : ' // &
                  TRIM( attName )
        CALL Do_Err_Out( errMsg, .TRUE., 0, 0, 0, 0, 0.0d0, 0.0d0 )
@@ -910,6 +971,11 @@ CONTAINS
 ! !INTERFACE:
 !
   SUBROUTINE NcGet_Glob_Attr_R8_arr( fid, attName, attValue )
+!
+! USES:
+!
+    USE netCDF
+    USE m_do_err_out
 !
 ! !INPUT PARAMETERS:
 !
@@ -942,10 +1008,10 @@ CONTAINS
     attValue = 0d0
 
     ! Get the attribute
-    status = Nf_Get_Att_Double( fId, NF_GLOBAL, attName, attValue )
+    status = NF90_Get_Att( fId, NF90_GLOBAL, attName, attValue )
 
     ! Exit w/ error message if unsuccessful
-    IF ( status /= NF_NOERR ) THEN
+    IF ( status /= NF90_NOERR ) THEN
        errMsg = 'In NcGet_Glob_Attr_R8_arr: cannot read attribute : ' // &
                  TRIM( attName )
        CALL Do_Err_Out( errMsg, .TRUE., 0, 0, 0, 0, 0.0d0, 0.0d0 )
@@ -969,6 +1035,11 @@ CONTAINS
 ! !INTERFACE:
 !
   SUBROUTINE NcGet_Var_Attr_C_nostop( fId, varName, attName, attValue, RC )
+!
+! USES:
+!
+    USE netCDF
+    USE m_do_err_out
 !
 ! !INPUT PARAMETERS:
 !
@@ -1003,19 +1074,19 @@ CONTAINS
     attValue = ''
 
     ! Check if VARNAME is a valid variable
-    status = Nf_Inq_Varid ( fId, varName, vId )
+    status = NF90_Inq_VarId( fId, varName, vId )
 
     ! Exit w/ error message if VARNAME is not valid
-    IF ( status /= NF_NOERR ) THEN
+    IF ( status /= NF90_NOERR ) THEN
        RC = status
        RETURN
     ENDIF
 
     !  Get the attribute
-    status = Nf_Get_Att_Text( fId, vId, attName, attValue )
+    status = NF90_Get_Att( fId, vId, attName, attValue )
 
     ! Exit w/ error message if unsuccessful
-    IF ( status /= NF_NOERR ) THEN
+    IF ( status /= NF90_NOERR ) THEN
        RC = status
        RETURN
     ENDIF

--- a/src/Shared/NcdfUtil/m_do_err_out.F90
+++ b/src/Shared/NcdfUtil/m_do_err_out.F90
@@ -127,7 +127,7 @@ CONTAINS
 
         ! NOTE: Should not exit but pass error code up
         ! work on this for a future version
-        stop 999 
+        stop 999
     ENDIF
 
     RETURN


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://hemco.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

We have updated the HEMCO netCDF reading/writing routines in `src/Shared/NcdfUtil` from the netCDF-F77 interface to the netCDF-F90 interface.  This is necessary to satisfy merging requirements for CESM.

The updates mainly involve:
- Replacing `INCLUDE "netcdf.inc"` with `USE netCDF`
- Replacing `NF_` with `NF90_` in netCDF parameters and function calls
- Replacing obsolete netCDF-F77 routines with equivalent netCDF-F90 functionality
- Also the `hco_m_netcdf_io_read.F90` was indented according to F90 free-format.

### Expected changes

This is a zero-diff update.  No changes are expected.

### Reference(s)

N/A

### Related Github Issue(s)

Closes #225

Also tagging @jimmielin 