### PR TITLE
Now sum DELPDRY in the vertical instead of averaging it when regridding from 72 -> 47 layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added call to `HCO_SetPBLm` in routine `HCOI_SA_RUN` so that the PBL height will evolve with time in the HEMCO standalone
 - Added `ExtState%TSKIN` for skin temperature and `ExtState%HFLUX` for sensible heat flux
 - Added `run/config_for_offline_emissions` folder to contain sample `HEMCO_Config.rc` files
+- Added `do_sum` argument to routine `Collapse` in `src/Core/hco_interp_mod.F90`
 
 ### Changed
 - Updated `lint-ci-workflows` to run on `main` and `dev/*` branches
@@ -36,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed security issues in GitHub Actions
 - Fixed bug in routine `Register_Species` caused by a null string being passed to `HCO_Msg`
+- Fixed bug in `hco_interp_mod.F90` where `Met_DELPDRY` was being averaged in the vertical instead of summed
 
 ### Removed
 - Removed Microsoft Azure Dev Pipeline continuous integration tests

--- a/src/Core/hco_interp_mod.F90
+++ b/src/Core/hco_interp_mod.F90
@@ -590,7 +590,7 @@ CONTAINS
     INTEGER                 :: L, T, NL, I
     INTEGER                 :: OS
     LOGICAL                 :: verb, infl, clps
-    LOGICAL                 :: DONE
+    LOGICAL                 :: DONE, do_sum
     CHARACTER(LEN=255)      :: MSG, LOC
 
     !=================================================================
@@ -684,6 +684,12 @@ CONTAINS
     IF ( .NOT. DONE ) THEN
 
        !----------------------------------------------------------------
+       ! Determine if the variable (e.g. Met_DELPDRY) needs
+       ! to be summed in the vertical instead of averaged.
+       !----------------------------------------------------------------
+       do_sum = ( INDEX( TRIM( Lct%Dct%cName ), "DELPDRY" ) > 0 )
+
+       !----------------------------------------------------------------
        ! Native to reduced GEOS-5 levels
        !----------------------------------------------------------------
        IF ( nz == 47 ) THEN
@@ -725,18 +731,18 @@ CONTAINS
             ! If remapping model grid layers, collapse layers 
              IF ( nlev == 72 ) THEN
                ! Collapse two levels (e.g. levels 37-38 into level 37):
-               CALL COLLAPSE( Lct, REGR_4D, 37, 37, 2, T, 5, RC )
-               CALL COLLAPSE( Lct, REGR_4D, 38, 39, 2, T, 5, RC )
-               CALL COLLAPSE( Lct, REGR_4D, 39, 41, 2, T, 5, RC )
-               CALL COLLAPSE( Lct, REGR_4D, 40, 43, 2, T, 5, RC )
+               CALL COLLAPSE( Lct, REGR_4D, 37, 37, 2, T, 5, do_sum, RC )
+               CALL COLLAPSE( Lct, REGR_4D, 38, 39, 2, T, 5, do_sum, RC )
+               CALL COLLAPSE( Lct, REGR_4D, 39, 41, 2, T, 5, do_sum, RC )
+               CALL COLLAPSE( Lct, REGR_4D, 40, 43, 2, T, 5, do_sum, RC )
                ! Collapse four levels:
-               CALL COLLAPSE( Lct, REGR_4D, 41, 45, 4, T, 5, RC )
-               CALL COLLAPSE( Lct, REGR_4D, 42, 49, 4, T, 5, RC )
-               CALL COLLAPSE( Lct, REGR_4D, 43, 53, 4, T, 5, RC )
-               CALL COLLAPSE( Lct, REGR_4D, 44, 57, 4, T, 5, RC )
-               CALL COLLAPSE( Lct, REGR_4D, 45, 61, 4, T, 5, RC )
-               CALL COLLAPSE( Lct, REGR_4D, 46, 65, 4, T, 5, RC )
-               CALL COLLAPSE( Lct, REGR_4D, 47, 69, 4, T, 5, RC )
+               CALL COLLAPSE( Lct, REGR_4D, 41, 45, 4, T, 5, do_sum, RC )
+               CALL COLLAPSE( Lct, REGR_4D, 42, 49, 4, T, 5, do_sum, RC )
+               CALL COLLAPSE( Lct, REGR_4D, 43, 53, 4, T, 5, do_sum, RC )
+               CALL COLLAPSE( Lct, REGR_4D, 44, 57, 4, T, 5, do_sum, RC )
+               CALL COLLAPSE( Lct, REGR_4D, 45, 61, 4, T, 5, do_sum, RC )
+               CALL COLLAPSE( Lct, REGR_4D, 46, 65, 4, T, 5, do_sum, RC )
+               CALL COLLAPSE( Lct, REGR_4D, 47, 69, 4, T, 5, do_sum, RC )
              ! If remapping model grid edges, sample at edges
              ELSEIF ( nlev == 73 ) THEN
                Lct%Dct%Dta%V3(T)%Val(:,:,38) = REGR_4D(:,:,39,T)
