### PR TITLE
Added .zenodo.json file and updated jinja2 to 3.1.5 (security fix)

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,22 @@
+{
+    "access_right": "open",
+    "creators": [
+	{
+	    "name": "The International GEOS-Chem User Community"
+	}
+    ],
+    "description": "The Harmonized Emissions Component (HEMCO)",
+    "keywords": [
+	"atmospheric-chemistry",
+	"atmospheric-composition",
+	"atmospheric-modeling",
+	"aws",
+	"climate-modeling",
+	"cloud-computing",
+	"geos-chem",
+	"atmospheric-computing",
+	"scientific-computing"
+    ],
+    "license": "mit-license",
+    "upload_type": "software"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+### Added
+- Added `.zenodo.json` for auto-DOI generation upon version releases
+
+### Changed
+- Bumped `jinja2` to version 3.1.5 in `docs/requirements.txt` to fix a security issue
+
 ## [3.10.1] - 2025-01-10
 ### Added
 - Added optional LUN argument to ConfigInit to allow external models to pass LUN of existing log file

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -12,4 +12,4 @@ sphinxcontrib-bibtex==2.6.2
 sphinx-autobuild==2021.3.14
 recommonmark==0.7.1
 docutils==0.20.1
-jinja2==3.1.4
+jinja2==3.1.5


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
In this PR we have done the following:

1. Added a `.zenodo.json` file, which will auto-populate fields when a DOI is triggered by each HEMCO release.
2. Bumped the `jinja2` package (which is used by ReadTheDocs) to version 3.1.5 in `docs/requirement.txt`.  This fixes a security issue identified by GitHub Dependabot. 

### Expected changes
These are zero-diff updates and can be merged alongside another HEMCO PR.  It can go either into 3.10.2 or 3.11.0, whichever is worked on first.