### PR TITLE
Handle 3D NEI emissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Limit volcano climatology file read message to root core
+- Updated `hco_interp_mod.F90` to handle 3D NEI emissions.
 
 ## [3.8.0] - 2024-02-07
 ### Changed

--- a/src/Core/hco_interp_mod.F90
+++ b/src/Core/hco_interp_mod.F90
@@ -500,17 +500,17 @@ CONTAINS
     IF ( nlev == nz .OR. nlev == nz + 1 ) THEN
        IsModelLev = .TRUE.
 
-   ! If input is 72 layer (or 36 layer) and output is 47 layer
+   ! If input is 72 layer (or 3/11/36 layer) and output is 47 layer
     ELSEIF ( nz == 47 ) THEN
-       IsModelLev = ( nlev == 72 .OR. nlev == 73 .OR. nlev == 36)
+       IsModelLev = ( nlev == 72 .OR. nlev == 73 .OR. nlev == 36 .OR. nlev == 3 .OR. nlev == 11)
 
     ! If input is 102 layer and output is 74 layer
     ELSEIF ( nz == 74 ) THEN
        IsModelLev = ( nlev == 102 .OR. nlev == 103 )
 
-    ! If input is 47 layer (or 36 layer) and output is 72 layer
+    ! If input is 47 layer (or 3/11/36 layer) and output is 72 layer
     ELSEIF ( nz == 72 ) THEN
-       IsModelLev = ( nlev == 47 .OR. nlev == 48 .OR. nlev == 36)
+       IsModelLev = ( nlev == 47 .OR. nlev == 48 .OR. nlev == 36 .OR. nlev == 3 .OR. nlev == 11)
 
     ELSE
       IsModelLev = .FALSE.
@@ -543,10 +543,11 @@ CONTAINS
 ! levels, this is interpreted as native data and will be collapsed onto the 
 ! reduced GISS grid. If the input holds 47/48 input levels, this is interpreted
 ! as reduced GEOS-5 data and it will be inflated to the native GEOS-5 grid
-! (with a warning, as this is not recommended). If the input holds 36 input levels,
-! this is assumed to be the first 36 levels of the GEOS-5 grid, meaning they will be
-! written as levels 1-36 of a 47 or 72 level output grid (with the remaining values
-! left to be zero) (nbalasus, 8/29/2023).
+! (with a warning, as this is not recommended). If the input holds N input levels,
+! (where N = 3, 11, or 36 to account for NEI and AEIC emissions), this is assumed 
+! to be the first N levels of the GEOS-5 grid, meaning they will be written as 
+! levels 1-N of a 47 or 72 level output grid (with the remaining values left to
+! be zero) (nbalasus, 8/29/2023).
 !
 !
 ! Currently, this routine can remap the following combinations:
@@ -554,7 +555,7 @@ CONTAINS
 ! * Native GEOS-5 onto reduced GEOS-5 (72 --> 47 levels, 73 --> 48 edges)
 ! * Native GISS onto reduced GISS (102 --> 74 levels, 103 --> 75 edges) 
 ! * Reduced GEOS-5 onto native GEOS-5 (47 --> 72 levels, 48 --> 73 edges)
-! * 36 levels onto native/reduced GEOS-5 (36 --> levels 1-36 levels of 47/72 level grid, rest are 0)
+! * N (N = 3/11/36) levels onto native/reduced GEOS-5 (N --> levels 1-N levels of 47/72 level grid, rest are 0)
 !
 ! !INTERFACE:
 !
