### PR TITLE
Now use short submodule names in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "docs/source/geos-chem-shared-docs"]
+[submodule "geos-chem-shared-docs"]
 	path = docs/source/geos-chem-shared-docs
 	url = https://github.com/geoschem/geos-chem-shared-docs.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - TBD
 ### Changed
 - Now allow up to 10 nested brackets (`((( )))`) in the `HEMCO_Config.rc` file
+- Now use short submodule names (i.e. w/o path) in `.gitmodules`
 
 ### Fixed
 - Limit volcano climatology file read message to root core


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/help-and-reference/CONTRIBUTING.html)

### Describe the update

This is a minor update that fixes some incorrect submodule names in the `.gitmodules` file.  We have changed:
```console
[submodule "docs/source/geos-chem-shared-docs"]
```
to
```console
[submodule "geos-chem-shared-docs"]
```

### Expected changes
This is a zero-diff update.

### Related Github Issue(s)
NOTE: This PR should be merged immediately after:
- https://github.com/geoschem/geos-chem/pull/2154
- https://github.com/geoschem/cloud-j/pull/2