@@ -815,21 +821,21 @@ CONTAINS
              ! If remapping model grid layers, collapse layers
              IF ( nlev == 102 ) THEN
                 ! Collapse two levels (e.g. levels 61-62 into level 61):
-                CALL COLLAPSE( Lct, REGR_4D, 61, 61, 2, T, 22, RC )
-                CALL COLLAPSE( Lct, REGR_4D, 62, 63, 2, T, 22, RC )
-                CALL COLLAPSE( Lct, REGR_4D, 63, 65, 2, T, 22, RC )
-                CALL COLLAPSE( Lct, REGR_4D, 64, 67, 2, T, 22, RC )
-                CALL COLLAPSE( Lct, REGR_4D, 65, 69, 2, T, 22, RC )
-                CALL COLLAPSE( Lct, REGR_4D, 66, 71, 2, T, 22, RC )
-                CALL COLLAPSE( Lct, REGR_4D, 67, 73, 2, T, 22, RC )
+                CALL COLLAPSE( Lct, REGR_4D, 61, 61, 2, T, 22, do_sum, RC )
+                CALL COLLAPSE( Lct, REGR_4D, 62, 63, 2, T, 22, do_sum, RC )
+                CALL COLLAPSE( Lct, REGR_4D, 63, 65, 2, T, 22, do_sum, RC )
+                CALL COLLAPSE( Lct, REGR_4D, 64, 67, 2, T, 22, do_sum, RC )
+                CALL COLLAPSE( Lct, REGR_4D, 65, 69, 2, T, 22, do_sum, RC )
+                CALL COLLAPSE( Lct, REGR_4D, 66, 71, 2, T, 22, do_sum, RC )
+                CALL COLLAPSE( Lct, REGR_4D, 67, 73, 2, T, 22, do_sum, RC )
                 ! Collapse four levels:
-                CALL COLLAPSE( Lct, REGR_4D, 68, 75, 4, T, 22, RC )
-                CALL COLLAPSE( Lct, REGR_4D, 69, 79, 4, T, 22, RC )
-                CALL COLLAPSE( Lct, REGR_4D, 70, 83, 4, T, 22, RC )
-                CALL COLLAPSE( Lct, REGR_4D, 71, 87, 4, T, 22, RC )
-                CALL COLLAPSE( Lct, REGR_4D, 72, 91, 4, T, 22, RC )
-                CALL COLLAPSE( Lct, REGR_4D, 73, 95, 4, T, 22, RC )
-                CALL COLLAPSE( Lct, REGR_4D, 74, 99, 4, T, 22, RC )
+                CALL COLLAPSE( Lct, REGR_4D, 68, 75, 4, T, 22, do_sum, RC )
+                CALL COLLAPSE( Lct, REGR_4D, 69, 79, 4, T, 22, do_sum, RC )
+                CALL COLLAPSE( Lct, REGR_4D, 70, 83, 4, T, 22, do_sum, RC )
+                CALL COLLAPSE( Lct, REGR_4D, 71, 87, 4, T, 22, do_sum, RC )
+                CALL COLLAPSE( Lct, REGR_4D, 72, 91, 4, T, 22, do_sum, RC )
+                CALL COLLAPSE( Lct, REGR_4D, 73, 95, 4, T, 22, do_sum, RC )
+                CALL COLLAPSE( Lct, REGR_4D, 74, 99, 4, T, 22, do_sum, RC )
              ! If remapping model grid edges, sample at the edges
              ELSE
                 Lct%Dct%Dta%V3(T)%Val(:,:,62) = REGR_4D(:,:,63,T)
