### PR TITLE
Change GEOS-IT meteorology constants file year

### DIFF
--- a/src/Core/hco_extlist_mod.F90
+++ b/src/Core/hco_extlist_mod.F90
@@ -1567,7 +1567,7 @@ CONTAINS
     ELSE IF ( TRIM(CF%MetField) == 'GEOSIT' ) THEN
        DEF_MET_UC = 'GEOSIT'
        DEF_MET_LC = 'geosit'
-       DEF_CN_YR  = '2018' ! Constant met fld year
+       DEF_CN_YR  = '1998' ! Constant met fld year
        DEF_NC_VER = 'nc'   ! NetCDF extension
     ENDIF
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Havard University

### Describe the update

This PR changes the year of the GEOS-IT constants file from 2018 to 1998. This change is due to the way GMAO will store the GEOS-IT in their long-term archive.

### Expected changes

This is a no diff update.

### Reference(s)

None

### Related Github Issue(s)

This should be merged at the same time as the following GEOS-Chem PR which bring in GEOS-IT meteorology:
https://github.com/geoschem/geos-chem/pull/1848
