### PR TITLE
Restrict read prints if using MPI

### DIFF
--- a/src/Core/hco_driver_mod.F90
+++ b/src/Core/hco_driver_mod.F90
@@ -62,7 +62,7 @@ CONTAINS
 !\\
 ! !INTERFACE:
 !
-  SUBROUTINE HCO_Run( HcoState, Phase, RC, IsEndStep )
+  SUBROUTINE HCO_Run( am_I_Root, HcoState, Phase, RC, IsEndStep )
 !
 ! !USES:
 !
@@ -75,6 +75,7 @@ CONTAINS
 !
 ! !INPUT PARAMETERS:
 !
+    LOGICAL,         INTENT(IN   ) :: am_I_Root   ! Root thread?
     INTEGER,         INTENT(IN   ) :: Phase       ! Run phase (1 or 2)
     LOGICAL,         INTENT(IN   ), OPTIONAL :: IsEndStep ! Last timestep of simulation?
 !
@@ -162,7 +163,7 @@ CONTAINS
 
     ! Update data, as specified in ReadList.
     IF ( Phase /= 2 ) THEN
-       CALL ReadList_Read( HcoState, RC )
+       CALL ReadList_Read( am_I_Root, HcoState, RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           PRINT *, "Error in ReadList_Read called from hco_run"
           RETURN

--- a/src/Core/hco_readlist_mod.F90
+++ b/src/Core/hco_readlist_mod.F90
@@ -223,7 +223,7 @@ CONTAINS
 !\\
 ! !INTERFACE:
 !
-  SUBROUTINE ReadList_Read( HcoState, RC, ReadAll )
+  SUBROUTINE ReadList_Read( am_I_Root, HcoState, RC, ReadAll )
 !
 ! !USES:
 !
@@ -236,6 +236,7 @@ CONTAINS
 !
 ! !INPUT PARAMETERS:
 !
+    LOGICAL,           INTENT(IN   )  :: am_I_Root  ! root thread?
     LOGICAL, OPTIONAL, INTENT(IN   )  :: ReadAll    ! read all fields?
 !
 ! !INPUT/OUTPUT PARAMETERS:
@@ -285,7 +286,7 @@ CONTAINS
           WRITE(MSG,*) 'Now reading once list!'
           CALL HCO_MSG(HcoState%Config%Err,MSG)
        ENDIF
-       CALL ReadList_Fill( HcoState, HcoState%ReadLists%Once, RC )
+       CALL ReadList_Fill( am_I_Root, HcoState, HcoState%ReadLists%Once, RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           MSG = 'Error in ReadList_Fill (1) called from HEMCO ReadList_Read'
           CALL HCO_ERROR( MSG, RC, THISLOC = LOC )
@@ -299,7 +300,7 @@ CONTAINS
           WRITE(MSG,*) 'Now reading year list!'
           CALL HCO_MSG(HcoState%Config%Err,MSG)
        ENDIF
-       CALL ReadList_Fill( HcoState, HcoState%ReadLists%Year, RC )
+       CALL ReadList_Fill( am_I_Root, HcoState, HcoState%ReadLists%Year, RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           MSG = 'Error in ReadList_Fill (2) called from HEMCO ReadList_Read'
           CALL HCO_ERROR( MSG, RC, THISLOC = LOC )
@@ -313,7 +314,7 @@ CONTAINS
           WRITE(MSG,*) 'Now reading month list!'
           CALL HCO_MSG(HcoState%Config%Err,MSG)
        ENDIF
-       CALL ReadList_Fill( HcoState, HcoState%ReadLists%Month, RC )
+       CALL ReadList_Fill( am_I_Root, HcoState, HcoState%ReadLists%Month, RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           MSG = 'Error in ReadList_Fill (3) called from HEMCO ReadList_Read'
           CALL HCO_ERROR( MSG, RC, THISLOC = LOC )
@@ -327,7 +328,7 @@ CONTAINS
           WRITE(MSG,*) 'Now reading day list!'
           CALL HCO_MSG(HcoState%Config%Err,MSG)
        ENDIF
-       CALL ReadList_Fill( HcoState, HcoState%ReadLists%Day, RC )
+       CALL ReadList_Fill( am_I_Root, HcoState, HcoState%ReadLists%Day, RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           MSG = 'Error in ReadList_Fill (4) called from HEMCO ReadList_Read'
           CALL HCO_ERROR( MSG, RC, THISLOC = LOC )
@@ -341,7 +342,7 @@ CONTAINS
           WRITE(MSG,*) 'Now reading hour list!'
           CALL HCO_MSG(HcoState%Config%Err,MSG)
        ENDIF
-       CALL ReadList_Fill( HcoState, HcoState%ReadLists%Hour, RC )
+       CALL ReadList_Fill( am_I_Root, HcoState, HcoState%ReadLists%Hour, RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           MSG = 'Error in ReadList_Fill (5) called from HEMCO ReadList_Read'
           CALL HCO_ERROR( MSG, RC, THISLOC = LOC )
@@ -355,7 +356,7 @@ CONTAINS
           WRITE(MSG,*) 'Now reading 3-hour list!'
           CALL HCO_MSG(HcoState%Config%Err,MSG)
        ENDIF
-       CALL ReadList_Fill( HcoState, HcoState%ReadLists%Hour3, RC )
+       CALL ReadList_Fill( am_I_Root, HcoState, HcoState%ReadLists%Hour3, RC )
        IF ( RC /= HCO_SUCCESS ) THEN
           MSG = 'Error in ReadList_Fill (6) called from HEMCO ReadList_Read'
           CALL HCO_ERROR( MSG, RC, THISLOC = LOC )
@@ -368,7 +369,7 @@ CONTAINS
        WRITE(MSG,*) 'Now reading always list!'
        CALL HCO_MSG(HcoState%Config%Err,MSG)
     ENDIF
-    CALL ReadList_Fill( HcoState, HcoState%ReadLists%Always, RC )
+    CALL ReadList_Fill( am_I_Root, HcoState, HcoState%ReadLists%Always, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        MSG = 'Error in called ReadList_Fill (7) from HEMCO ReadList_Read'
        CALL HCO_ERROR( MSG, RC, THISLOC = LOC )
@@ -407,7 +408,7 @@ CONTAINS
 !\\
 ! !INTERFACE:
 !
-  SUBROUTINE ReadList_Fill( HcoState, ReadList, RC )
+  SUBROUTINE ReadList_Fill( am_I_Root, HcoState, ReadList, RC )
 !
 ! !USES:
 !
@@ -422,6 +423,7 @@ CONTAINS
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
+    LOGICAL,         INTENT(IN)     :: am_I_Root  ! Root thread?    
     TYPE(HCO_State), POINTER        :: HcoState   ! HEMCO state object
     TYPE(ListCont),  POINTER        :: ReadList   ! Current reading list
     INTEGER,         INTENT(INOUT)  :: RC         ! Success or failure?
@@ -499,7 +501,7 @@ CONTAINS
           ELSE
 
              ! Read data
-             CALL HCOIO_DATAREAD( HcoState, Lct, RC )
+             CALL HCOIO_DATAREAD( am_I_Root, HcoState, Lct, RC )
              IF ( RC /= HCO_SUCCESS ) THEN
                 MSG = 'Error in HCOIO_DATAREAD called from HEMCO ReadList_Fill: ' // TRIM(Lct%Dct%cname)
                 CALL HCO_ERROR( MSG, RC, THISLOC = LOC )

--- a/src/Core/hcoio_dataread_mod.F90
+++ b/src/Core/hcoio_dataread_mod.F90
@@ -158,7 +158,7 @@ CONTAINS
 !\\
 ! !INTERFACE:
   !
-  SUBROUTINE HCOIO_DataRead( HcoState, Lct, RC )
+  SUBROUTINE HCOIO_DataRead( am_I_Root, HcoState, Lct, RC )
 !
 ! !USES:
 !
@@ -166,6 +166,7 @@ CONTAINS
 !
 ! !INPUT PARAMETERS:
 !
+    LOGICAL,          INTENT(IN)     :: am_I_Root
     TYPE(HCO_State),  POINTER        :: HcoState
     TYPE(ListCont),   POINTER        :: Lct
 !
@@ -203,7 +204,7 @@ CONTAINS
 
     ! Call the HEMCO Data Input Layer
     ! Selection of which HCOIO module to be used is performed at compile level
-    CALL HCOIO_READ( HcoState, Lct, RC )
+    CALL HCOIO_READ( am_I_Root, HcoState, Lct, RC )
 
     ! Trap potential errors
     IF ( RC /= HCO_SUCCESS ) THEN

--- a/src/Core/hcoio_read_std_mod.F90
+++ b/src/Core/hcoio_read_std_mod.F90
@@ -115,7 +115,7 @@ CONTAINS
 !\\
 ! !INTERFACE:
 !
-  SUBROUTINE HCOIO_Read( HcoState, Lct, RC )
+  SUBROUTINE HCOIO_Read( am_I_Root, HcoState, Lct, RC )
 !
 ! !USES:
 !
@@ -147,6 +147,7 @@ CONTAINS
 !
 ! !INPUT PARAMETERS:
 !
+    LOGICAL,          INTENT(IN)     :: am_I_Root  ! Root thread?
     TYPE(HCO_State),  POINTER        :: HcoState   ! HEMCO state object
     TYPE(ListCont),   POINTER        :: Lct        ! HEMCO list container
 !
@@ -413,7 +414,7 @@ CONTAINS
        ELSE
 
           ! Write a mesage to stdout (HEMCO: Opening...)
-          WRITE( 6, 100 ) TRIM( srcFile )
+          IF ( am_I_Root ) WRITE( 6, 100 ) TRIM( srcFile )
 
        ENDIF
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR passes am_I_Root to several HEMCO subroutines to restrict prints if using MPI. This update is relevant only for use of HEMCO read routines within MPI models. It does not impact GCHP.

**Note that this update will impact HEMCO interfaces in parent models. Companion PRs coming soon.**

### Expected changes

This is a no diff update.

### Reference(s)

None

### Related Github Issue

None
