### PR TITLE
Increase string length for reading lines from HEMCO standalone grid file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+### Changed
+- Increase string length for reading lines from HEMCO standalone grid file for 0.125x0.15625 global resolution
+
 ## [3.11.0] - 2025-04-18
 ### Added
 - Added option to enable `InvMEGAN` manual diagnostic output

--- a/src/Core/hco_chartools_mod.F90
+++ b/src/Core/hco_chartools_mod.F90
@@ -869,8 +869,8 @@ CONTAINS
 !
 ! LOCAL VARIABLES:
 !
-    INTEGER             :: IOS
-    CHARACTER(LEN=5500) :: DUM
+    INTEGER              :: IOS
+    CHARACTER(LEN=15000) :: DUM
 
     !=================================================================
     ! GetNextLine begins here
@@ -950,9 +950,9 @@ CONTAINS
 !
 ! !LOCAL VARIABLES:
 !
-    INTEGER             :: IOS, C
-    CHARACTER(LEN=255)  :: MSG
-    CHARACTER(LEN=5500) :: DUM
+    INTEGER              :: IOS, C
+    CHARACTER(LEN=255)   :: MSG
+    CHARACTER(LEN=15000) :: DUM
 
     !=================================================================
     ! HCO_ReadLine begins here!

--- a/src/Interfaces/Standalone/hcoi_standalone_mod.F90
+++ b/src/Interfaces/Standalone/hcoi_standalone_mod.F90
@@ -1057,7 +1057,7 @@ CONTAINS
     CHARACTER(LEN=255)    :: LOC
     CHARACTER(LEN=  1)    :: COL
     CHARACTER(LEN=255)    :: MyGridFile, ThisLoc
-    CHARACTER(LEN=5500)   :: DUM
+    CHARACTER(LEN=15000)  :: DUM
     CHARACTER(LEN=255)    :: ErrMsg,  Msg
 
     !=================================================================


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard

### Describe the update

The HEMCO standalone currently crashes when running global 0.125x0.15625 (aka 12km) resolution simulations, because the YEDGE and YMID lines in https://github.com/geoschem/HEMCO/blob/main/run/HEMCO_sa_Grid.0125x015625.rc are too long.

In PR #207 we increased the maximum string length to 5500 to allow for global 0.25x0.3125 HEMCO standalone simulations. However for 0.125x0.15625 global grids, the length of the YEDGE and YMID string in HEMCO_sa_Grid.rc are 12,103 and 10,657 characters, respectively. To get around this we can increase the length of string DUM from 5500 to 15000.

### Expected changes

This is a zero difference update. It adds a fix to be able to run the HEMCO standalone on a 0.125x0.15625 degree global grid.

### Reference(s)

If this is a science update, please provide a literature citation.

### Related Github Issue

- https://github.com/geoschem/HEMCO/issues/334
