### PR TITLE
Fix improper handling of date timestamps and lat/lon bounds for mask files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased - TBD
+### Added
+- Added `Lons` and `Lats` to `FileData` type to store bounds of mask files
+
+### Fixed
+- Fixed improper handling of mask files by removing code that overwrote	mask file years and months with lat/lon values and later hardcoded year and month values to -999
+
 ## [3.10.2] - 2025-03-04
 ### Added
 - Added `.zenodo.json` for auto-DOI generation upon version releases

--- a/src/Core/hco_config_mod.F90
+++ b/src/Core/hco_config_mod.F90
@@ -2449,10 +2449,10 @@ CONTAINS
           ThisCover = -1
 #else
           ! Get mask edges
-          lon1 = Lct%Dct%Dta%ncYrs(1)
-          lat1 = Lct%Dct%Dta%ncYrs(2)
-          lon2 = Lct%Dct%Dta%ncMts(1)
-          lat2 = Lct%Dct%Dta%ncMts(2)
+          lon1 = Lct%Dct%Dta%Lons(1)
+          lon2 = Lct%Dct%Dta%Lons(2)
+          lat1 = Lct%Dct%Dta%Lats(1)
+          lat2 = Lct%Dct%Dta%Lats(2)
 
           ! If ncFile is passed as the lon1/lat1/lon2/lat2 instead
           ! of netCDF file name, then set ncRead to false, so that
@@ -2477,8 +2477,6 @@ CONTAINS
 
           ! Update container information
           Lct%Dct%Dta%Cover    = ThisCover
-          Lct%Dct%Dta%ncYrs(:) = -999
-          Lct%Dct%Dta%ncMts(:) = -999
 
           IF ( HcoState%Config%doVerbose ) THEN
              WRITE(MSG,*) 'Coverage: ', Lct%Dct%Dta%Cover
@@ -5256,12 +5254,11 @@ CONTAINS
           RETURN
        ENDIF
 
-       ! Save temporarily in year and month range. Will be
-       ! reset lateron.
-       Dta%ncYrs(1) = splitInts(1)
-       Dta%ncYrs(2) = splitInts(2)
-       Dta%ncMts(1) = splitInts(3)
-       Dta%ncMts(2) = splitInts(4)
+       ! Save lat and lon ranges for mask
+       Dta%Lons(1) = splitInts(1)
+       Dta%Lats(1) = splitInts(2)
+       Dta%Lons(2) = splitInts(3)
+       Dta%Lats(2) = splitInts(4)
 
        ! Make sure that masks are always being read if specified so.
        IF ( char2 == 'y' .OR. char2 == 'Y' ) THEN

--- a/src/Core/hco_logfile_mod.F90
+++ b/src/Core/hco_logfile_mod.F90
@@ -164,7 +164,8 @@ CONTAINS
 ! !USES
 !
       USE HCO_STATE_MOD,     ONLY : HCO_State
-      USE HCO_TYPES_MOD,     ONLY : DataCont, HCO_DCTTYPE_BASE
+      USE HCO_TYPES_MOD,     ONLY : DataCont
+      USE HCO_TYPES_MOD,     ONLY : HCO_DCTTYPE_BASE, HCO_DCTTYPE_MASK
 !
 ! !INPUT ARGUMENTS:
 !
@@ -282,6 +283,14 @@ CONTAINS
          CALL HCO_MSG(MSG,LUN=HcoState%Config%hcoLogLUN)
          write(MSG,*) '   -->Coverage        : ', Dct%Dta%Cover
          CALL HCO_MSG(MSG,LUN=HcoState%Config%hcoLogLUN)
+
+         ! For masks
+         IF ( Dct%DctType == HCO_DCTTYPE_MASK ) THEN
+            write(MSG,*) '   -->Lon range       : ', Dct%Dta%Lons
+            CALL HCO_MSG(MSG,LUN=HcoState%Config%hcoLogLUN)
+            write(MSG,*) '   -->Lat range       : ', Dct%Dta%Lats
+            CALL HCO_MSG(MSG,LUN=HcoState%Config%hcoLogLUN)
+         ENDIF
 
          ! For base emissions
          IF ( Dct%DctType==HCO_DCTTYPE_BASE ) THEN

--- a/src/Core/hco_types_mod.F90
+++ b/src/Core/hco_types_mod.F90
@@ -372,6 +372,8 @@ MODULE HCO_TYPES_MOD
      LOGICAL                     :: DoShare   ! shared object?
      LOGICAL                     :: IsInList  ! is in emissions list?
      LOGICAL                     :: IsTouched ! Has container been touched yet?
+     INTEGER                     :: Lats(2)   ! Latitude  range (masks only)
+     INTEGER                     :: Lons(2)   ! Longitude range (masks only)
   END TYPE FileData
 
   !-------------------------------------------------------------------------


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard

### Describe the update

As reported in https://github.com/geoschem/HEMCO/issues/307, mask with temporal variability were only read once per simulation. This was caused by a bug in `hco_config_mod.F90` where the year and month values for mask fields were overwritten by the lat/lon bounds of the mask file and later set to -999. To fix this, new fields `Lats` and `Lons` have been added to the `FileData` type in hco_types_mod.F90. The lat and lon bounds are now directly stored in those 2D arrays without modifying the year and month values. The lat and lon values will now also be printed to the log file for mask files.

