### PR TITLE
Allow up to 10 nested brackets in the HEMCO_Config.rc file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+### Changed
+- Now allow up to 10 nested brackets (`((( )))`) in the `HEMCO_Config.rc` file
+
 ## [3.8.0] - 2024-02-07
 ### Changed
 - Updated TOMAS_Jeagle sea salt extension

--- a/src/Core/hco_config_mod.F90
+++ b/src/Core/hco_config_mod.F90
@@ -1366,7 +1366,7 @@ CONTAINS
 ! !LOCAL VARIABLES:
 !
     ! Maximum number of nested brackets
-    INTEGER, PARAMETER            :: MAXBRACKNEST = 5
+    INTEGER, PARAMETER            :: MAXBRACKNEST = 10
     INTEGER                       :: IDX, STRLEN, ExtNr
     LOGICAL                       :: FOUND
     LOGICAL                       :: UseBracket, UseThis


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://hemco.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update
In this PR, we have updated the `MAXBRACKNEST` parameter setting from 5 to 10 in the `BracketCheck` routine of `src/Core/hco_config_mod.F90`.  This update is needed to account for additional nested brackets, because bracket conditions do not recognize the `.and.` operator. 

### Expected changes
This is a zero-diff update.  It should allow `HEMCO_Config.rc` files with more than 5 nested brackets (such as we have in https://github.com/geoschem/geos-chem/pull/2171) to be parsed without error.

### Related Github Issue(s)

- Needed for https://github.com/geoschem/geos-chem/pull/2171
