### PR TITLE
Fix print in adjoint code for getting current emissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [NOT YET RELEASED] - TBD
+### Fixed
+- Fixed print in adjoint subroutine for getting current emissions
+
 ## [3.11.0] - 2025-04-18
 ### Added
 - Added option to enable `InvMEGAN` manual diagnostic output

--- a/src/Core/hco_calc_mod.F90
+++ b/src/Core/hco_calc_mod.F90
@@ -2837,7 +2837,7 @@ END FUNCTION GetEmisLUnit
     ! Verbose
     IF ( HcoState%Config%doVerbose ) THEN
        WRITE(MSG,*) 'Evaluate field ', TRIM(BaseDct%cName)
-       CALL HCO_MSG(SEP1=' ',LUN=HcoState%Config%hcoLogLUN)
+       CALL HCO_MSG(MSG,LUN=HcoState%Config%hcoLogLUN)
     ENDIF
 
     ! ----------------------------------------------------------------


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren, on behalf of Kay Suselj (JPL)
Institution: Harvard University

### Describe the update

Fix print in GCHP adjoint-only code for getting current emissions.

### Expected changes

None. This update is in adjoint-only code

### Reference(s)

None

### Related Github Issue

This PR supercedes https://github.com/geoschem/HEMCO/pull/323 so that usage of Kay's main branch off of an older version is preserved.