With this fix, the `SEASONAL_RES_MASK` container in the GEOS-Chem CH4 simulation now properly lists the year and month ranges instead of -999 values. Previously, the log file listed:

```
 New container set to ReadList:
Container SEASONAL_RES_MASK
    -->Data type       :            3
    -->Container ID    :            7
    -->Target ID       :            7
    -->File data home?           -999
    -->Source file     : $ROOT/CH4/v2024-01/ResME/reservoir_mask.01x01.nc
    -->ncRead?            T
    -->Shared data file?  F
    -->Source parameter: Mask
    -->Year range      :         -999        -999
    -->Month range     :         -999        -999
    -->Day range       :            1           1
    -->Hour range      :            0           0
    -->SpaceDim        :            2
    -->Array dimension :            0           0
    -->Array sum       :    0.00000000
    -->Array min & max :    0.00000000       0.00000000
    -->Time dimension  :            0
    -->Delta t[h]      :            0
    -->Local time?        F
    -->OrigUnit        : 1
    -->Concentration?     F
    -->Coverage        :            1
    -->Scal ID         :         1500
    -->Operator        :            1
```

With this fix:

```
 New container set to ReadList:
Container SEASONAL_RES_MASK
    -->Data type       :            3
    -->Container ID    :            6
    -->Target ID       :            6
    -->File data home?           -999
    -->Source file     : $ROOT/CH4/v2024-01/ResME/reservoir_mask.01x01.nc
    -->ncRead?            T
    -->Shared data file?  F
    -->Source parameter: Mask
    -->Year range      :         2022        2022
    -->Month range     :            1          12
    -->Day range       :            1           1
    -->Hour range      :            0           0
    -->SpaceDim        :            2
    -->Array dimension :            0           0
    -->Array sum       :    0.00000000
    -->Array min & max :    0.00000000       0.00000000
    -->Time dimension  :            0
    -->Delta t[h]      :            0
    -->Local time?        F
    -->OrigUnit        : 1
    -->Concentration?     F
    -->Coverage        :            1
    -->Lon range       :         -180         180
    -->Lat range       :          -90          90
    -->Scal ID         :         1500
    -->Operator        :            1
```

I have confirmed that the reservoir mask file in these simulations is now read and updated monthly. From the log file:

```
 Processing container: SEASONAL_RES_MASK
 Parsing source file and replacing tokens
 Opening file: /n/holylfs06/LABS/jacob_lab/Shared/GEOS-CHEM/gcgrid/gcdata/ExtData/HEMCO/CH4/v2024-01/ResME/reservoir_mask.01x01.nc
HEMCO: Opening /n/holylfs06/LABS/jacob_lab/Shared/GEOS-CHEM/gcgrid/gcdata/ExtData/HEMCO/CH4/v2024-01/ResME/reservoir_mask.01x01.nc
HEMCO: Entering GET_TIMEIDX (HCOIO_UTIL_MOD.F90) ( 6)
 Number of time slices found:           12
 Time slice range :    202201010000.00000        202212010000.00000
          preferred datetime:  202201010000.
              selected tidx1:              1
...
 Processing container: SEASONAL_RES_MASK
 Parsing source file and replacing tokens
 Opening file: /n/holylfs06/LABS/jacob_lab/Shared/GEOS-CHEM/gcgrid/gcdata/ExtData/HEMCO/CH4/v2024-01/ResME/reservoir_mask.01x01.nc
HEMCO: Opening /n/holylfs06/LABS/jacob_lab/Shared/GEOS-CHEM/gcgrid/gcdata/ExtData/HEMCO/CH4/v2024-01/ResME/reservoir_mask.01x01.nc
HEMCO: Entering GET_TIMEIDX (HCOIO_UTIL_MOD.F90) ( 6)
 Number of time slices found:           12
 Time slice range :    202201010000.00000        202212010000.00000
          preferred datetime:  202202010000.
              selected tidx1:              2
...
 Processing container: SEASONAL_RES_MASK
 Parsing source file and replacing tokens
 Opening file: /n/holylfs06/LABS/jacob_lab/Shared/GEOS-CHEM/gcgrid/gcdata/ExtData/HEMCO/CH4/v2024-01/ResME/reservoir_mask.01x01.nc
HEMCO: Opening /n/holylfs06/LABS/jacob_lab/Shared/GEOS-CHEM/gcgrid/gcdata/ExtData/HEMCO/CH4/v2024-01/ResME/reservoir_mask.01x01.nc
HEMCO: Entering GET_TIMEIDX (HCOIO_UTIL_MOD.F90) ( 6)
 Number of time slices found:           12
 Time slice range :    202201010000.00000        202212010000.00000
          preferred datetime:  202203010000.
              selected tidx1:              3
etc.
```

### Expected changes

This  is a zero-difference update with respect to full-chemistry benchmark simulations. It will impact CH4 GEOS-Chem simulations which do include mask files with temporal variability.

### Related Github Issue

- Closes https://github.com/geoschem/HEMCO/issues/307
