### PR TITLE
Update IsModelLevel check for CESM and WRF-GC

### DIFF
--- a/src/Core/hcoio_read_std_mod.F90
+++ b/src/Core/hcoio_read_std_mod.F90
@@ -695,6 +695,8 @@ CONTAINS
        ! going to 72 levels. Otherwise, use MESSy (nbalasus, 8/24/2023).
        IF ( Lct%Dct%Dta%Levels == 0 ) THEN
 
+#if defined( MODEL_CESM ) || defined( MODEL_WRF )
+
           ! In WRF/CESM, IsModelLevel has a different meaning of "GEOS-Chem levels"
           ! because the models in WRF and CESM are user-defined and thus fixed input
           ! files would never be on the model level. In this case, a check is added
@@ -702,8 +704,7 @@ CONTAINS
           ! data will be handled later in this file accordingly to be vertically
           ! regridded to the runtime model levels using MESSy.
           ! This fixes a regression from the vertical regridding fixes in 3.7.1.
-          ! (hplin, 10/16/23)
-#if defined( MODEL_CESM ) || defined( MODEL_WRF )
+          !
           ! The meaning of "is model levels" in WRF and CESM are different.
           ! Model levels can be changed and thus data is never on the model level.
           ! In this case, IsModelLevel means that the data is on standard
@@ -716,12 +717,15 @@ CONTAINS
           !     nlev == 47 .or. nlev == 48 .or. nlev == 36 .or. nlev == 72 .or. nlev == 73 ) THEN
               IsModelLevel = .true.
           ENDIF
+
 #else
+
           CALL ModelLev_Check( HcoState, nlev, IsModelLevel, RC )
           IF ( RC /= HCO_SUCCESS ) THEN
               CALL HCO_ERROR( 'ERROR 3', RC, THISLOC=LOC )
               RETURN
           ENDIF
+
 #endif
 
           ! Set level indeces to be read

--- a/src/Core/hcoio_read_std_mod.F90
+++ b/src/Core/hcoio_read_std_mod.F90
@@ -695,11 +695,34 @@ CONTAINS
        ! going to 72 levels. Otherwise, use MESSy (nbalasus, 8/24/2023).
        IF ( Lct%Dct%Dta%Levels == 0 ) THEN
 
+          ! In WRF/CESM, IsModelLevel has a different meaning of "GEOS-Chem levels"
+          ! because the models in WRF and CESM are user-defined and thus fixed input
+          ! files would never be on the model level. In this case, a check is added
+          ! in order to match the file with known GEOS-Chem levels, and if so, the
+          ! data will be handled later in this file accordingly to be vertically
+          ! regridded to the runtime model levels using MESSy.
+          ! This fixes a regression from the vertical regridding fixes in 3.7.1.
+          ! (hplin, 10/16/23)
+#if defined( MODEL_CESM ) || defined( MODEL_WRF )
+          ! The meaning of "is model levels" in WRF and CESM are different.
+          ! Model levels can be changed and thus data is never on the model level.
+          ! In this case, IsModelLevel means that the data is on standard
+          ! GEOS-Chem levels, and if so, the data will be handled accordingly
+          ! using a hard-coded set of GEOS-Chem levels to be interpolated using MESSy.
+          ! (hplin, 10/15/23)
+          IF ( TRIM(LevUnit) == "level" .or. TRIM(LevUnit) == "GEOS-Chem level" ) THEN
+          ! the below check will be obsolete and is unmaintainable, but would be consistent with ModelLev_Check.
+          ! it is more robust to check for the explicit intention of LevUnit
+          !     nlev == 47 .or. nlev == 48 .or. nlev == 36 .or. nlev == 72 .or. nlev == 73 ) THEN
+              IsModelLevel = .true.
+          ENDIF
+#else
           CALL ModelLev_Check( HcoState, nlev, IsModelLevel, RC )
           IF ( RC /= HCO_SUCCESS ) THEN
               CALL HCO_ERROR( 'ERROR 3', RC, THISLOC=LOC )
               RETURN
           ENDIF
+#endif
 
           ! Set level indeces to be read
           lev1 = 1


### PR DESCRIPTION
### Name and Institution (Required)

Name: Haipeng Lin
Institution: Harvard U.

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://hemco.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

In HEMCO 3.7.x (via PR https://github.com/geoschem/HEMCO/pull/235), @nicholasbalasus and I introduced changes to the vertical regridding handling in HEMCO for accuracy and for removing legacy code.

However, this causes a regression in functionality for GEOS-Chem within CESM and WRF-GC as they can no longer vertically regrid emissions to their (dynamically set) model levels.

In `MODEL_CESM` and `MODEL_WRF`, `IsModelLevel` can never be `.true.` because models are dynamically set and thus no fixed input file is on "CESM/WRF model levels" at runtime. Thus the `IsModelLevel` variable in these models is interpreted to be "GEOS-Chem model levels" and a fixed set of GEOS-Chem level parameters is included in the file to regrid these to the CESM/WRF model grids.

Changes to the `Is_ModelLevel` subroutine has made it return `.false.` under CESM/WRF which causes HEMCO to attempt to read sigma levels from files which do not have these levels, e.g., AEIC19 inventory.

This update returns HEMCO in CESM/WRF to its original functionality with a more robust check of units (`level` or `GEOS-Chem level` will mean data is on GEOS-Chem levels). Sigma coordinates explicitly specified will still be handled correctly.

### Expected changes

No changes to GEOS-Chem full-chemistry benchmark.

Returns HEMCO vertical regridding behavior in CESM/WRF to pre-3.7.x behavior.

### Reference(s)

N/A

### Related Github Issue(s)

Steps to reproduce in CESM: clone CESM latest, manually checkout `[HEMCO]` external under `src/hemco/HEMCO` to versions 3.7.1. Run will fail due to AEIC19 inventory not containing proper sigma levels.
