### PR TITLE
Fix logic errors that caused incorrect time cycling behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+### Fixed
+- Fixed IF-block logic errors in `SrcFile_Parse` that led to incorrect time-cycling behavior
+
 ## [3.12.1] - 2026-04-08
 ### Changed
 - Updated GitHub Actions to the latest versions

--- a/src/Core/hcoio_util_mod.F90
+++ b/src/Core/hcoio_util_mod.F90
@@ -1710,21 +1710,24 @@ CONTAINS
              ENDIF
 
              ! Get next type
+             ! Update logic so that NEWTYP can be given values of 5, 6,
+             ! or 7.  Previouly these ELSEIF blocks were unreachable.
+             ! See: https://github.com/geoschem/HEMCO/issues/358
              IF ( nextTyp ) THEN
                 NEWTYP = -1
-                IF     ( hasHr .AND. TYP < 1 ) THEN
+                IF     ( hasHr .AND.             TYP < 1 ) THEN
                    NEWTYP = 1
-                ELSEIF ( hasDy .AND. TYP < 2 ) THEN
+                ELSEIF ( hasDy .AND.             TYP < 2 ) THEN
                    NEWTYP = 2
-                ELSEIF ( hasMt .AND. TYP < 3 ) THEN
+                ELSEIF ( hasMt .AND.             TYP < 3 ) THEN
                    NEWTYP = 3
-                ELSEIF ( hasYr .AND. TYP < 4 ) THEN
+                ELSEIF ( hasYr .AND.             TYP < 4 ) THEN
                    NEWTYP = 4
-                ELSEIF ( hasDy .AND. TYP < 2 ) THEN
+                ELSEIF ( hasHr .AND. hasDy .AND. TYP < 5 ) THEN
                    NEWTYP = 5
-                ELSEIF ( hasDy .AND. TYP < 2 ) THEN
+                ELSEIF ( hasDy .AND. hasMt .AND. TYP < 6 ) THEN
                    NEWTYP = 6
-                ELSEIF ( hasDy .AND. TYP < 2 ) THEN
+                ELSEIF ( hasMt .AND. hasYr .AND. TYP < 7 ) THEN
                    NEWTYP = 7
                 ENDIF
 
@@ -1773,7 +1776,10 @@ CONTAINS
                    EXIT
              END SELECT
 
-             ! Check if we need to adjust a year/month/day/hour
+             ! Check if we need to adjust a year/month/day/hour.
+             ! We have added logic to avoid adjusting the year when 
+             ! TYP==3 (which is the "adjust month only" case).
+             ! See: https://github.com/geoschem/HEMCO/issues/358
              IF ( prefHr < 0 ) THEN
                 prefHr = 23
                 prefDy = prefDy - 1
@@ -1790,13 +1796,21 @@ CONTAINS
                 prefDy = 1
                 prefMt = prefMt + 1
              ENDIF
-             IF ( prefMt < 1  ) THEN
-                prefMt = 12
-                prefYr = prefYr - 1
+             IF ( prefMt < 1 ) THEN
+                IF ( TYP /= 3 ) THEN
+                   prefMt = 12
+                   prefYr = prefYr - 1
+                ELSE
+                   TYPCNT = 999         ! force transition to TYP=4
+                ENDIF
              ENDIF
              IF ( prefMt > 12 ) THEN
-                prefMt = 1
-                prefYr = prefYr + 1
+                IF ( TYP /= 3 ) THEN
+                   prefMt = 1
+                   prefYr = prefYr + 1
+                ELSE
+                   TYPCNT = 999         ! force transition to TYP=4
+                ENDIF
              ENDIF
 
              ! Make sure day does not exceed max. number of days in this month


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This is the companion PR to #358.  We have fixed a couple of logic errors in routine `SrcFile_Parse` that caused incorrect time cycling behavior.  See the discussion in #358 for a detailed description of the problem, plus the proposed fix.

### Expected changes
This is a no-diff-to-benchmark update:

### Related Github Issue
- Closes #358 