### PR TITLE
Add commented out debug code useful for MPI debugging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [3.10.3] - TBD
+### Added
+- Added commented out debug print options useful for debugging HEMCO in MPI models
+
 ### Fixed
 - Fixed bug setting destination grid object sigma vector passed to MESSy for vertical regridding
 

--- a/src/Core/hco_calc_mod.F90
+++ b/src/Core/hco_calc_mod.F90
@@ -200,7 +200,7 @@ CONTAINS
     CHARACTER(LEN=255)  :: MSG, LOC
 
     ! testing / debugging
-    integer :: ix,iy
+    integer :: ix,iy,L
 
     !=================================================================
     ! HCO_CalcEmis begins here!
@@ -402,6 +402,13 @@ CONTAINS
              CALL HCO_MSG(MSG,LUN=HcoState%Config%hcoLogLUN)
              WRITE(MSG,*) 'Spc. emissions: ', SUM(SpcFlx)
              CALL HCO_MSG(MSG,LUN=HcoState%Config%hcoLogLUN)
+
+             ! Optional debug print: single column profile of emissions
+             !DO L = 1, HcoState%NZ
+             !   CALL HCO_MSG(MSG,LUN=HcoState%Config%hcoLogLUN)
+             !   WRITE(MSG,*) 'Cat. emissions at (1,1,L): ', L, CatFlx(1,1,L)
+             !ENDDO
+
           ENDIF
 
           ! Add category emissions to diagnostics at category level

--- a/src/Core/hco_geotools_mod.F90
+++ b/src/Core/hco_geotools_mod.F90
@@ -1332,6 +1332,21 @@ CONTAINS
     ! Wrap up and leave
     ! ------------------------------------------------------------------
 
+    ! Optional debug print: Fields in specific lat/lon box
+    !write(HcoState%Config%stdLogLUN,*) 'HCO_CalcVertGrid: fields at XMID (lon), YMID (lat): ', &
+    !     HcoState%Grid%XMID%Val(I,J), HcoState%Grid%YMID%Val(I,J)
+    !DO I = 1, HcoState%NX
+    !   DO J = 1,  HcoState%NY
+    !      IF ( ( HcoState%Grid%XMID%Val(I,J) < -104 ) .AND. &
+    !           ( HcoState%Grid%XMID%Val(I,J) > -106 ) .AND. &
+    !           ( HcoState%Grid%YMID%Val(I,J) <   41 ) .AND. &
+    !           ( HcoState%Grid%YMID%Val(I,J) >   39 ) ) THEN
+    !         write(HcoState%Config%stdLogLUN,*) ' --> PSFC: ', HcoState%Grid%PSFC%Val(I,J)
+    !         ! Add more as needed
+    !      ENDIF
+    !   ENDDO
+    !ENDDO
+
     ! Verbose
     IF ( Verb ) THEN
        WRITE(MSG,*) 'Vertical grid calculations done.'

--- a/src/Core/hcoio_messy_mod.F90
+++ b/src/Core/hcoio_messy_mod.F90
@@ -145,7 +145,7 @@ MODULE HCOIO_MESSY_MOD
     REAL(hp)                      :: sigMin
     INTEGER                       :: NZIN, NZOUT, NTIME
     INTEGER                       :: NXIN, NYIN
-    INTEGER                       :: I, L, AS
+    INTEGER                       :: I, J, L, AS
     INTEGER                       :: NCALLS
     CHARACTER(LEN=255)            :: MSG, LOC
     LOGICAL                       :: SameGrid, verb
@@ -379,6 +379,23 @@ MODULE HCOIO_MESSY_MOD
     ! Get horizontal grid directly from HEMCO state
     lon   => HcoState%Grid%XEDGE%Val(:,1)
     lat   => HcoState%Grid%YEDGE%Val(1,:)