@@ -638,8 +639,8 @@ CONTAINS
     IF ( ( ( nlev == nz ) .OR. ( nlev == nz+1 ) ) .OR. &                          ! write data without doing anything
          ( ( nz == 47 ) .AND. ( ( nlev == 72 ) .OR. ( nlev == 73 ) ) ) .OR. &     ! collapse native to reduced GEOS-5
          ( ( nz == 74 ) .AND. ( ( nlev == 102 ) .OR. ( nlev == 103 ) ) ) .OR. &   ! collapse native to reduced GISS
-         ( ( nz == 72 ) .AND. ( ( nlev == 47 ) .OR. ( nlev == 48 ) ) ) .OR. &   ! inflate reduced to native GEOS-5
-         ( ( ( nz == 72 ) .OR. ( nz == 47 ) ) .AND. ( nlev == 36 ) ) ) THEN         ! write 36 levels to reduced/native GEOS-5
+         ( ( nz == 72 ) .AND. ( ( nlev == 47 ) .OR. ( nlev == 48 ) ) ) .OR. &     ! inflate reduced to native GEOS-5
+         ( ( ( nz == 72 ) .OR. ( nz == 47 ) ) .AND. ( ( nlev == 3 ) .OR. ( nlev == 11 ) .OR. ( nlev == 36 ) ) ) ) THEN  ! write 3/11/36 levels to reduced/native GEOS-5
          ! do nothing
     ELSE
       WRITE(MSG,*) 'ModelLev_Interpolate was called but MESSy should have been used: ',TRIM(Lct%Dct%cName)
@@ -694,15 +695,21 @@ CONTAINS
           ELSEIF ( nlev == 73 ) THEN
              NL   = 37
              nout = 48
+          ELSEIF ( nlev == 3 ) THEN
+             NL   = 3
+             nout = 47
+          ELSEIF ( nlev == 11 ) THEN
+             NL   = 11
+             nout = 47
           ELSEIF ( nlev == 36 ) THEN
              NL   = 36
              nout = 47
           ELSE
              MSG = 'Can only remap from native onto reduced GEOS-5 if '// &
-                   'input data has exactly 72, 73, or 36 levels: '//TRIM(Lct%Dct%cName)
+                   'input data has exactly 72, 73, 3, 11, or 36 levels: '//TRIM(Lct%Dct%cName)
              CALL HCO_ERROR( MSG, RC )
              RETURN
-          ENDIF ! nlev == (72,73,36,ELSE)
+          ENDIF ! nlev == (72,73,3,11,36ELSE)
 
           ! Make sure output array is allocated
           CALL FileData_ArrCheck( HcoState%Config, Lct%Dct%Dta, nx, ny, nout, nt, RC )
@@ -743,7 +750,15 @@ CONTAINS
                Lct%Dct%Dta%V3(T)%Val(:,:,46) = REGR_4D(:,:,65,T)
                Lct%Dct%Dta%V3(T)%Val(:,:,47) = REGR_4D(:,:,69,T)
                Lct%Dct%Dta%V3(T)%Val(:,:,48) = REGR_4D(:,:,73,T)
-            ! If the input is 36 levels, levels 37-47 are set to 0
+            ! If the input is N (N = 3/11/36) levels, levels N+1 to 47 are set to 0
+             ELSEIF ( nlev == 3 ) THEN
+               DO L = 4,47
+                  Lct%Dct%Dta%V3(T)%Val(:,:,L) = 0.0_hp
+               ENDDO !L
+             ELSEIF ( nlev == 11 ) THEN
+               DO L = 12,47
+                  Lct%Dct%Dta%V3(T)%Val(:,:,L) = 0.0_hp
+               ENDDO !L
              ELSEIF ( nlev == 36 ) THEN
                DO L = 37,47
                   Lct%Dct%Dta%V3(T)%Val(:,:,L) = 0.0_hp
@@ -756,8 +771,8 @@ CONTAINS
           IF ( HCO_IsVerb( HcoState%Config%Err ) ) THEN
              WRITE(MSG,*) 'Mapped ', nlev, ' levels onto reduced GEOS-5 levels.'
              CALL HCO_MSG(HcoState%Config%Err,MSG)
-             IF ( nlev == 36 ) THEN
-               WRITE(MSG,*) 'The input variable has 36 L, which were written to be L 1-36 on the output 47 L grid (remaining values set to 0).'
+             IF ( nlev == 3 .OR. nlev == 11 .OR. nlev == 36 ) THEN
+               WRITE(MSG,*) 'The input variable has ', nlev, 'L, which were written to be L 1-', nlev, ' on the output 47 L grid (remaining values set to 0).'
              ELSE
                WRITE(MSG,*) 'Pressure-weighted vertical regridding was done - consider if this is appropriate for the variable units.'
              CALL HCO_MSG(HcoState%Config%Err,MSG)
