### PR TITLE
Option to (re-)enable manual InvMEGAN diagnostics.

### DIFF
--- a/src/Extensions/hcox_megan_mod.F90
+++ b/src/Extensions/hcox_megan_mod.F90
@@ -3584,11 +3584,10 @@ CONTAINS
         CALL HCO_ERROR( 'ERROR 35', RC, THISLOC=LOC )
         RETURN
     ENDIF
-    Inst%InvMEGANAll = .FALSE.
     CALL GetExtOpt( HcoState%Config, ExtNr, 'InvMEGAN All ', &
                     OptValBool=Inst%InvMEGANAll, Found=FOUND, RC=RC )
     IF ( RC /= HCO_SUCCESS ) THEN
-        CALL HCO_ERROR( 'ERROR 36', RC, THISLOC=LOC )
+        CALL HCO_ERROR( 'ERROR 65', RC, THISLOC=LOC )
         RETURN
     ENDIF
 

--- a/src/Extensions/hcox_megan_mod.F90
+++ b/src/Extensions/hcox_megan_mod.F90
@@ -3584,8 +3584,9 @@ CONTAINS
         CALL HCO_ERROR( 'ERROR 35', RC, THISLOC=LOC )
         RETURN
     ENDIF
+    Inst%InvMEGANAll = .FALSE.
     CALL GetExtOpt( HcoState%Config, ExtNr, 'InvMEGAN All ', &
-                    OptValBool=Inst%InvMEGANAll, RC=RC )
+                    OptValBool=Inst%InvMEGANAll, Found=FOUND, RC=RC )
     IF ( RC /= HCO_SUCCESS ) THEN
         CALL HCO_ERROR( 'ERROR 36', RC, THISLOC=LOC )
         RETURN

--- a/src/Extensions/hcox_megan_mod.F90
+++ b/src/Extensions/hcox_megan_mod.F90
@@ -141,6 +141,7 @@ MODULE HCOX_MEGAN_MOD
      REAL(hp)                :: MONOTOSOAS   ! Direct SOA Emission factor
      REAL(hp)                :: OTHRTOSOAS   ! Direct SOA Emission factor
      LOGICAL                 :: LISOPCO2     ! Include CO2 inhibition of ISOP?
+     LOGICAL                 :: InvMEGANAll  ! Include all manual InvMEGAN diagnostics?
      LOGICAL                 :: NORMLAI      ! Normalize LAI by PFT?
      LOGICAL                 :: OFFLINE_BIOGENICVOC ! Use offline emiss?
 
@@ -3583,6 +3584,13 @@ CONTAINS
         CALL HCO_ERROR( 'ERROR 35', RC, THISLOC=LOC )
         RETURN
     ENDIF
+    CALL GetExtOpt( HcoState%Config, ExtNr, 'InvMEGAN All ', &
+                    OptValBool=Inst%InvMEGANAll, RC=RC )
+    IF ( RC /= HCO_SUCCESS ) THEN
+        CALL HCO_ERROR( 'ERROR 36', RC, THISLOC=LOC )
+        RETURN
+    ENDIF
+
 
     ! Normalize LAI by PFT? Default setting is 'yes'
     ! ckeller, 7/17/17.
@@ -3854,6 +3862,9 @@ CONTAINS
        CALL HCO_MSG( msg, LUN=HcoState%Config%hcoLogLUN )
        WRITE(MSG,*) ' --> Use CO2 inhibition on isoprene option ', &
                     Inst%LISOPCO2
+       CALL HCO_MSG( msg, LUN=HcoState%Config%hcoLogLUN )
+       WRITE(MSG,*) ' --> Use all InvMEGAN manual diagnostic option ', &
+                    Inst%InvMEGANAll
        CALL HCO_MSG( msg, LUN=HcoState%Config%hcoLogLUN )
        WRITE(MSG,*) ' --> Global atmospheric CO2 concentration : ', &
                     Inst%GLOBCO2, ' ppmv'
@@ -4295,6 +4306,251 @@ CONTAINS
     Inst%AEF_LIMO  = 0.0_hp
     Inst%AEF_OCIM  = 0.0_hp
     Inst%AEF_SABI  = 0.0_hp
