### PR TITLE
Turn off emission extensions when EMISSIONS logical is set to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Rename `HEMCO_Config.rc.sample` to `HEMCO_Config.rc` in `createRunDir.sh` if sample is used.
+- Added fix to turn off emissions extensions when `EMISSIONS` logical is false
 
 ## [3.7.1] - 2023-10-10
 ### Changed


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard / GCST

### Describe the update

The `EMISSIONS` logical switch in HEMCO_Config.rc currently only turns off base emissions and not the emission extensions. The emission extension data are bracketed by the logical so those data are not read in. However, because the extensions themselves are still on, they get called in HEMCO and result in the model crashing because the input data can't be found.

This is now fixed by adding a check in subroutine `ExtSwitch2Buffer` (in `hco_config_mod.F90`) to see if `EMISSIONS` is set and using that to define a local logical `DoEmis`. In that same routine, if `DoEmis` is false then all emission extensions will be defined with `Enabled = .FALSE.` to avoid calling them during the run stage of HEMCO.

Addresses https://github.com/geoschem/HEMCO/issues/249.

### Expected changes

This fix will result in zero differences in out-of-the-box simulations because `EMISSIONS` is set to true by default in all simulations.

### Related Github Issue(s)

- https://github.com/geoschem/HEMCO/issues/249
