### PR TITLE
Remove month loop in GetIndex2Interp

### DIFF
--- a/src/Core/hcoio_util_mod.F90
+++ b/src/Core/hcoio_util_mod.F90
@@ -1177,27 +1177,6 @@ CONTAINS
           IF ( tidx2 > 0 ) EXIT
        ENDDO
 
-       ! Repeat above but now only modify month.
-       IF ( tidx2 < 0 ) THEN
-          tmpYMDhm = availYMDhm(tidx1)
-          DO
-             ! Increase by one month
-             tmpYMDhm = tmpYMDhm + 1.0e6_dp
-
-             ! Exit if we are beyond available dates
-             IF ( tmpYMDhm > availYMDhm(nTime) ) EXIT
-
-             ! Check if there is a time slice with that date
-             DO I = tidx1,nTime
-                IF ( ABS( tmpYMDhm - availYMDhm(I) ) < EPSILON ) THEN
-                   tidx2 = I
-                   EXIT
-                ENDIF
-             ENDDO
-             IF ( tidx2 > 0 ) EXIT
-          ENDDO
-       ENDIF
-
        ! Repeat above but now only modify day
        IF ( tidx2 < 0 ) THEN
           tmpYMDhm = availYMDhm(tidx1)


### PR DESCRIPTION
### Name and Institution (Required)

Name: Nick Balasus
Institution: Harvard University

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://hemco.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

Removes one of the loops in `GetIndex2Interp` that was used to find the upper bound for time interpolation. The loop that is removed is impacting leaf area index interpolation (see #253).

### Expected changes

`Met_MODISLAI` will be altered in all simulations.

### Reference(s)

n/a

### Related Github Issue(s)

#253