@@ -1020,21 +1026,25 @@ CONTAINS
 !\\
 ! !INTERFACE:
 !
-  SUBROUTINE COLLAPSE ( Lct, REGR_4D, OutLev, InLev1, NLEV, T, MET, RC )
+  SUBROUTINE COLLAPSE( Lct,    REGR_4D, OutLev,                              &
+                       InLev1, NLEV,    T,                                   &
+                       MET,    do_sum,  RC                                  )
 !
 ! !INPUT PARAMETERS:
 !
-    REAL(sp),         POINTER        :: REGR_4D(:,:,:,:)  ! 4D input data
-    INTEGER,          INTENT(IN)     :: OutLev
-    INTEGER,          INTENT(IN)     :: InLev1
-    INTEGER,          INTENT(IN)     :: NLEV
-    INTEGER,          INTENT(IN)     :: T
-    INTEGER,          INTENT(IN)     :: MET               ! 22=GISS E2.2, else GEOS-5
+    REAL(sp),         POINTER        :: REGR_4D(:,:,:,:) ! 4D input data
+    INTEGER,          INTENT(IN)     :: OutLev           ! Output level
+    INTEGER,          INTENT(IN)     :: InLev1           ! 1st input level
+    INTEGER,          INTENT(IN)     :: NLEV             ! # of levels
+    INTEGER,          INTENT(IN)     :: T                ! Time index
+    LOGICAL,          INTENT(IN)     :: do_sum           ! Sum instead of avg?
+    INTEGER,          INTENT(IN)     :: MET              ! 22=GISS E2.2,
+                                                         !  otherwise GMAO
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
-    TYPE(ListCont),   POINTER        :: Lct               ! HEMCO list container
-    INTEGER,          INTENT(INOUT)  :: RC                ! Success or failure?
+    TYPE(ListCont),   POINTER        :: Lct              ! HEMCO list container
+    INTEGER,          INTENT(INOUT)  :: RC               ! Success or failure?
 !
 ! !REVISION HISTORY:
 !  30 Dec 2014 - C. Keller   - Initial version
@@ -1080,12 +1090,17 @@ CONTAINS
     ! Thickness of output level
     THICK = EDG(1) - EDG(NLEV+1)
 
-    ! Get level weights
+    ! Get level weights.  If DO_SUM = T, then we will sum
+    ! the variable in the vertical instead of averaging.
     ALLOCATE(WGT(NLEV))
-    WGT = 0.0
-    DO I = 1, NLEV
-       WGT(I) = ( EDG(I) - EDG(I+1) ) / THICK
-    ENDDO
+    IF ( do_sum ) THEN
+       WGT = 1.0
+    ELSE
+       WGT = 0.0
+       DO I = 1, NLEV
+          WGT(I) = ( EDG(I) - EDG(I+1) ) / THICK
+       ENDDO
+    ENDIF
 
     ! Pass levels to output data, one after each other
     Lct%Dct%Dta%V3(T)%Val(:,:,OutLev) = REGR_4D(:,:,InLev1,T) * WGT(1)


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca (Harvard) and Lee Murray (Rochester)

### Describe the update
This is the companion PR to https://github.com/geoschem/geos-chem/issues/3170, in which @ltmurray found that `Met_DELPDRY` field was being vertically averaged instead of summed during regridding from 72 -> 47 layers.  This led to an incorrect initialization of the stratosphere.

### Expected changes
<img width="1061" height="522" alt="delpdry" src="https://github.com/user-attachments/assets/569b8a6b-46c8-4ebd-b472-908276f72d23" />

The figure above shows stratospheric zonal means for ozone taken from a 72-layer restart file (left), ozone concentrations with the incorrectly-initialized stratosphere (center), and ozone concentrations with the fix in this PR having been applied (right).  As you can see, the fixed ozone concentrations in the right panel closely matches the ozone from the 72 layer restart file.

### Related Github Issue
- Closes https://github.com/geoschem/geos-chem/issues/3170