### PR TITLE
Fix inconsistent pressure units in HEMCO standalone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - TBD
 ### Fixed
 - Added brackets around `exempt-issue-labels` list in `.github/workflows/stale.yml`
+- Fixed incorrect pressure handling in HEMCO standalone (see issue #277)
 
 ## [3.9.2] - 2024-07-24
 ### Changed


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This is the companion PR to #277 by @yuanjianz.  It fixes the inconsistent pressure unit handling in the HEMCO standalone as described in that issue.

### Expected changes
The HEMCO standalone will use 'Pa' for pressure units regardless of input meteorology.

### Related Github Issue
- Closes #277