@@ -857,15 +872,21 @@ CONTAINS
           ELSEIF ( nlev == 48 ) THEN
              NL   = 37
              nout = 73
+          ELSEIF ( nlev == 3 ) THEN
+             NL   = 3
+             nout = 72
+          ELSEIF ( nlev == 11 ) THEN
+             NL   = 11
+             nout = 72
           ELSEIF ( nlev == 36 ) THEN
              NL   = 36
              nout = 72
           ELSE
              MSG = 'Can only remap from reduced onto native GEOS-5 if '// &
-                   'input data has exactly 47, 48, or 36 levels: '//TRIM(Lct%Dct%cName)
+                   'input data has exactly 47, 48, 3, 11, or 36 levels: '//TRIM(Lct%Dct%cName)
              CALL HCO_ERROR( MSG, RC )
              RETURN
-          ENDIF ! nlev == (48,48,36,ELSE)
+          ENDIF ! nlev == (48,48,3,11,36,ELSE)
 
           ! Make sure output array is allocated
           CALL FileData_ArrCheck( HcoState%Config, Lct%Dct%Dta, nx, ny, nout, nt, RC )
@@ -924,20 +945,30 @@ CONTAINS
                    Lct%Dct%Dta%V3(T)%Val(:,:,fineIDX) = REGR_4D(:,:,coarseIDX,T)
                 ENDDO ! I
                 
+             ELSEIF ( nlev == 3 ) THEN
+               DO L = 4,72
+                  Lct%Dct%Dta%V3(T)%Val(:,:,L) = 0.0_hp
+               ENDDO !L
+
+             ELSEIF ( nlev == 11 ) THEN
+               DO L = 12,72
+                  Lct%Dct%Dta%V3(T)%Val(:,:,L) = 0.0_hp
+               ENDDO !L
+
              ELSEIF ( nlev == 36 ) THEN
                DO L = 37,72
                   Lct%Dct%Dta%V3(T)%Val(:,:,L) = 0.0_hp
                ENDDO !L
 
-             ENDIF ! nlev == (47,48,36)
+             ENDIF ! nlev == (47,48,3,11,36)
           ENDDO ! T
 
           ! Verbose
           IF ( HCO_IsVerb(HcoState%Config%Err ) ) THEN
              WRITE(MSG,*) 'Mapped ', nlev, ' levels onto native GEOS-5 levels.'
              CALL HCO_MSG(HcoState%Config%Err,MSG)
-             IF ( nlev == 36 ) THEN
-               WRITE(MSG,*) 'The input variable has 36 L, which were written to be L 1-36 on the output 72 L grid (remaining values set to 0).'
+             IF ( nlev == 3 .OR. nlev == 11 .OR. nlev == 36 ) THEN
+               WRITE(MSG,*) 'The input variable has ', nlev, 'L, which were written to be L 1-', nlev, ' on the output 72 L grid (remaining values set to 0).'
              ELSE
                WRITE(MSG,*) 'Inflating from 47/48 to 72/73 levels is not recommended and is likely not mass-conserving.'
              ENDIF


### PR DESCRIPTION
### Name and Institution (Required)

Name: Nick Balasus
Institution: Harvard

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://hemco.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

Modifies `src/Core/hco_interp_mod.F90` to handle 3D emissions from NEI. The handling is now that if the emissions are 3, 11, or 36 levels, they are assumed to be GEOS-Chem levels. 3 and 11 levels are NEI emissions and 36 levels are AEIC emissions. This is not the prettiest fix so let me know what you think @jimmielin @yantosca. This update was necessary because of the changes made in https://github.com/geoschem/HEMCO/commit/daf54d07ed16d0948302070855468b6b27fdd9a5.

### Expected changes

If merged with https://github.com/geoschem/geos-chem/pull/2213, NEI emissions should work again.  Thanks to @Lukemonr for finding this issue.

### Reference(s)

n/a

### Related Github Issue(s)

https://github.com/geoschem/HEMCO/issues/264
