### PR TITLE
Fix remaining memory leaks in HEMCO

### DIFF
--- a/src/Core/hco_arr_mod.F90
+++ b/src/Core/hco_arr_mod.F90
@@ -1638,6 +1638,9 @@ CONTAINS
        DEALLOCATE( Arr )
     ENDIF
 
+    ! Make sure we return a null pointer
+    Arr => NULL()
+
   END SUBROUTINE HCO_ArrCleanup_2D_Hp
 !EOC
 !------------------------------------------------------------------------------
@@ -1684,6 +1687,9 @@ CONTAINS
        CALL HCO_ValCleanup( Arr%Val, Arr%Alloc, DeepClean=DC )
        DEALLOCATE( Arr )
     ENDIF
+
+    ! Make sure we return a null pointer
+    Arr => NULL()
 
   END SUBROUTINE HCO_ArrCleanup_2D_Sp
 !EOC
@@ -1732,6 +1738,9 @@ CONTAINS
        DEALLOCATE( Arr )
     ENDIF
 
+    ! Make sure we return a null pointer
+    Arr => NULL()
+
   END SUBROUTINE HCO_ArrCleanup_2D_I
 !EOC
 !------------------------------------------------------------------------------
@@ -1778,6 +1787,10 @@ CONTAINS
        CALL HCO_ValCleanup( Arr%Val, Arr%Alloc, DeepClean=DC )
        DEALLOCATE( Arr )
     ENDIF
+
+    ! Make sure we return a null pointer
+    Arr => NULL()
+
   END SUBROUTINE HCO_ArrCleanup_3D_Hp
 !EOC
 !------------------------------------------------------------------------------
@@ -1824,6 +1837,9 @@ CONTAINS
        CALL HCO_ValCleanup( Arr%Val, Arr%Alloc, DeepClean=DC )
        DEALLOCATE( Arr )
     ENDIF
+
+    ! Make sure we return a null pointer
+    Arr => NULL()
 
   END SUBROUTINE HCO_ArrCleanup_3D_Sp
 !EOC
@@ -1876,6 +1892,9 @@ CONTAINS
 
     ENDIF
 
+    ! Make sure we return a null pointer
+    ArrVec => NULL()
+
   END SUBROUTINE HCO_ArrVecCleanup_2D_Hp
 !EOC
 !------------------------------------------------------------------------------
@@ -1926,6 +1945,9 @@ CONTAINS
        DEALLOCATE ( ArrVec )
 
     ENDIF
+
+    ! Make sure we return a null pointer
+    ArrVec => NULL()
 
   END SUBROUTINE HCO_ArrVecCleanup_2D_Sp
 !EOC
@@ -1978,6 +2000,9 @@ CONTAINS
 
     ENDIF
 
+    ! Make sure we return a null pointer
+    ArrVec => NULL()
+
   END SUBROUTINE HCO_ArrVecCleanup_3D_Hp
 !EOC
 !------------------------------------------------------------------------------
@@ -2028,6 +2053,9 @@ CONTAINS
        DEALLOCATE ( ArrVec )
 
     ENDIF
+
+    ! Make sure we return a null pointer
+    ArrVec => NULL()
 
   END SUBROUTINE HCO_ArrVecCleanup_3D_Sp
 !EOC

--- a/src/Core/hco_tidx_mod.F90
+++ b/src/Core/hco_tidx_mod.F90
@@ -285,6 +285,7 @@ CONTAINS
     ! tIDx_Cleanup begins here!
     !======================================================================
 
+    ! Deallocate fields
     IF ( ASSOCIATED( AlltIDx ) ) THEN
 
        IF ( ASSOCIATED(AlltIDx%CONSTANT) ) THEN
@@ -307,9 +308,18 @@ CONTAINS
           DEALLOCATE(AlltIDx%MONTHLY)
        ENDIF
 
-       ! Also deallocate AlltIDx pointer
+       ! Nullify fields
+       AlltIDx%CONSTANT    => NULL()
+       AlltIDx%HOURLY      => NULL()
+       AlltIDx%HOURLY_GRID => NULL()
+       AlltIDx%WEEKDAY     => NULL()
+       AlltIDx%MONTHLY     => NULL()
+
+       ! Deallocate container
        DEALLOCATE( AlltIDx )
     ENDIF
+
+    ! Make sure we return a null pointer
     AlltIDx => NULL()
 
   END SUBROUTINE tIDx_Cleanup


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/help-and-reference/CONTRIBUTING.html)

### Describe the update
**This is a placeholder PR and should not yet be merged.  I have made the base branch `main` but will change it later.**

This is a companion PR to [geoschem/geos-chem#2102](https://github.com/geoschem/geos-chem/issues/2102).  Configuring GEOS-Chem with `-DSANITIZE=y` has revealed the following memory leaks in GEOS-Chem and HEMCO:
```console
=================================================================
==1495473==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 107464 byte(s) in 133 object(s) allocated from:
    #0 0x14815712993f in __interceptor_malloc ../../.././libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x1bd566d in __hco_filedata_mod_MOD_filedata_init /n/holyscratch01/jacob_lab/ryantosca/tests/cloudj/test_memory/CodeDir/src/HEMCO/src/Core/hco_filedata_mod.F90:174
    #2 0x202020202020201f  (<unknown module>)

Direct leak of 29248 byte(s) in 8 object(s) allocated from:
    #0 0x14815712993f in __interceptor_malloc ../../.././libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x10c438e in __histcontainer_mod_MOD_histcontainer_create /n/holyscratch01/jacob_lab/ryantosca/tests/cloudj/test_memory/CodeDir/src/GEOS-Chem/History/histcontainer_mod.F90:319
    #2 0x202020202020201f  (<unknown module>)

Direct leak of 3720 byte(s) in 1 object(s) allocated from:
    #0 0x14815712993f in __interceptor_malloc ../../.././libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x18f6ae1 in __state_chm_mod_MOD_init_state_chm /n/holyscratch01/jacob_lab/ryantosca/tests/cloudj/test_memory/CodeDir/src/GEOS-Chem/Headers/state_chm_mod.F90:803

Direct leak of 3160 byte(s) in 1 object(s) allocated from:
    #0 0x14815712993f in __interceptor_malloc ../../.././libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x18fe162 in __state_chm_mod_MOD_init_state_chm /n/holyscratch01/jacob_lab/ryantosca/tests/cloudj/test_memory/CodeDir/src/GEOS-Chem/Headers/state_chm_mod.F90:1027

SUMMARY: AddressSanitizer: 143592 byte(s) leaked in 143 allocation(s).
```

Leak 1 is in HEMCO.  We are still investigating.

The other leaks are being addressed in https://github.com/geoschem/geos-chem/pull/2104.

Tagging @msulprizio @lizziel

### Expected changes
This will be a zero-diff update that will remove memory leaks.  It will not change results.

### Reference(s)
N/A

### Related Github Issue(s)

- See https://github.com/geoschem/geos-chem/pull/2104
- Closes https://github.com/geoschem/geos-chem/issues/2102