+
+    ! Optional debug print: print what is used to create dest axis for location on grid
+    DO I = 1, HcoState%NX
+       DO J = 1, HcoState%NY
+          IF ( ( HcoState%Grid%XMID%Val(I,J) < -104 ) .AND. &
+               ( HcoState%Grid%XMID%Val(I,J) > -106 ) .AND. &
+               ( HcoState%Grid%YMID%Val(I,J) <   41 ) .AND. &
+               ( HcoState%Grid%YMID%Val(I,J) >   39 ) ) THEN
+             write(HcoState%Config%stdLogLUN,*) ' '
+             write(HcoState%Config%stdLogLUN,*) 'hcoio_messy_regrid at lon, lat: ', HcoState%Grid%XMID%Val(I,J), HcoState%Grid%YMID%Val(I,J)
+             write(HcoState%Config%stdLogLUN,*) '  --> lons for this core: ', lon
+             write(HcoState%Config%stdLogLUN,*) '  --> lats for this core: ', lat
+             write(HcoState%Config%stdLogLUN,*) ' '
+          ENDIF
+       ENDDO
+    ENDDO
+
     IF( ASSOCIATED(LevEdge) ) sigma => sigout(:,:,1:NZOUT+1)
 
     CALL AXIS_CREATE( HcoState, lon, lat, sigma, axis_dst, RC )
@@ -459,6 +476,12 @@ MODULE HCOIO_MESSY_MOD
        !-----------------------------------------------------------------
        ! Do the regridding
        !-----------------------------------------------------------------
+       ! takes global array of source data (narr_src) and its MESSy axis properties
+       ! (axis_src). Also takes MESSy axis properties of destination HEMCO grid (global
+       ! for GC-Classic, regional for MPI applications). The axis_dst object contains
+       ! 1D array of latitudes, 1D array of longitudes, and 1D array of sigma pressures.
+       ! The 1D array of sigma pressures was created by collapse a 3D array of sigma
+       ! during creation of axis_dst in earlier call to axis_create for destination.
        CALL NREGRID(s=narr_src,      sax=axis_src, dax=axis_dst, d=narr_dst, &
                     rg_type=rg_type, sovl=sovl,    dovl=dovl,    rcnt=rcnt    )
 
@@ -722,9 +745,9 @@ MODULE HCOIO_MESSY_MOD
        ax(N)%lm = .false.     ! VERTICAL AXIS IS NON-MODULO AXIS
 
        ! Axis dimension
-       XLEV = SIZE(lev,1)
-       YLEV = SIZE(lev,2)
-       ZLEV = SIZE(lev,3)
+       XLEV = SIZE(lev,1)  ! HEMCO lon
+       YLEV = SIZE(lev,2)  ! HEMCO lat
+       ZLEV = SIZE(lev,3)  ! HEMCO lev+1
 
        ! Sanity check: if XLEV and YLEV are > 1, they must correspond
        ! to the lon/lat axis defined above
@@ -781,13 +804,15 @@ MODULE HCOIO_MESSY_MOD
 
        ALLOCATE(ax(N)%dat%vd(nlev),STAT=status)
        IF ( status/= 0 ) THEN
-          CALL HCO_ERROR( 'Cannot allocate lat axis', RC )
+          CALL HCO_ERROR( 'Cannot allocate lev axis', RC )
           RETURN
        ENDIF
 
        ! -------------------------------------------------------------
        ! Pass vertical sigma coordinates to vector
        ! -------------------------------------------------------------
+       ! Order is pressure profile of (lat1,lon1), (lat2,lon1), ..., (latN,lon1),
+       ! (lat1,lon2), (lat2,lon2), ..., (latN,lon2), ... until (latN,lonN)
        LOW = 1
        UPP = 1
        DO I = 1, XLEV !lon
@@ -1028,7 +1053,7 @@ MODULE HCOIO_MESSY_MOD
     ! MESSY2HCO begins here
     !=================================================================
 
-    ! Grid dimensions
+    ! Grid dimensions (global in GC-Classic, regional in MPI applications)
     NX = HcoState%NX
     NY = HcoState%NY
     NT = SIZE(narr)

--- a/src/Core/hcoio_messy_mod.F90
+++ b/src/Core/hcoio_messy_mod.F90
@@ -381,20 +381,20 @@ MODULE HCOIO_MESSY_MOD
     lat   => HcoState%Grid%YEDGE%Val(1,:)
 
     ! Optional debug print: print what is used to create dest axis for location on grid
