### PR TITLE
Turn off map_a2a pole-averaging when using CESM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Bumped `jinja2` to version 3.1.5 in `docs/requirements.txt` to fix a security issue
+- Turned off map_a2a pole averaging when using CESM to avoid core-dependency in 2D emissions
+
+### Fixed
+- Updated several prints to limit to root thread to reduce log redundancy when using MPI
 
 ## [3.10.1] - 2025-01-10
 ### Added

--- a/src/Core/hco_config_mod.F90
+++ b/src/Core/hco_config_mod.F90
@@ -2212,11 +2212,8 @@ CONTAINS
           CALL HCO_MSG( msg, LUN=HcoConfig%hcoLogLUN )
        ENDIF
 #else
-       ! Always write to atm.log in CESM. LogFile entry in HEMCO_Config.rc
-       ! is omitted in CESM HEMCO_Config.rc. If it is found it will be ignored.
+       ! Always write to atm.log in CESM
        LogFile = 'atm.log'
-       msg = 'WARNING: HEMCO config entry for LogFile is ignored in CESM'
-       CALL HCO_MSG( msg, LUN=HcoConfig%stdLogLUN)
 #endif
 
        ! Initialize (standard) HEMCO tokens

--- a/src/Core/hco_config_mod.F90
+++ b/src/Core/hco_config_mod.F90
@@ -1512,7 +1512,7 @@ CONTAINS
        ENDIF
 
        ! Verbose mode
-       IF ( HcoConfig%doVerbose ) THEN
+       IF ( HcoConfig%doVerbose .AND. HcoConfig%amIRoot ) THEN
           MSG = 'Opened shortcut bracket: '//TRIM(TmpBracket)
           CALL HCO_MSG( msg, LUN=HcoConfig%hcoLogLUN )
           WRITE(MSG,*) ' - Skip content of this bracket: ', SKIP
@@ -1541,7 +1541,7 @@ CONTAINS
        NEST              = NEST - 1
 
        ! Verbose mode
-       IF ( HcoConfig%doVerbose ) THEN
+       IF ( HcoConfig%doVerbose .AND. HcoConfig%amIRoot ) THEN
           MSG = 'Closed shortcut bracket: '//TRIM(TmpBracket)
           CALL HCO_MSG( msg, LUN=HcoConfig%hcoLogLUN )
           WRITE(MSG,*) ' - Skip following lines: ', SKIP

--- a/src/Core/hco_readlist_mod.F90
+++ b/src/Core/hco_readlist_mod.F90
@@ -802,7 +802,7 @@ CONTAINS
 
     ELSE
        WRITE(MSG,*) 'ReadList not defined yet!!'
-       CALL HCO_MSG( msg, SEP1='=', LUN=HcoState%Config%hcoLogLUN )
+       IF ( HcoState%Config%amIRoot ) CALL HCO_MSG( msg, SEP1='=', LUN=HcoState%Config%hcoLogLUN )
     ENDIF
 
   END SUBROUTINE ReadList_Print

--- a/src/Shared/GeosUtil/hco_regrid_a2a_mod.F90
+++ b/src/Shared/GeosUtil/hco_regrid_a2a_mod.F90
@@ -776,6 +776,7 @@ CONTAINS
 1000 continue
      !$OMP END PARALLEL DO
 
+#ifndef MODEL_CESM
      !===================================================================
      ! Final processing for poles
      !===================================================================
@@ -816,6 +817,7 @@ CONTAINS
         endif
 
      endif
+#endif
 
    END SUBROUTINE ymap_r8r8
 !EOC
@@ -973,6 +975,7 @@ CONTAINS
 1000 continue
      !$OMP END PARALLEL DO
 
+#ifndef MODEL_CESM
      !===================================================================
      ! Final processing for poles
      !===================================================================
@@ -1013,6 +1016,7 @@ CONTAINS
         endif
 
      endif
+#endif
 
    END SUBROUTINE ymap_r4r8
 !EOC
@@ -1171,6 +1175,7 @@ CONTAINS
 1000 continue
      !$OMP END PARALLEL DO
 
+#ifndef MODEL_CESM          
      !===================================================================
      ! Final processing for poles
      !===================================================================
@@ -1211,6 +1216,7 @@ CONTAINS
         endif
 
      endif
+#endif
 
    END SUBROUTINE ymap_r8r4
 !EOC
@@ -1369,6 +1375,7 @@ CONTAINS
 1000 continue
      !$OMP END PARALLEL DO
 
+#ifndef MODEL_CESM          
      !===================================================================
      ! Final processing for poles
      !===================================================================
@@ -1410,6 +1417,7 @@ CONTAINS
           enddo
         endif
      endif
+#endif
 
    END SUBROUTINE ymap_r4r4
 !EOC


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR disables pole-averaging in the map_a2a horizontal regridding scheme when using CESM. This avoids introducing differences in 2D emissions when using different numbers of cores. This PR also updates several print statements to limit to root thread in order to reduce log redundancy when using MPI.

Note that after this PR there is still an issue in CESM with core-dependency. However, it will be limited to 3D emissions only.

### Expected changes

This will be a zero difference update for GC-Classic and GCHP.

### Reference(s)

none

### Related Github Issue

None