+
+    !=================================================================
+    ! Create manual diagnostics
+    !=================================================================
+    IF ( Inst%InvMEGANAll ) THEN
+       CALL Diagn_Create( HcoState  = HcoState,              &
+                       cName     = 'InvMEGAN_ACET_MBOX',  &
+                       ExtNr     = ExtNr,                 &
+                       Cat       = -1,                    &
+                       Hier      = -1,                    &
+                       HcoID     = -1,                    &
+                       SpaceDim  = 2,                     &
+                       OutUnit   = 'kg/m2/s',             &
+                       AutoFill  = 0,                     &
+                       Trgt2D    = Inst%FLUXACETmb,       &
+                       RC        = RC )
+       IF ( RC /= HCO_SUCCESS ) THEN
+          CALL HCO_ERROR( 'ERROR 45', RC, THISLOC=LOC )
+          RETURN
+       ENDIF
+
+       CALL Diagn_Create( HcoState  = HcoState,              &
+                       cName     = 'InvMEGAN_ACET_DIRECT',&
+                       ExtNr     = ExtNr,                 &
+                       Cat       = -1,                    &
+                       Hier      = -1,                    &
+                       HcoID     = -1,                    &
+                       SpaceDim  = 2,                     &
+                       OutUnit   = 'kg/m2/s',             &
+                       AutoFill  = 0,                     &
+                       Trgt2D    = Inst%FLUXACETbg,       &
+                       RC        = RC )
+       IF ( RC /= HCO_SUCCESS ) THEN
+           CALL HCO_ERROR( 'ERROR 46', RC, THISLOC=LOC )
+           RETURN
+       ENDIF
+
+       CALL Diagn_Create( HcoState  = HcoState,              &
+                       cName     = 'InvMEGAN_APIN',       &
+                       ExtNr     = ExtNr,                 &
+                       Cat       = -1,                    &
+                       Hier      = -1,                    &
+                       HcoID     = -1,                    &
+                       SpaceDim  = 2,                     &
+                       OutUnit   = 'kg/m2/s',             &
+                       AutoFill  = 0,                     &
+                       Trgt2D    = Inst%FLUXAPIN,         &
+                       RC        = RC )
+       IF ( RC /= HCO_SUCCESS ) THEN
+           CALL HCO_ERROR( 'ERROR 47', RC, THISLOC=LOC )
+           RETURN
+       ENDIF
+
+       CALL Diagn_Create( HcoState  = HcoState,              &
+                       cName     = 'InvMEGAN_BPIN',       &
+                       ExtNr     = ExtNr,                 &
+                       Cat       = -1,                    &
+                       Hier      = -1,                    &
+                       HcoID     = -1,                    &
+                       SpaceDim  = 2,                     &
+                       OutUnit   = 'kg/m2/s',             &
+                       AutoFill  = 0,                     &
+                       Trgt2D    = Inst%FLUXBPIN,         &
+                       RC        = RC )
+       IF ( RC /= HCO_SUCCESS ) THEN
+           CALL HCO_ERROR( 'ERROR 48', RC, THISLOC=LOC )
+           RETURN
+       ENDIF
+
+       CALL Diagn_Create( HcoState  = HcoState,              &
+                       cName     = 'InvMEGAN_SABI',       &
+                       ExtNr     = ExtNr,                 &
+                       Cat       = -1,                    &
+                       Hier      = -1,                    &
+                       HcoID     = -1,                    &
+                       SpaceDim  = 2,                     &
+                       OutUnit   = 'kg/m2/s',             &
+                       AutoFill  = 0,                     &
+                       Trgt2D    = Inst%FLUXSABI,         &
+                       RC        = RC )
+       IF ( RC /= HCO_SUCCESS ) THEN
+           CALL HCO_ERROR( 'ERROR 49', RC, THISLOC=LOC )
+           RETURN
+       ENDIF
+
+       CALL Diagn_Create( HcoState  = HcoState,              &
+                       cName     = 'InvMEGAN_MYRC',       &
+                       ExtNr     = ExtNr,                 &
+                       Cat       = -1,                    &
+                       Hier      = -1,                    &
+                       HcoID     = -1,                    &
+                       SpaceDim  = 2,                     &
+                       OutUnit   = 'kg/m2/s',             &
+                       AutoFill  = 0,                     &
+                       Trgt2D    = Inst%FLUXMYRC,         &
+                       RC        = RC )
+       IF ( RC /= HCO_SUCCESS ) THEN
+           CALL HCO_ERROR( 'ERROR 50', RC, THISLOC=LOC )
+           RETURN
+       ENDIF
+
+       CALL Diagn_Create( HcoState  = HcoState,              &
+                       cName     = 'InvMEGAN_CARE',       &
+                       ExtNr     = ExtNr,                 &
+                       Cat       = -1,                    &
+                       Hier      = -1,                    &
+                       HcoID     = -1,                    &
+                       SpaceDim  = 2,                     &
+                       OutUnit   = 'kg/m2/s',             &
+                       AutoFill  = 0,                     &
+                       Trgt2D    = Inst%FLUXCARE,         &
+                       RC        = RC )
+       IF ( RC /= HCO_SUCCESS ) THEN
+           CALL HCO_ERROR( 'ERROR 51', RC, THISLOC=LOC )
+           RETURN
+       ENDIF
+
+       CALL Diagn_Create( HcoState  = HcoState,              &
+                       cName     = 'InvMEGAN_OCIM',       &
+                       ExtNr     = ExtNr,                 &
+                       Cat       = -1,                    &
+                       Hier      = -1,                    &
+                       HcoID     = -1,                    &
+                       SpaceDim  = 2,                     &
+                       OutUnit   = 'kg/m2/s',             &
+                       AutoFill  = 0,                     &
+                       Trgt2D    = Inst%FLUXOCIM,         &
+                       RC        = RC )
+       IF ( RC /= HCO_SUCCESS ) THEN
+           CALL HCO_ERROR( 'ERROR 52', RC, THISLOC=LOC )
+           RETURN
+       ENDIF
+
+       CALL Diagn_Create( HcoState  = HcoState,              &
+                       cName     = 'InvMEGAN_OMON',       &
+                       ExtNr     = ExtNr,                 &
+                       Cat       = -1,                    &
+                       Hier      = -1,                    &
+                       HcoID     = -1,                    &
+                       SpaceDim  = 2,                     &
+                       OutUnit   = 'kg/m2/s',             &
+                       AutoFill  = 0,                     &
+                       Trgt2D    = Inst%FLUXOMON,         &
+                       RC        = RC )
+       IF ( RC /= HCO_SUCCESS ) THEN
+           CALL HCO_ERROR( 'ERROR 53', RC, THISLOC=LOC )
+           RETURN
+       ENDIF
+
+       CALL Diagn_Create( HcoState  = HcoState,              &
+                       cName     = 'InvMEGAN_FARN',       &
+                       ExtNr     = ExtNr,                 &
+                       Cat       = -1,                    &
+                       Hier      = -1,                    &
+                       HcoID     = -1,                    &
+                       SpaceDim  = 2,                     &
+                       OutUnit   = 'kg/m2/s',             &
+                       AutoFill  = 0,                     &
+                       Trgt2D    = Inst%FLUXFARN,         &
+                       RC        = RC )
+       IF ( RC /= HCO_SUCCESS ) THEN
+           CALL HCO_ERROR( 'ERROR 54', RC, THISLOC=LOC )
+           RETURN
+       ENDIF
+
+       CALL Diagn_Create( HcoState  = HcoState,              &
+                       cName     = 'InvMEGAN_BCAR',       &
+                       ExtNr     = ExtNr,                 &
+                       Cat       = -1,                    &
+                       Hier      = -1,                    &
+                       HcoID     = -1,                    &
+                       SpaceDim  = 2,                     &
+                       OutUnit   = 'kg/m2/s',             &
+                       AutoFill  = 0,                     &
+                       Trgt2D    = Inst%FLUXBCAR,         &
+                       RC        = RC )
+       IF ( RC /= HCO_SUCCESS ) THEN
+           CALL HCO_ERROR( 'ERROR 55', RC, THISLOC=LOC )
+           RETURN
+       ENDIF
+
+       CALL Diagn_Create( HcoState  = HcoState,              &
+                       cName     = 'InvMEGAN_OSQT',       &
+                       ExtNr     = ExtNr,                 &
+                       Cat       = -1,                    &
+                       Hier      = -1,                    &
+                       HcoID     = -1,                    &
+                       SpaceDim  = 2,                     &
+                       OutUnit   = 'kg/m2/s',             &
+                       AutoFill  = 0,                     &
+                       Trgt2D    = Inst%FLUXOSQT,         &
+                       RC        = RC )
+       IF ( RC /= HCO_SUCCESS ) THEN
+           CALL HCO_ERROR( 'ERROR 56', RC, THISLOC=LOC )
+           RETURN
+       ENDIF
+
+       CALL Diagn_Create( HcoState  = HcoState,              &
+                       cName     = 'InvMEGAN_MBOX',       &
+                       ExtNr     = ExtNr,                 &
+                       Cat       = -1,                    &
+                       Hier      = -1,                    &
+                       HcoID     = -1,                    &
+                       SpaceDim  = 2,                     &
+                       OutUnit   = 'kg/m2/s',             &
+                       AutoFill  = 0,                     &
+                       Trgt2D    = Inst%FLUXMBOX,         &
+                       RC        = RC )
+       IF ( RC /= HCO_SUCCESS ) THEN
+           CALL HCO_ERROR( 'ERROR 57', RC, THISLOC=LOC )
+           RETURN
+       ENDIF
+
+       CALL Diagn_Create( HcoState  = HcoState,              &
+                       cName     = 'InvMEGAN_FAXX',       &
+                       ExtNr     = ExtNr,                 &
+                       Cat       = -1,                    &
+                       Hier      = -1,                    &
+                       HcoID     = -1,                    &
+                       SpaceDim  = 2,                     &
+                       OutUnit   = 'kg/m2/s',             &
+                       AutoFill  = 0,                     &
+                       Trgt2D    = Inst%FLUXFAXX,         &
+                       RC        = RC )
+       IF ( RC /= HCO_SUCCESS ) THEN
+           CALL HCO_ERROR( 'ERROR 58', RC, THISLOC=LOC )
+           RETURN
+       ENDIF
+
+       CALL Diagn_Create( HcoState  = HcoState,              &
+                       cName     = 'InvMEGAN_AAXX',       &
+                       ExtNr     = ExtNr,                 &
+                       Cat       = -1,                    &
+                       Hier      = -1,                    &
+                       HcoID     = -1,                    &
+                       SpaceDim  = 2,                     &
+                       OutUnit   = 'kg/m2/s',             &
+                       AutoFill  = 0,                     &
+                       Trgt2D    = Inst%FLUXAAXX,         &
+                       RC        = RC )
+       IF ( RC /= HCO_SUCCESS ) THEN
+           CALL HCO_ERROR( 'ERROR 59', RC, THISLOC=LOC )
+           RETURN
+       ENDIF
+    ENDIF
 
     !=================================================================
     ! Initialize internal diagnostics. These are the restart variables