-    DO I = 1, HcoState%NX
-       DO J = 1, HcoState%NY
-          IF ( ( HcoState%Grid%XMID%Val(I,J) < -104 ) .AND. &
-               ( HcoState%Grid%XMID%Val(I,J) > -106 ) .AND. &
-               ( HcoState%Grid%YMID%Val(I,J) <   41 ) .AND. &
-               ( HcoState%Grid%YMID%Val(I,J) >   39 ) ) THEN
-             write(HcoState%Config%stdLogLUN,*) ' '
-             write(HcoState%Config%stdLogLUN,*) 'hcoio_messy_regrid at lon, lat: ', HcoState%Grid%XMID%Val(I,J), HcoState%Grid%YMID%Val(I,J)
-             write(HcoState%Config%stdLogLUN,*) '  --> lons for this core: ', lon
-             write(HcoState%Config%stdLogLUN,*) '  --> lats for this core: ', lat
-             write(HcoState%Config%stdLogLUN,*) ' '
-          ENDIF
-       ENDDO
-    ENDDO
+    !DO I = 1, HcoState%NX
+    !   DO J = 1, HcoState%NY
+    !      IF ( ( HcoState%Grid%XMID%Val(I,J) < -104 ) .AND. &
+    !           ( HcoState%Grid%XMID%Val(I,J) > -106 ) .AND. &
+    !           ( HcoState%Grid%YMID%Val(I,J) <   41 ) .AND. &
+    !           ( HcoState%Grid%YMID%Val(I,J) >   39 ) ) THEN
+    !         write(HcoState%Config%stdLogLUN,*) ' '
+    !         write(HcoState%Config%stdLogLUN,*) 'hcoio_messy_regrid at lon, lat: ', HcoState%Grid%XMID%Val(I,J), HcoState%Grid%YMID%Val(I,J)
+    !         write(HcoState%Config%stdLogLUN,*) '  --> lons for this core: ', lon
+    !         write(HcoState%Config%stdLogLUN,*) '  --> lats for this core: ', lat
+    !         write(HcoState%Config%stdLogLUN,*) ' '
+    !      ENDIF
+    !   ENDDO
+    !ENDDO
 
     IF( ASSOCIATED(LevEdge) ) sigma => sigout(:,:,1:NZOUT+1)
 

--- a/src/Core/hcoio_read_std_mod.F90
+++ b/src/Core/hcoio_read_std_mod.F90
@@ -730,7 +730,7 @@ CONTAINS
 
 #endif
 
-          ! Set level indeces to be read
+          ! Set level indexes to be read
           lev1 = 1
           lev2 = nlev
 
@@ -1495,8 +1495,12 @@ CONTAINS
 
        ENDIF ! nlev>1
 
+       ! Optional debug tool: make input data constant everywhere
+       !NcArr = 1.e-5_sp
+
 #if defined( MODEL_WRF ) || defined( MODEL_CESM )
        ! Input data is "never" on model levels because model levels can change! (hplin, 5/29/20)
+       ! Update IsModelLevel to be false when passed to MESSy
        IsModelLevel = .false.
 #endif
 
@@ -1505,8 +1509,8 @@ CONTAINS
                                LonEdge,   LatEdge,      SigEdge, &
                                Lct,       IsModelLevel, RC        )
        IF ( RC /= HCO_SUCCESS ) THEN
-           CALL HCO_ERROR( 'ERROR 15', RC, THISLOC=LOC )
-           RETURN
+          CALL HCO_ERROR( 'ERROR 15', RC, THISLOC=LOC )
+          RETURN
        ENDIF
 
        ! Cleanup


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR adds commented out debug code that may be useful in the future when debugging HEMCO in MPI models. It can be trickier to debug HEMCO in MPI runs because HEMCO operates on a regional grid per core in those models.

### Expected changes

This is a no diff update.

### Reference(s)

None

### Related Github Issue

None
