### PR TITLE
Fixes to build and run in GEOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed excessive prints when using MPI
+- Fixed F77 formating in hcox_dustdead_mod.F
 
 ### Removed
 - Removed warnings count in HcoState%Config%Err
 - Removed RC argument in HCO_WARNING
 - Deleted subroutine HCO_IsVerb
+- Remove print of HcoDiagn%MassScal since never set in the model
 
 ## [3.10.0] - 2024-11-07
 ### Added

--- a/src/Core/hco_diagn_mod.F90
+++ b/src/Core/hco_diagn_mod.F90
@@ -1109,8 +1109,6 @@ CONTAINS
           IF ( HcoState%Config%doVerbose ) THEN
              WRITE(MSG, *) '  ThisDiagn%AreaScal = ', ThisDiagn%AreaScal
              CALL HCO_MSG( msg, LUN=HcoState%Config%hcoLogLUN )
-             WRITE(MSG, *) '  ThisDiagn%MassScal = ', ThisDiagn%MassScal
-             CALL HCO_MSG( msg, LUN=HcoState%Config%hcoLogLUN )
           ENDIF
           !----------------------------------------------------------------
           ! Determine the normalization factors applied to the diagnostics

--- a/src/Extensions/hcox_dustdead_mod.F
+++ b/src/Extensions/hcox_dustdead_mod.F
@@ -5864,7 +5864,9 @@ c Fix up for negative argument, erf, etc.
       FNDLABEL = TRIM(CSLABEL) 
       IF ( .NOT. HcoState%Grid%AREA_M2%Alloc ) THEN
          MSG = 'Warning: AREA_M2 not found, will use default number'
-         IF ( HcoState%Config%doVerbose ) CALL HCO_WARNING(  MSG, THISLOC=LOC )
+         IF ( HcoState%Config%doVerbose ) THEN
+            CALL HCO_WARNING(  MSG, THISLOC=LOC )
+         ENDIF
       ELSE
          AM2 = SUM(HcoState%Grid%AREA_M2%Val)/(HcoState%NX*HcoState%NY)
          RES = SQRT(AM2)


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR contains small fixes for running this version of HEMCO in GEOS. Fixes include:
- Remove printing HcoDiagn%MassScal since never set in the model and thus prints garbage values.
- Update formatting in F77 file for dustdead extension. GEOS was failing build due to a line that was too long.

### Expected changes

This is a no diff update.

### Reference(s)

None

### Related Github Issue

None
