### PR TITLE
Fix bug in volcano extension causing crash when volcano turned off

### DIFF
--- a/src/Extensions/hcox_volcano_mod.F90
+++ b/src/Extensions/hcox_volcano_mod.F90
@@ -354,23 +354,7 @@ CONTAINS
 
     ! Extension Nr.
     ExtNr = GetExtNr( HcoState%Config%ExtList, TRIM(ExtName) )
-
-    ! Print to log
-    IF ( HcoState%amIRoot ) THEN
-       IF ( ExtNr > 0 ) THEN
-          ! Write the name of the extension regardless of the verbose setting
-          msg = 'Using HEMCO extension: Volcano (volcanic SO2 emissions)'
-          IF ( HCO_IsVerb( HcoState%Config%Err ) ) THEN
-             CALL HCO_Msg( HcoState%Config%Err, msg, sep1='-' ) ! with separator
-          ELSE
-             CALL HCO_Msg( msg, verb=.TRUE.                   ) ! w/o separator
-          ENDIF
-       ELSE
-          MSG = 'The Volcano extension is turned off.'
-          CALL HCO_MSG( HcoState%Config%Err,  MSG )
-          RETURN
-       ENDIF
-    ENDIF
+    IF ( ExtNr <= 0 ) RETURN
 
     ! Enter
     CALL HCO_ENTER( HcoState%Config%Err, LOC, RC )
@@ -379,13 +363,22 @@ CONTAINS
         RETURN
     ENDIF
 
-    ! Create Volcano instance for this simulation
+    ! Create instance for this simulation
     Inst => NULL()
     CALL InstCreate( ExtNr, ExtState%Volcano, Inst, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
-       CALL HCO_Error(                                  &
-                      'Cannot create Volcano instance', RC                  )
+       CALL HCO_Error( 'Cannot create Volcano instance', RC )
        RETURN
+    ENDIF
+
+    ! Write the name of the extension regardless of the verbose settings
+    IF ( HcoState%amIRoot ) THEN
+       msg = 'Using HEMCO extension: Volcano (volcanic SO2 emissions)'
+       IF ( HCO_IsVerb( HcoState%Config%Err ) ) THEN
+          CALL HCO_Msg( HcoState%Config%Err, msg, sep1='-' ) ! with separator
+       ELSE
+          CALL HCO_Msg( msg, verb=.TRUE.                   ) ! w/o separator
+       ENDIF
     ENDIF
 
     ! Get species IDs.
@@ -483,9 +476,6 @@ CONTAINS
 
     ! Verbose mode
     IF ( HcoState%amIRoot ) THEN
-       MSG = 'Use emissions extension `Volcano`:'
-       CALL HCO_MSG( HcoState%Config%Err,  MSG )
-
        MSG = ' - use the following species (Name, HcoID, Scaling relative to kgS):'
        CALL HCO_MSG( HcoState%Config%Err, MSG)
        DO N = 1, Inst%nSpc


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Confirm you have reviewed the following documentation

- [X] [Contributing guidelines](https://hemco.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

This update fixes a problem where the simulation will crash in the volcano extension init subroutine on non-root threads if the volcano extension is turned off, such as in the transport tracer simulation. The fix moves the return if extension number is zero to directly after the call to retrieve extension number. This is the same handling as all other HEMCO extension initialization routines.

### Expected changes

The model will not crash if the volcano extension is turned off.

### Reference(s)

none

### Related Github Issue(s)

https://github.com/geoschem/GCHP/issues/331
