### PR TITLE
Bugfix: Restore stale workflow functionality

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-label: 'stale'
-        exempt-issue-labels: ['category: Discussion','category: Feature Request','deferred','help needed: Open Research Problem','help needed: Request Input from Community','never stale','TODO: Documentation']
+        exempt-issue-labels: 'category: Discussion,category: Feature Request,deferred,help needed: Open Research Problem,help needed: Request Input from Community,never stale,TODO: Documentation'
         days-before-issue-stale: 30
         days-before-issue-close: 7
         stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. If there are no updates within 7 days it will be closed. You can add the "never stale" tag to prevent the issue from closing this issue.'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added TSOIL1 field to ExtState
 
+### Fixed
+- Fixed formatting error in `.github/workflows/stale.yml` that caused the Mark Stale Issues action not to run
+
 ### Changed
 - Added emission factors for ALK6, C4H6, EBZ, STYR, TMB for GFED and FINN biomass burning extensions
 - Updated soil NOx extention to include the option to use soil temperature and parameterization based on Yi Wang et al. (ERL, 2021) instead of the temperature at 2 meters.


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard

### Describe the update

The stale workflows are currently failing with the error:

```
Invalid workflow file: .github/workflows/stale.yml#L26
The workflow is not valid. .github/workflows/stale.yml (Line: 26, Col: 11): A sequence was not expected
```

To fix this, the list of exempt-issues-labels in .github/workflows/stale.yml must be a  comma separated list. A single quote is placed around the list to allow for use of colons in label names.

Note that the **Mark stale issues** Github action will need to be reenabled once the `dev/14.5.0` branch has been merged into `main`.

### Expected changes

This is a zero-difference update with respect to the fullchemistry benchmark. It only impacts github workflows. 

### Related Github issues

- https://github.com/geoschem/geos-chem/pull/2472
- https://github.com/geoschem/GCClassic/pull/67
- https://github.com/geoschem/GCHP/pull/444
- https://github.com/geoschem/HEMCO/pull/289
- https://github.com/geoschem/gcpy/pull/342