### PR TITLE
rename HEMCO_Config.rc.sample to HEMCO_Config.rc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.8.0]
+### Changed
+
+### Fixed
+- Rename `HEMCO_Config.rc.sample` to `HEMCO_Config.rc` in `createRunDir.sh` if sample is used.
+
 ## [3.7.1] - 2023-10-10
 ### Changed
 - Updated version numbers to 3.7.1
@@ -30,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add GEOSIT as an allowable meteorology directory name in HEMCO_Config.rc
 - Added `.readthedocs.yaml` file to configure ReadTheDocs builds
 
-# Changed
+### Changed
 - `Verbose` is now a `true/false` variable in `run/HEMCO_sa_Config.rc` and `run/HEMCO_Config.rc.sample`
 - HEMCO warnings are now only generated when `Verbose: true` is found in the HEMCO configuration file (no more numerical levels)
 - Updated GFED4 emission factors for VOCs to Andreae et al. (2019)

--- a/run/createRunDir.sh
+++ b/run/createRunDir.sh
@@ -202,6 +202,11 @@ while [ "$valid_path" -eq 0 ]; do
     if [[ "$hco_config_file" == *".rc"* ]]; then
 	hco_config_dir=$(dirname $hco_config_file)
     fi
+
+    if [[ "$hco_config_file" == "./HEMCO_Config.rc.sample" ]]; then
+    mv "./HEMCO_Config.rc.sample" "./HEMCO_Config.rc"
+    hco_config_file="./HEMCO_Config.rc"
+    fi
     
 done
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Nick Balasus
Institution: Harvard University

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://hemco.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

In `createRunDir.sh`, users are given the option to type `./HEMCO_Config.rc.sample` if they do not have a `HEMCO_Config.rc` file. Currently, `HEMCO_Config.rc.sample` is copied directly without changing the name, meaning this code does not run successfully because `HEMCO_Config.rc` does not exist.

https://github.com/geoschem/HEMCO/blob/00aaf656934963d64d283a8e6c302743f62942e1/run/createRunDir.sh#L366-L368

To fix this, I rename `HEMCO_Config.rc.sample` to `HEMCO_Config.rc`. This is consistent with what is done for `HEMCO_Diagn.rc`.

https://github.com/geoschem/HEMCO/blob/00aaf656934963d64d283a8e6c302743f62942e1/run/createRunDir.sh#L310

### Expected changes

Only to HEMCO standalone run directory creations where the user specifies `./HEMCO_Config.rc.sample`.

### Reference(s)

n/a

### Related Github Issue(s)

n/a