### PR TITLE
Restrict volcano climatology prints to root thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.8.1] - TBD
+### Fixed
+- Limit volcano climatology file read message to root core
+
 ## [3.8.0] - 2024-02-07
 ### Changed
 - Updated TOMAS_Jeagle sea salt extension

--- a/src/Extensions/hcox_volcano_mod.F90
+++ b/src/Extensions/hcox_volcano_mod.F90
@@ -651,9 +651,11 @@ CONTAINS
           INQUIRE( FILE=TRIM( ThisFile ), EXIST=FileExists )
 
           ! Write message to stdout and HEMCO log
-          MSG = 'Attempting to read volcano climatology file'
-          WRITE( 6,   300 ) TRIM( MSG )             
-          CALL HCO_MSG( HcoState%Config%Err, MSG )
+          IF ( Hcostate%amIRoot ) THEN
+             MSG = 'Attempting to read volcano climatology file'
+             WRITE( 6,   300 ) TRIM( MSG )             
+             CALL HCO_MSG( HcoState%Config%Err, MSG )
+          ENDIF
 
           ! Create a display string based on whether or not the file is found
           IF ( FileExists ) THEN


### PR DESCRIPTION
### Name and Institution (Required)

Name: Christoph Keller
Institution: GMAO

### Describe the update

This PR is a bug fix that limits the warning message about using climatological volcano emissions to the root CPU.

### Expected changes

This is a no diff update.

### Reference(s)

None

### Related Github Issue(s)

https://github.com/GEOS-ESM/HEMCO/pull/13
