### PR TITLE
Updates from GMAO: HCOIO_IsValid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated IsModelLevel check for CESM and WRF-GC
 - Interpolation error for 8-day MODIS LAI files (removed month loop in `GetIndex2Interp`)
 
+### Added
+- Add subroutine HCOIO_IsValid to query if a HEMCO container has a valid field attached to it.
+
 ## [3.7.2] - 2023-12-01
 ### Added
 - Script `.release/changeVersionNumbers.sh` to change version numbers before a new HEMCO release


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR pulls in the latest updates developed by GMAO into the standard model. From Christoph Keller (@christophkeller):

> HCOIO_IsValid is a wrapper routine to check if a HEMCO container has a valid field attached to it. In an ESMF environment, there are edge cases where the fields can change from defined to undefined over the course of a simulation. This routine returns the validity of a field as determined by ESMF routine ESMFL_field_is_undefined. In a non-ESMF environment, this routine simply returns whether the queried field name has a corresponding data container or not.

### Expected changes

This is a zero diff update.

### Reference(s)

None

### Related Github Issue(s)

https://github.com/GEOS-ESM/HEMCO/pull/11
