### PR TITLE
Add CI builds for macOS, Windows, and Ubuntu

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -1,0 +1,39 @@
+name: Mac
+
+on: 
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  gnu:
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        gcc_version: [12, 13, 14]
+        build_type: [Debug, Release]
+    env:
+      FC: gfortran-${{ matrix.gcc_version }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: brew install netcdf netcdf-fortran
+
+      - name: Run Cmake
+        run: cmake -S . -B build -D CMAKE_BUILD_TYPE=${{ matrix.build_type }}
+
+      - name: Build
+        run: cmake --build build  --verbose
+      
+      - name: Run tests
+        run: ctest -C ${{ matrix.build_type }} --rerun-failed --output-on-failure . --verbose
+        working-directory: build

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -2,8 +2,8 @@ name: Mac
 
 on: 
   push:
-    branches:
-      - main
+    # branches:
+    #   - main
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -2,8 +2,8 @@ name: Mac
 
 on: 
   push:
-    # branches:
-    #   - main
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,0 +1,42 @@
+name: Ubuntu
+
+on: 
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  gnu:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        gcc_version: [12, 13, 14]
+        build_type: [Debug, Release]
+    env:
+      FC: gfortran-${{ matrix.gcc_version }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libnetcdf-dev netcdf-bin libnetcdff-dev
+
+      - name: Run Cmake
+        run: cmake -S . -B build -D CMAKE_BUILD_TYPE=${{ matrix.build_type }}
+
+      - name: Build
+        run: cmake --build build  --verbose
+
+      - name: Run tests
+        run: ctest -C ${{ matrix.build_type }} --rerun-failed --output-on-failure . --verbose
+        working-directory: build

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -2,8 +2,8 @@ name: Ubuntu
 
 on: 
   push:
-    # branches:
-    #   - main
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -2,8 +2,8 @@ name: Ubuntu
 
 on: 
   push:
-    branches:
-      - main
+    # branches:
+    #   - main
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,55 @@
+name: Windows
+
+on: 
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  gnu:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [Debug, Release]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          update: true
+          install: >-
+            base-devel
+            mingw-w64-x86_64-toolchain
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-gcc-fortran
+            mingw-w64-x86_64-cmake
+            mingw-w64-x86_64-netcdf
+            mingw-w64-x86_64-netcdf-fortran
+          msystem: MINGW64
+
+      - name: Add MSYS2 mingw64 to PATH
+        shell: msys2 {0}
+        run: echo "C:/msys64/mingw64/bin" >> $GITHUB_PATH
+
+      - name: Configure with CMake
+        shell: msys2 {0}
+        run: cmake -G "MinGW Makefiles" -B build -D CMAKE_BUILD_TYPE=${{ matrix.build_type }}
+
+      - name: Build the project
+        shell: msys2 {0}
+        run: cmake --build build  --verbose
+
+      - name: Run tests
+        shell: msys2 {0}
+        run: ctest -C ${{ matrix.build_type }} --rerun-failed --output-on-failure . --verbose
+        working-directory: build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,8 +2,8 @@ name: Windows
 
 on: 
   push:
-    # branches:
-    #   - main
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,8 +2,8 @@ name: Windows
 
 on: 
   push:
-    branches:
-      - main
+    # branches:
+    #   - main
   pull_request:
   workflow_dispatch:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.11.0] - TBD
+
+### Added
+- Added GitHub Actions tests to build and test HEMCO on Windows, macOS, and Ubuntu automatically with each submitted PR
+
 ## [3.10.1] - 2025-01-10
 ### Added
 - Added optional LUN argument to ConfigInit to allow external models to pass LUN of existing log file

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,13 +62,22 @@ set(HEMCO_Fortran_FLAGS_DEBUG_Intel
    -g -O0 "SHELL:-check arg_temp_created" "SHELL:-debug all" -fpe0 -ftrapuv -check,bounds -DDEBUG
    CACHE STRING "HEMCO compiler flags for build type debug with Intel compilers"
 )
-
-set(HEMCO_Fortran_FLAGS_GNU
-   -cpp -w -std=legacy -fautomatic -fno-align-commons -fconvert=big-endian
-   -fno-range-check -mcmodel=medium -fbacktrace -g -DLINUX_GFORTRAN
-   -ffree-line-length-none
-   CACHE STRING "HEMCO compiler flags for all build types with GNU compilers"
-)
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm64")
+    # arm based processors only support mcmodels of large small tiny
+    set(HEMCO_Fortran_FLAGS_GNU
+    -cpp -w -std=legacy -fautomatic -fno-align-commons -fconvert=big-endian
+    -fno-range-check -mcmodel=small -fbacktrace -g -DLINUX_GFORTRAN
+    -ffree-line-length-none
+    CACHE STRING "HEMCO compiler flags for all build types with GNU compilers"
+    )
+else()
+    set(HEMCO_Fortran_FLAGS_GNU
+    -cpp -w -std=legacy -fautomatic -fno-align-commons -fconvert=big-endian
+    -fno-range-check -mcmodel=medium -fbacktrace -g -DLINUX_GFORTRAN
+    -ffree-line-length-none
+    CACHE STRING "HEMCO compiler flags for all build types with GNU compilers"
+    )
+endif()
 set(HEMCO_Fortran_FLAGS_RELEASE_GNU
    -O3 -funroll-loops
    CACHE STRING "HEMCO compiler flags for build type release with GNU compilers"

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@
   <a href="https://github.com/geoschem/hemco/blob/main/LICENSE.txt"><img src="https://img.shields.io/badge/License-MIT-blue.svg"></a>
   <a href="https://hemco.readthedocs.io/en/latest/"><img src="https://img.shields.io/readthedocs/geos-chem?label=ReadTheDocs"></a>
 </p>
+[![Ubuntu](https://github.com/geoschem/hemco/actions/workflows/ubuntu.yml/badge.svg)](https://github.com/geoschem/hemco/actions/workflows/ubuntu.yml)
+[![Mac](https://github.com/geoschem/hemco/actions/workflows/mac.yml/badge.svg)](https://github.com/geoschem/hemco/actions/workflows/mac.yml)
+[![Windows](https://github.com/geoschem/hemco/actions/workflows/windows.yml/badge.svg)](https://github.com/geoschem/hemco/actions/workflows/windows.yml)
 
 ## Description
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Kyle Shores
Institution: National Center for Atmospheric Research (NCAR)

### Describe the update

This builds HEMCO on macOS, Ubuntu, and Windows. All platforms build with debug and release (why not?). Ubuntu and macOS also build both configurations with GCC 12, 13, and 14. Adding these files ensures HEMCO builds on all platforms. While the plans are still unclear, there has been talk of including HEMCO into MUSICA. One of our software requirements to be have software included in MUSICA is to build on all platforms.

### Expected changes

None

### Reference(s)

N/A

### Related Github Issue

N/A