### PR TITLE
Fix bug setting destination grid object sigma vector passed to MESSy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.10.3] - TBD
+### Fixed
+- Fixed bug setting destination grid object sigma vector passed to MESSy for vertical regridding
+
 ## [3.10.2] - 2025-03-04
 ### Added
 - Added `.zenodo.json` for auto-DOI generation upon version releases

--- a/src/Core/hcoio_messy_mod.F90
+++ b/src/Core/hcoio_messy_mod.F90
@@ -790,8 +790,8 @@ MODULE HCOIO_MESSY_MOD
        ! -------------------------------------------------------------
        LOW = 1
        UPP = 1
-       DO J = 1, YLEV !lat
        DO I = 1, XLEV !lon
+       DO J = 1, YLEV !lat
           UPP                   = LOW + ZLEV - 1 ! Upper index
           ax(N)%dat%vd(LOW:UPP) = lev(I,J,:)     ! Pass to vector
           LOW                   = UPP + 1        ! Next lower index


### PR DESCRIPTION


### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

While investigating differences in CESM output when using HEMCO with different core counts I discovered a bug in vertical regridding using MESSy. The MESSy regridding scheme is used by models that input 3D atmospheric data on a different vertical grid than model grid, e.g. CESM and WRF-GC but not GEOS-Chem Classic or GCHP.

The collapse of the HEMCO grid 3D pressure sigma array into a 1D vector passed to the MESSy regridding scheme is at odds with how it is used within MESSy. Swapping two dimensions of the collapse (lat and lon) fixes the bug. This bug is not part of MESSy (written in 2002) but the interface to MESSy within HEMCO (written in 2014). It has been present since MESSy was originally implemented into HEMCO.

The bug causes the wrong horizontal layout of sigma pressure profiles during vertical regridding. In MPI models, the profiles within a given core are correct but are distributed across the regional grid of that core incorrectly. 

### Expected changes

This update only affects models which use HEMCO to vertically regrid input data that are not on the model vertical grid, i.e. CESM and WRF-GC. The extent of the impact is dependent on the model decomposition and how many CPUs are used.

To assess the impact I ran a 3-hr CESM run using HEMCO with CAM-chem. All emissions were turned off except for AEIC CO emissions, which were computed and output as a diagnostic every timestep. The following results show the impact of the bug at hour 3 of the run (instantaneous output). All plots show a single level where CO emissions from aviation tracks are visible.

**Before and after the fix, 72 cores**
<img width="799" alt="72core_before_vs_after" src="https://github.com/user-attachments/assets/8a8c04a8-4681-4151-bc1b-0284f95cedbc" />

**Before and after the fix, 144 cores**
<img width="804" alt="144core_before_vs_after" src="https://github.com/user-attachments/assets/27585c1b-ef55-48eb-89b7-b413dcc6864b" />

### Reference(s)

None

### Related Github Issue

Coming soon
