### PR TITLE
Increase string length for netCDF variable name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+##[ Unreleased 3.7.2] - TBD
+### Changed
+- Increased netCDF variable string length from 50 to 100
+
 ## [3.7.1] - 2023-10-10
 ### Changed
 - Updated version numbers to 3.7.1

--- a/src/Core/hco_config_mod.F90
+++ b/src/Core/hco_config_mod.F90
@@ -635,7 +635,7 @@ CONTAINS
     LOGICAL                   :: Found
     CHARACTER(LEN= 63)        :: cName
     CHARACTER(LEN=255)        :: srcFile
-    CHARACTER(LEN= 50)        :: srcVar
+    CHARACTER(LEN=100)        :: srcVar
     CHARACTER(LEN= 31)        :: srcTime
     CHARACTER(LEN= 31)        :: TmCycle
     CHARACTER(LEN=  1)        :: WildCard

--- a/src/Core/hco_types_mod.F90
+++ b/src/Core/hco_types_mod.F90
@@ -338,7 +338,7 @@ MODULE HCO_TYPES_MOD
   !-------------------------------------------------------------------------
   TYPE :: FileData
      CHARACTER(LEN=255)          :: ncFile    ! file path+name
-     CHARACTER(LEN= 50)          :: ncPara    ! file parameter
+     CHARACTER(LEN=100)          :: ncPara    ! file parameter
      INTEGER                     :: ncYrs(2)  ! year range
      INTEGER                     :: ncMts(2)  ! month range
      INTEGER                     :: ncDys(2)  ! day range


### PR DESCRIPTION

### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard / GCST

### Describe the update

The GHGI v2 inventory in CH4 and carbon simulations within GEOS-Chem introduced netCDF varible names that exceeded the current defined string length (50 characters). This value has been increased to 100 to avoid errors.

### Expected changes

This is a zero difference update.