### PR DESCRIPTION
### Name and Institution (Required)

Name:  Patrick Campbell
Institution:  George Mason University

### Describe the update
#282  removed these diagnostics from the output. With this change, it is no longer to possible to get output for these additional species (such as AAXX, FAXX, and APIN). A quick fix here provides an optional flag to enable the previous behavior #281 , i.e. including all of the InvMEGANs in the diagnostic output regardless of the diagnostics configuration.   The option to control these manual diagnostics can now be added in the config file when using the MEGAN extension.

```
--> InvMEGAN All      :       true
```

### Expected changes

When turning ```InvMEGAN All``` to true in the config file the output will contain all InvMEGAN manual diagnostics in the output:

```
float InvMEGAN_AAXX(time, lat, lon) ;
                InvMEGAN_AAXX:long_name = "InvMEGAN_AAXX" ;
                InvMEGAN_AAXX:units = "kg/m2/s" ;
                InvMEGAN_AAXX:_FillValue = -1.e+31f ;
                InvMEGAN_AAXX:averaging_method = "Instantaneous" ;
        float InvMEGAN_FAXX(time, lat, lon) ;
                InvMEGAN_FAXX:long_name = "InvMEGAN_FAXX" ;
                InvMEGAN_FAXX:units = "kg/m2/s" ;
                InvMEGAN_FAXX:_FillValue = -1.e+31f ;
                InvMEGAN_FAXX:averaging_method = "Instantaneous" ;
        float InvMEGAN_MBOX(time, lat, lon) ;
                InvMEGAN_MBOX:long_name = "InvMEGAN_MBOX" ;
                InvMEGAN_MBOX:units = "kg/m2/s" ;
                InvMEGAN_MBOX:_FillValue = -1.e+31f ;
                InvMEGAN_MBOX:averaging_method = "Instantaneous" ;
        float InvMEGAN_OSQT(time, lat, lon) ;
                InvMEGAN_OSQT:long_name = "InvMEGAN_OSQT" ;
                InvMEGAN_OSQT:units = "kg/m2/s" ;
                InvMEGAN_OSQT:_FillValue = -1.e+31f ;
                InvMEGAN_OSQT:averaging_method = "Instantaneous" ;
        float InvMEGAN_BCAR(time, lat, lon) ;
                InvMEGAN_BCAR:long_name = "InvMEGAN_BCAR" ;
                InvMEGAN_BCAR:units = "kg/m2/s" ;
                InvMEGAN_BCAR:_FillValue = -1.e+31f ;
                InvMEGAN_BCAR:averaging_method = "Instantaneous" ;
        float InvMEGAN_FARN(time, lat, lon) ;
                InvMEGAN_FARN:long_name = "InvMEGAN_FARN" ;
                InvMEGAN_FARN:units = "kg/m2/s" ;
                InvMEGAN_FARN:_FillValue = -1.e+31f ;
                InvMEGAN_FARN:averaging_method = "Instantaneous" ;
        float InvMEGAN_OMON(time, lat, lon) ;
                InvMEGAN_OMON:long_name = "InvMEGAN_OMON" ;
                InvMEGAN_OMON:units = "kg/m2/s" ;
                InvMEGAN_OMON:_FillValue = -1.e+31f ;
                InvMEGAN_OMON:averaging_method = "Instantaneous" ;
        float InvMEGAN_OCIM(time, lat, lon) ;
                InvMEGAN_OCIM:long_name = "InvMEGAN_OCIM" ;
                InvMEGAN_OCIM:units = "kg/m2/s" ;
                InvMEGAN_OCIM:_FillValue = -1.e+31f ;
                InvMEGAN_OCIM:averaging_method = "Instantaneous" ;
        float InvMEGAN_CARE(time, lat, lon) ;
                InvMEGAN_CARE:long_name = "InvMEGAN_CARE" ;
                InvMEGAN_CARE:units = "kg/m2/s" ;
                InvMEGAN_CARE:_FillValue = -1.e+31f ;
                InvMEGAN_CARE:averaging_method = "Instantaneous" ;
        float InvMEGAN_MYRC(time, lat, lon) ;
                InvMEGAN_MYRC:long_name = "InvMEGAN_MYRC" ;
                InvMEGAN_MYRC:units = "kg/m2/s" ;
                InvMEGAN_MYRC:_FillValue = -1.e+31f ;
                InvMEGAN_MYRC:averaging_method = "Instantaneous" ;
        float InvMEGAN_SABI(time, lat, lon) ;
                InvMEGAN_SABI:long_name = "InvMEGAN_SABI" ;
                InvMEGAN_SABI:units = "kg/m2/s" ;
                InvMEGAN_SABI:_FillValue = -1.e+31f ;
                InvMEGAN_SABI:averaging_method = "Instantaneous" ;
        float InvMEGAN_BPIN(time, lat, lon) ;
                InvMEGAN_BPIN:long_name = "InvMEGAN_BPIN" ;
                InvMEGAN_BPIN:units = "kg/m2/s" ;
                InvMEGAN_BPIN:_FillValue = -1.e+31f ;
                InvMEGAN_BPIN:averaging_method = "Instantaneous" ;
        float InvMEGAN_APIN(time, lat, lon) ;
                InvMEGAN_APIN:long_name = "InvMEGAN_APIN" ;
                InvMEGAN_APIN:units = "kg/m2/s" ;
                InvMEGAN_APIN:_FillValue = -1.e+31f ;
                InvMEGAN_APIN:averaging_method = "Instantaneous" ;
        float InvMEGAN_ACET_DIRECT(time, lat, lon) ;
                InvMEGAN_ACET_DIRECT:long_name = "InvMEGAN_ACET_DIRECT" ;
                InvMEGAN_ACET_DIRECT:units = "kg/m2/s" ;
                InvMEGAN_ACET_DIRECT:_FillValue = -1.e+31f ;
                InvMEGAN_ACET_DIRECT:averaging_method = "Instantaneous" ;
        float InvMEGAN_ACET_MBOX(time, lat, lon) ;
                InvMEGAN_ACET_MBOX:long_name = "InvMEGAN_ACET_MBOX" ;
                InvMEGAN_ACET_MBOX:units = "kg/m2/s" ;
                InvMEGAN_ACET_MBOX:_FillValue = -1.e+31f ;
                InvMEGAN_ACET_MBOX:averaging_method = "Instantaneous" ;
```

### Reference(s)

If this is a science update, please provide a literature citation.

### Related Github Issue

#320 
@zmoon