### PR TITLE
Build-time option for MAPL3 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an error in `src/Shared/GeosUtil/hco_regrid_a2a_mod.F90` where an accumulator was uninitialized before reuse, which may inherit junk data from the previous iteration if the southmost source cell is not found
 - Fixed IF-block logic errors in `SrcFile_Parse` that led to incorrect time-cycling behavior
 
+### Added
+- Added code blocks for MAPL3 code in development
+- Added C-preprocessor switches USE_ESMF and MAPL3
+
+### Changed
+- Renamed subroutine HCO_CopyFromIntnal_ESMF to HCO_CopyFromInternal_ESMF
+- Renamed state objects HcoState%IMPORT and HcoStateEXPORT to HcoState%internalState and HcoState%exportState respectively
+
+#### Removed
+- Removed C-preprocessor switch ESMF_
+
 ## [3.12.1] - 2026-04-08
 ### Changed
 - Updated GitHub Actions to the latest versions

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ add_library(HEMCOBuildProperties INTERFACE)
 #---------------------------------------------------------------------
 set(HEMCO_Fortran_FLAGS_Intel
    -cpp -w -auto -noalign "SHELL:-convert big_endian" "SHELL:-fp-model source" -mcmodel=medium
-   -shared-intel -traceback -DLINUX_IFORT
+   -shared-intel -traceback -diag-disable 10448 -DLINUX_IFORT
    CACHE STRING "HEMCO compiler flags for all build types with Intel compilers"
 )
 set(HEMCO_Fortran_FLAGS_RELEASE_Intel
@@ -323,17 +323,36 @@ endif()
 # For HEMCO as submodule in MAPL/ESMF superproject
 #-----------------------------------------------------------------------------
 if(HEMCO_EXTERNAL_CONFIG AND MAPL_ESMF)
+if(NOT MAPL3)
     target_link_libraries(HEMCOBuildProperties
         INTERFACE $<LINK_ONLY:MAPL.base>
+        INTERFACE $<LINK_ONLY:MAPL.shared>
         INTERFACE $<LINK_ONLY:MAPL.generic>
     )
     target_include_directories(HEMCOBuildProperties 
         INTERFACE $<TARGET_PROPERTY:MAPL.base,INTERFACE_INCLUDE_DIRECTORIES>
+	INTERFACE $<TARGET_PROPERTY:MAPL.shared,INTERFACE_INCLUDE_DIRECTORIES>
         INTERFACE $<TARGET_PROPERTY:MAPL.generic,INTERFACE_INCLUDE_DIRECTORIES>
     )
     target_compile_definitions(HEMCOBuildProperties
-        INTERFACE ESMF_ MAPL_ESMF
+        INTERFACE ESMF_ USE_ESMF MAPL_ESMF
     )
+endif()
+if(MAPL3)
+    target_link_libraries(HEMCOBuildProperties
+        INTERFACE $<LINK_ONLY:MAPL.base>
+        INTERFACE $<LINK_ONLY:mapl3g>
+	INTERFACE $<LINK_ONLY:MAPL.generic3g>
+    )
+    target_include_directories(HEMCOBuildProperties
+        INTERFACE $<TARGET_PROPERTY:MAPL.base,INTERFACE_INCLUDE_DIRECTORIES>
+        INTERFACE $<TARGET_PROPERTY:mapl3g,INTERFACE_INCLUDE_DIRECTORIES>
+	INTERFACE $<TARGET_PROPERTY:MAPL.generic3g,INTERFACE_INCLUDE_DIRECTORIES>
+    )
+    target_compile_definitions(HEMCOBuildProperties
+        INTERFACE ESMF_ USE_ESMF MAPL_ESMF MAPL3
+    )
+endif()
 
     # Specify the HEMCO interface being used
     set(HEMCO_INTERFACE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ add_library(HEMCOBuildProperties INTERFACE)
 #---------------------------------------------------------------------
 set(HEMCO_Fortran_FLAGS_Intel
    -cpp -w -auto -noalign "SHELL:-convert big_endian" "SHELL:-fp-model source" -mcmodel=medium
-   -shared-intel -traceback -diag-disable 10448 -DLINUX_IFORT
+   -shared-intel -traceback -DLINUX_IFORT
    CACHE STRING "HEMCO compiler flags for all build types with Intel compilers"
 )
 set(HEMCO_Fortran_FLAGS_RELEASE_Intel
@@ -335,7 +335,7 @@ if(NOT MAPL3)
         INTERFACE $<TARGET_PROPERTY:MAPL.generic,INTERFACE_INCLUDE_DIRECTORIES>
     )
     target_compile_definitions(HEMCOBuildProperties
-        INTERFACE ESMF_ USE_ESMF MAPL_ESMF
+        INTERFACE USE_ESMF MAPL_ESMF
     )
 endif()
 if(MAPL3)
@@ -350,7 +350,7 @@ if(MAPL3)
 	INTERFACE $<TARGET_PROPERTY:MAPL.generic3g,INTERFACE_INCLUDE_DIRECTORIES>
     )
     target_compile_definitions(HEMCOBuildProperties
-        INTERFACE ESMF_ USE_ESMF MAPL_ESMF MAPL3
+        INTERFACE USE_ESMF MAPL_ESMF MAPL3
     )
 endif()
 

--- a/src/Core/hco_calc_mod.F90
+++ b/src/Core/hco_calc_mod.F90
@@ -891,7 +891,7 @@ CONTAINS
        CALL HCO_Msg( msg, sep1=' ', LUN=HcoState%Config%hcoLogLUN )
     ENDIF
 
-#if !defined ( ESMF_ )
+#ifndef MAPL_ESMF
     ! Put check for PBLHEIGHT here, if not running in ESMF/MAPL
     IF ( .NOT. ASSOCIATED( HcoState%Grid%PBLHEIGHT%Val ) ) THEN
        msg = 'PBLHEIGHT (in meters) is missing in HEMCO state'

--- a/src/Core/hco_config_mod.F90
+++ b/src/Core/hco_config_mod.F90
@@ -1008,8 +1008,8 @@ CONTAINS
                    ENDIF
                 ENDIF
 
-#if defined(ESMF_)
-                ! In an ESMF environment, the source data will be imported
+#ifdef MAPL_ESMF
+                ! In an MAPL/ESMF environment, the source data will be imported
                 ! through ExtData by name, hence need to set ncFile equal to
                 ! container name!
                 IF ( Dta%ncRead ) THEN
@@ -1228,8 +1228,8 @@ CONTAINS
                 ENDIF
              ENDIF
 
-#if defined(ESMF_)
-             ! In an ESMF environment, the source data will be imported
+#ifdef MAPL_ESMF
+             ! In a MAPL/ESMF environment, the source data will be imported
              ! through ExtData by name, hence need to set ncFile equal to
              ! container name!
              IF ( Dta%ncRead ) THEN
@@ -2098,10 +2098,9 @@ CONTAINS
 
     ENDDO
 
-#ifndef MODEL_GEOS
 #ifndef MODEL_WRF
 #ifndef MODEL_CESM
-#ifndef ESMF_
+#ifndef MAPL_ESMF
     !=======================================================================
     ! Look for met field and grid resolution.  When running the HEMCO
     ! standalone these will need to be read from the configuration file.
@@ -2141,7 +2140,6 @@ CONTAINS
        END SELECT
        HcoConfig%GridRes = TRIM( GridRes )
     ENDIF
-#endif
 #endif
 #endif
 #endif
@@ -2447,7 +2445,7 @@ CONTAINS
           !
           ! Thus, the following fix needs to be applied for ESMF environments,
           ! skipping a lot of the calculations below.
-#if defined ( ESMF_ ) || defined( MODEL_WRF ) || defined( MODEL_CESM )
+#if defined ( MAPL_ESMF ) || defined( MODEL_WRF ) || defined( MODEL_CESM )
           ThisCover = -1
 #else
           ! Get mask edges

--- a/src/Core/hco_diagn_mod.F90
+++ b/src/Core/hco_diagn_mod.F90
@@ -413,7 +413,7 @@ CONTAINS
     ! ------------------------------------------------------------------
     ! HEMCO restart
     ! ------------------------------------------------------------------
-#if defined ( ESMF_ )
+#ifdef MAPL_ESMF
     deltaYMD = 0
     deltaHMS = 1
 #else
@@ -526,7 +526,7 @@ CONTAINS
     ! ------------------------------------------------------------------
     ! Manual diagnostics
     ! ------------------------------------------------------------------
-#if defined ( ESMF_ )
+#ifdef MAPL_ESMF
     deltaYMD = 0
     deltaHMS = 1
 #else
@@ -4316,9 +4316,9 @@ CONTAINS
        DeltaHMS = 0 ! = 000000
     ENDIF
 
-    ! Force to 'Always' in ESMF environment to make sure that
+#ifdef MAPL_ESMF
+    ! Force to 'Always' in MAPL/ESMF environment to make sure that
     ! diagnostics are passed to MAPL HISTORY every time.
-#if defined ( ESMF_ )
     DeltaYMD = 0 ! = 00000000
     DeltaHMS = 1 ! = 000001   ==> 1 second!
 #endif

--- a/src/Core/hco_error_mod.F90
+++ b/src/Core/hco_error_mod.F90
@@ -184,7 +184,6 @@ CONTAINS
 ! !USES:
 !
 #ifdef MAPL_ESMF
-    USE ESMF
 #ifdef MAPL3
 #include "MAPL.h"
     USE mapl3
@@ -193,7 +192,10 @@ CONTAINS
     USE MAPLBase_Mod
 #endif
 #endif
-!
+#ifdef USE_ESMF
+    USE ESMF
+#endif
+    !
 ! !INPUT PARAMETERS:
 !
     CHARACTER(LEN=*), INTENT(IN   )            :: ErrMsg

--- a/src/Core/hco_error_mod.F90
+++ b/src/Core/hco_error_mod.F90
@@ -184,6 +184,7 @@ CONTAINS
 ! !USES:
 !
 #ifdef MAPL_ESMF
+    USE ESMF
 #ifdef MAPL3
 #include "MAPL.h"
     USE mapl3
@@ -192,10 +193,7 @@ CONTAINS
     USE MAPLBase_Mod
 #endif
 #endif
-#ifdef USE_ESMF
-    USE ESMF
-#endif
-    !
+!
 ! !INPUT PARAMETERS:
 !
     CHARACTER(LEN=*), INTENT(IN   )            :: ErrMsg
@@ -214,7 +212,7 @@ CONTAINS
 !BOC
     INTEGER             :: I, J, hcoLogLUN
     CHARACTER(LEN=1023) :: MSG
-#if defined( USE_ESMF )
+#if defined( MAPL_ESMF )
     INTEGER             :: localPET, STATUS
     CHARACTER(4)        :: localPETchar
     TYPE(ESMF_VM)       :: VM
@@ -229,7 +227,7 @@ CONTAINS
     IF ( PRESENT( LUN ) ) hcoLogLUN = LUN
 
     ! Construct error message
-#ifdef USE_ESMF
+#ifdef MAPL_ESMF
     ! Get current thread number
     CALL ESMF_VMGetCurrent(VM, RC=STATUS)
     !CALL ESMF_VmGet( VM, localPET=localPET, __RC__ )

--- a/src/Core/hco_error_mod.F90
+++ b/src/Core/hco_error_mod.F90
@@ -183,10 +183,15 @@ CONTAINS
 !
 ! !USES:
 !
-#if defined( ESMF_ )
-#include "MAPL_Generic.h"
+#ifdef MAPL_ESMF
     USE ESMF
+#ifdef MAPL3
+#include "MAPL.h"
+    USE mapl3
+#else
+#include "MAPL_Generic.h"
     USE MAPLBase_Mod
+#endif
 #endif
 !
 ! !INPUT PARAMETERS:
@@ -207,7 +212,7 @@ CONTAINS
 !BOC
     INTEGER             :: I, J, hcoLogLUN
     CHARACTER(LEN=1023) :: MSG
-#if defined( ESMF_)
+#if defined( USE_ESMF )
     INTEGER             :: localPET, STATUS
     CHARACTER(4)        :: localPETchar
     TYPE(ESMF_VM)       :: VM
@@ -222,10 +227,11 @@ CONTAINS
     IF ( PRESENT( LUN ) ) hcoLogLUN = LUN
 
     ! Construct error message
-#if defined( ESMF_ )
+#ifdef USE_ESMF
     ! Get current thread number
     CALL ESMF_VMGetCurrent(VM, RC=STATUS)
-    CALL ESMF_VmGet( VM, localPET=localPET, __RC__ )
+    !CALL ESMF_VmGet( VM, localPET=localPET, __RC__ )
+    CALL ESMF_VmGet( VM, localPET=localPET, _RC )
     WRITE(localPETchar,'(I4.4)') localPET
     MSG = 'HEMCO ERROR [' // TRIM( localPETchar ) //']: '// TRIM( ErrMsg )
 #else

--- a/src/Core/hco_geotools_mod.F90
+++ b/src/Core/hco_geotools_mod.F90
@@ -596,7 +596,9 @@ CONTAINS
 !
 ! !LOCAL VARIABLES:
 !
+#ifdef MAPL3
     INTEGER          :: status    
+#endif
     REAL             :: LonR(N), LatR(N)
     REAL, PARAMETER  :: radToDeg = 57.2957795
     TYPE(ESMF_Grid)  :: Grid
@@ -604,7 +606,7 @@ CONTAINS
 #ifndef MAPL3
     ! Defined Iam and STATUS
     __Iam__("HCO_GetHorzIJIndex (hco_geotools_mod.F90)")
-#endif    
+#endif
     
     !-------------------------------
     ! HCO_GetHorzIJIndex begins here

--- a/src/Core/hco_geotools_mod.F90
+++ b/src/Core/hco_geotools_mod.F90
@@ -539,7 +539,7 @@ CONTAINS
 
   END SUBROUTINE HCO_GetSUNCOS
 !EOC
-#if defined(ESMF_)
+#ifdef MAPL_ESMF
 !------------------------------------------------------------------------------
 !                   Harmonized Emissions Component (HEMCO)                    !
 !------------------------------------------------------------------------------
@@ -557,9 +557,19 @@ CONTAINS
 !
 ! !USES
 !
+#ifdef MAPL3
+#include "MAPL.h"
+#else
 #include "MAPL_Generic.h"
+#endif
+
     USE ESMF
+#ifdef MAPL3
+    USE mapl3
+    USE mapl3g_GridGetHorzIJIndex, ONLY : GridGetHorzIJIndex
+#else
     USE MAPLBase_Mod
+#endif
     USE HCO_STATE_MOD,   ONLY : HCO_STATE
 !
 ! !INPUT PARAMETERS:
@@ -586,32 +596,41 @@ CONTAINS
 !
 ! !LOCAL VARIABLES:
 !
+    INTEGER          :: status    
     REAL             :: LonR(N), LatR(N)
     REAL, PARAMETER  :: radToDeg = 57.2957795
     TYPE(ESMF_Grid)  :: Grid
 
+#ifndef MAPL3
     ! Defined Iam and STATUS
     __Iam__("HCO_GetHorzIJIndex (hco_geotools_mod.F90)")
-
+#endif    
+    
     !-------------------------------
     ! HCO_GetHorzIJIndex begins here
     !-------------------------------
 
     ! Get grid
+#ifdef MAPL3
+    _ASSERT(ASSOCIATED(HcoState%GridComp),'HcoState%GridComp must be associated!')
+    CALL ESMF_GridCompGet( HcoState%GridComp, Grid=Grid, _RC )
+#else
     ASSERT_(ASSOCIATED(HcoState%GridComp))
     CALL ESMF_GridCompGet( HcoState%GridComp, Grid=Grid, __RC__ )
+#endif
 
     ! Shadow variables
     LonR(:) = Lon / radToDeg
     LatR(:) = Lat / radToDeg
 
-    ! Get indeces
-    CALL MAPL_GetHorzIJIndex( npts=N,   II=idx,   JJ=jdx,    &
-                              lon=LonR, lat=LatR, Grid=Grid, &
-                              __RC__)
-
-!!! old version of MAPL:
-!    CALL MAPL_GetHorzIJIndex(N,idx,jdx,LonR,LatR,Grid=Grid,__RC__)
+    ! Get indices
+#ifdef MAPL3
+    CALL GridGetHorzIJIndex( npts=N, ii=idx, jj=jdx,    &
+         lon=LonR, lat=LatR, grid=Grid, _RC)
+#else
+     CALL MAPL_GetHorzIJIndex( npts=N,   II=idx,   JJ=jdx,    &
+          lon=LonR, lat=LatR, Grid=Grid, __RC__)
+#endif
 
     ! Return w/ success
     RC =  HCO_SUCCESS

--- a/src/Core/hco_restart_mod.F90
+++ b/src/Core/hco_restart_mod.F90
@@ -74,8 +74,8 @@ MODULE HCO_RESTART_MOD
 !
 ! !PRIVATE MEMBER FUNCTIONS:
 !
-#if defined(ESMF_)
-  PRIVATE :: HCO_CopyFromIntnal_ESMF
+#ifdef MAPL_ESMF 
+  PRIVATE :: HCO_CopyFromInternal_ESMF
 #endif
 
   INTERFACE HCO_RestartDefine
@@ -319,12 +319,12 @@ CONTAINS
     ! Is the output array filled yet?
     FLD = .FALSE.
 
+#ifdef MAPL_ESMF
     ! ------------------------------------------------------------------
     ! Try to get from ESMF internal state
     ! ------------------------------------------------------------------
-#if defined(ESMF_)
-    CALL HCO_CopyFromIntnal_ESMF( HcoState, TRIM(Name),   &
-                                  1,        FLD,      RC, Arr3D=Arr3D )
+    CALL HCO_CopyFromInternal_ESMF( HcoState, TRIM(Name), -1,  &
+         FLD, RC, Arr3D=Arr3D )
     IF ( RC /= HCO_SUCCESS ) THEN
         CALL HCO_ERROR( 'ERROR 2', RC, THISLOC=LOC )
         RETURN
@@ -484,12 +484,12 @@ CONTAINS
     ! Is the output array filled yet?
     FLD = .FALSE.
 
+#ifdef MAPL_ESMF
     ! ------------------------------------------------------------------
     ! Try to get from ESMF internal state
     ! ------------------------------------------------------------------
-#if defined(ESMF_)
-    CALL HCO_CopyFromIntnal_ESMF( HcoState, TRIM(Name),   &
-                                  1,        FLD,      RC, Arr2D=Arr2D )
+    CALL HCO_CopyFromInternal_ESMF( HcoState, TRIM(Name), 1,  &
+         FLD, RC, Arr2D=Arr2D )
     IF ( RC /= HCO_SUCCESS ) THEN
         CALL HCO_ERROR( 'ERROR 4', RC, THISLOC=LOC )
         RETURN
@@ -643,9 +643,9 @@ CONTAINS
     ! Data written to internal state?
     WRITTEN = .FALSE.
 
-#if defined(ESMF_)
-    CALL HCO_CopyFromIntnal_ESMF( HcoState, TRIM(Name), &
-                                  -1,       WRITTEN,    RC, Arr3D=Arr3D )
+#ifdef MAPL_ESMF
+    CALL HCO_CopyFromInternal_ESMF( HcoState, TRIM(Name), -1, &
+         WRITTEN, RC, Arr3D=Arr3D )
 #endif
 
     ! Pass to output
@@ -711,9 +711,9 @@ CONTAINS
     ! Data written to internal state?
     WRITTEN = .FALSE.
 
-#if defined(ESMF_)
-    CALL HCO_CopyFromIntnal_ESMF( HcoState, TRIM(Name), &
-                                  -1,       WRITTEN,    RC, Arr2D=Arr2D )
+#ifdef MAPL_ESMF
+    CALL HCO_CopyFromInternal_ESMF( HcoState, TRIM(Name), -1, &
+         WRITTEN, RC, Arr2D=Arr2D )
 #endif
 
     ! Pass to output
@@ -726,30 +726,41 @@ CONTAINS
 
   END SUBROUTINE HCO_RestartWrite_2D
 !EOC
-#if defined(ESMF_)
+#ifdef MAPL_ESMF
 !------------------------------------------------------------------------------
 !                   Harmonized Emissions Component (HEMCO)                    !
 !------------------------------------------------------------------------------
 !BOP
 !
-! !ROUTINE: HCO_CopyFromIntnal_ESMF
+! !ROUTINE: HCO_CopyFromInternal_ESMF
 !
-! !DESCRIPTION: Subroutine HCO\_CopyFromIntnal\_ESMF attempts to transfer
+! !DESCRIPTION: Subroutine HCO\_CopyFromInternal\_ESMF attempts to transfer
 ! data to and from the ESMF/MAPL internal state.
 !\\
 !\\
 ! !INTERFACE:
 !
-  SUBROUTINE HCO_CopyFromIntnal_ESMF ( HcoState,  Name,    &
+  SUBROUTINE HCO_CopyFromInternal_ESMF ( HcoState,  Name,    &
                                        Direction, Found, RC, Arr2D, Arr3D )
 !
 ! !USES:
 !
+#ifdef MAPL3    
+#include "MAPL.h"
+#else
 #include "MAPL_Generic.h"
+#endif
+
     USE ESMF
+#ifdef MAPL3
+    USE mapl3
+    USE mapl3g_Generic,   only : MAPL_GridCompGetInternalState
+    USE mapl3g_State_API, only : MAPL_StateGetPointer
+#else
     USE ESMFL_MOD
     USE MAPL_GenericMod
     USE MAPL_ErrorHandlingMod
+#endif
     USE HCO_STATE_MOD,   ONLY : Hco_State
 !
 ! !ARGUMENTS:
@@ -771,41 +782,62 @@ CONTAINS
 !
 ! !LOCAL VARIABLES:
 !
-    INTEGER                      :: STAT
-    TYPE(MAPL_MetaComp), POINTER :: STATE
-    TYPE(ESMF_STATE)             :: INTERNAL
+    INTEGER                      :: STAT, status
+    TYPE(ESMF_STATE)             :: internalState
     REAL,                POINTER :: Ptr2D(:,:)
     REAL,                POINTER :: Ptr3D(:,:,:)
-
+#ifndef MAPL3
+    TYPE(MAPL_MetaComp), POINTER :: maplState
+#endif
+    
     ! ================================================================
-    ! HCO_CopyFromIntnal_ESMF begins here
+    ! HCO_CopyFromInternal_ESMF begins here
     ! ================================================================
 
+#ifndef MAPL3
     ! For MAPL/ESMF error handling (defines Iam and STATUS)
-    __Iam__('HCO_CopyFromIntnal_ESMF (hco_restart_mod.F90)')
+    __Iam__('HCO_CopyFromInternal_ESMF (hco_restart_mod.F90)')
+#endif
 
     ! Init
     Ptr2D => NULL()
     Ptr3D => NULL()
 
     ! Get internal state
-    CALL MAPL_GetObjectFromGC( HcoState%GridComp, STATE, __RC__ )
-    CALL MAPL_Get ( STATE, INTERNAL_ESMF_STATE=INTERNAL, __RC__ )
+#ifdef MAPL3
+    CALL MAPL_GridCompGetInternalState(HcoState%GridComp, internalState, _RC)
+#else
+    CALL MAPL_GetObjectFromGC( HcoState%GridComp, maplState, __RC__ )
+    CALL MAPL_Get ( maplState, INTERNAL_ESMF_STATE=internalState, __RC__ )
+#endif
 
     ! Try to import field
     IF ( PRESENT(Arr2D) ) THEN
-       CALL MAPL_GetPointer( INTERNAL, Ptr2D, TRIM(Name), &
+#ifdef MAPL3
+       CALL MAPL_StateGetPointer( internalState, Ptr2D, TRIM(Name), _RC )
+#else
+       CALL MAPL_GetPointer( internalState, Ptr2D, TRIM(Name), &
                              NotFoundOk=.TRUE., __RC__ )
+#endif
 
        ! Eventually copy data to or from output array
        IF ( ASSOCIATED(Ptr2D) ) THEN
 
+#ifdef MAPL3
+          ! Make sure we can copy the data
+          _ASSERT(SIZE(Arr2D,1)==SIZE(Ptr2D,1),'First dimension size mismatch in 2D arrays!')
+          _ASSERT(SIZE(Arr2D,2)==SIZE(Ptr2D,2),'Second dimension size mismatch in 2D arrays!')
+
+          ! transfer direction must be 1 or -1
+          _ASSERT(Direction==1 .OR. Direction==-1,'Dimension must be either 1 or -1!')
+#else
           ! Make sure we can copy the data
           ASSERT_(SIZE(Arr2D,1)==SIZE(Ptr2D,1))
           ASSERT_(SIZE(Arr2D,2)==SIZE(Ptr2D,2))
 
           ! transfer direction must be 1 or -1
           ASSERT_(Direction==1 .OR. Direction==-1)
+#endif
 
           ! Transfer data
           IF ( Direction == 1 ) THEN
@@ -824,12 +856,25 @@ CONTAINS
 
     ! Try to import field
     IF ( PRESENT(Arr3D) ) THEN
-       CALL MAPL_GetPointer( INTERNAL, Ptr3D, TRIM(Name), &
+#ifdef MAPL3
+       CALL MAPL_StateGetPointer( internalState, Ptr3D, TRIM(Name), _RC )
+#else
+       CALL MAPL_GetPointer( internalState, Ptr3D, TRIM(Name), &
                              NotFoundOk=.TRUE., __RC__ )
-
+#endif
+       
        ! Eventually copy data to or from output array
        IF ( ASSOCIATED(Ptr3D) ) THEN
 
+#ifdef MAPL3
+          ! Make sure we can copy the data
+          _ASSERT(SIZE(Arr3D,1)==SIZE(Ptr3D,1),'First dimension size mismatch in 3D arrays!')
+          _ASSERT(SIZE(Arr3D,2)==SIZE(Ptr3D,2),'Second dimension size mismatch in 3D arrays!')
+          _ASSERT(SIZE(Arr3D,3)==SIZE(Ptr3D,3),'Third dimension size mismatch in 3D arrays!')
+
+          ! transfer direction must be 1 or -1
+          _ASSERT(Direction==1 .OR. Direction==-1,'Direction must be 1 or -1!')
+#else
           ! Make sure we can copy the data
           ASSERT_(SIZE(Arr3D,1)==SIZE(Ptr3D,1))
           ASSERT_(SIZE(Arr3D,2)==SIZE(Ptr3D,2))
@@ -837,6 +882,7 @@ CONTAINS
 
           ! transfer direction must be 1 or -1
           ASSERT_(Direction==1 .OR. Direction==-1)
+#endif
 
           ! Transfer data
           IF ( Direction == 1 ) THEN
@@ -856,7 +902,7 @@ CONTAINS
     ! Return success
     RC = HCO_SUCCESS
 
-  END SUBROUTINE HCO_CopyFromIntnal_ESMF
+  END SUBROUTINE HCO_CopyFromInternal_ESMF
 !EOC
 #endif
 END MODULE HCO_RESTART_MOD

--- a/src/Core/hco_restart_mod.F90
+++ b/src/Core/hco_restart_mod.F90
@@ -323,7 +323,7 @@ CONTAINS
     ! ------------------------------------------------------------------
     ! Try to get from ESMF internal state
     ! ------------------------------------------------------------------
-    CALL HCO_CopyFromInternal_ESMF( HcoState, TRIM(Name), -1,  &
+    CALL HCO_CopyFromInternal_ESMF( HcoState, TRIM(Name), 1,  &
          FLD, RC, Arr3D=Arr3D )
     IF ( RC /= HCO_SUCCESS ) THEN
         CALL HCO_ERROR( 'ERROR 2', RC, THISLOC=LOC )
@@ -782,11 +782,13 @@ CONTAINS
 !
 ! !LOCAL VARIABLES:
 !
-    INTEGER                      :: STAT, status
+    INTEGER                      :: STAT
     TYPE(ESMF_STATE)             :: internalState
     REAL,                POINTER :: Ptr2D(:,:)
     REAL,                POINTER :: Ptr3D(:,:,:)
-#ifndef MAPL3
+#ifdef MAPL3
+    INTEGER                      :: status
+#else
     TYPE(MAPL_MetaComp), POINTER :: maplState
 #endif
     

--- a/src/Core/hco_state_mod.F90
+++ b/src/Core/hco_state_mod.F90
@@ -34,7 +34,7 @@ MODULE HCO_State_Mod
   USE HCO_Arr_Mod
   USE HCO_VertGrid_Mod
 
-#if defined(ESMF_)
+#ifdef MAPL_ESMF
   USE ESMF
 #endif
 
@@ -115,10 +115,10 @@ MODULE HCO_State_Mod
      TYPE(DiagnBundle),  POINTER :: Diagn  => NULL()
 
      !%%%%%  ESMF objects
-#if defined(ESMF_)
-     TYPE(ESMF_GridComp), POINTER :: GridComp
-     TYPE(ESMF_State),    POINTER :: IMPORT
-     TYPE(ESMF_State),    POINTER :: EXPORT
+#ifdef MAPL_ESMF
+     TYPE(ESMF_GridComp), POINTER :: gridComp
+     TYPE(ESMF_State),    POINTER :: importState
+     TYPE(ESMF_State),    POINTER :: exportState
 #endif
 #ifdef ADJOINT
      LOGICAL                      :: isAdjoint
@@ -477,10 +477,10 @@ CONTAINS
     IF ( .NOT. Found ) HcoState%Options%VertWeight = .TRUE.
 
     ! Make sure ESMF pointers are not dangling
-#if defined(ESMF_)
-    HcoState%GridComp => NULL()
-    HcoState%IMPORT   => NULL()
-    HcoState%EXPORT   => NULL()
+#ifdef MAPL_ESMF
+    HcoState%gridComp    => NULL()
+    HcoState%importState => NULL()
+    HcoState%exportState => NULL()
 #endif
 
     ! Read unit tolerance
@@ -599,10 +599,10 @@ CONTAINS
     IF ( ASSOCIATED ( HcoState%Options ) ) DEALLOCATE ( HcoState%Options )
     IF ( ASSOCIATED ( HcoState%Phys    ) ) DEALLOCATE ( HcoState%Phys    )
 
-#if defined(ESMF_)
-    HcoState%GridComp => NULL()
-    HcoState%IMPORT   => NULL()
-    HcoState%EXPORT   => NULL()
+#ifdef MAPL_ESMF
+    HcoState%gridComp    => NULL()
+    HcoState%importState => NULL()
+    HcoState%exportState => NULL()
 #endif
 
   END SUBROUTINE HcoState_Final

--- a/src/Core/hcoio_diagn_mod.F90
+++ b/src/Core/hcoio_diagn_mod.F90
@@ -167,16 +167,16 @@ CONTAINS
 #endif
           END SELECT
 
-#if       !defined ( ESMF_ )
-          ! If not ESMF environment, never write the manual diagnostics
-          ! to disk. Instead, the content of the manual diagnostics needs
-          ! to be fetched explicitly.
-          IF ( I == 3 ) CYCLE
-#else
+#ifdef MAPL_ESMF
           ! Don't write restart variables to EXPORT in an ESMF environment.
           ! They are already passed to the INTERNAL state when calling
           ! HCO_RestartWrite. (ckeller, 10/9/17)
           IF ( I == 2 ) CYCLE
+#else
+          ! If not ESMF environment, do not write the manual diagnostics
+          ! to disk. Instead, the content of the manual diagnostics needs
+          ! to be fetched explicitly.
+          IF ( I == 3 ) CYCLE
 #endif
 
           ! Restart file
@@ -249,9 +249,9 @@ CONTAINS
     thisLoc = 'HCOIO_DIAGN_WRITEOUT (src/Core/hcoio_diagn_mod.F90)'
 
 
-#if defined(ESMF_)
+#ifdef MAPL_ESMF
     !------------------------------------------------------------------------
-    ! ESMF environment: call ESMF output routines
+    ! ESMF environment: call ESMF output routine
     !------------------------------------------------------------------------
     CALL HCOIO_Write( HcoState,                                              &
                       RC,                                                    &

--- a/src/Core/hcoio_read_mapl_mod.F90
+++ b/src/Core/hcoio_read_mapl_mod.F90
@@ -1,7 +1,7 @@
 !BOC
-#if defined ( ESMF_ )
+#ifdef MAPL_ESMF
 ! The 'standard' HEMCO I/O module is used for:
-! - GEOS-Chem High Performance / GCHP and GEOS (ESMF_)
+! - GEOS-Chem High Performance / GCHP and GEOS
 !EOC
 !------------------------------------------------------------------------------
 !                   Harmonized Emissions Component (HEMCO)                    !
@@ -62,10 +62,15 @@ CONTAINS
 ! !USES:
 !
     USE ESMF
+#ifdef MAPL3    
+#include "MAPL.h"
+    USE mapl3
+    USE mapl3g_State_API, only: MAPL_StateGetPointer
+#else
+#include "MAPL_Generic.h"
     USE MAPLBase_mod
+#endif
     USE HCO_FILEDATA_MOD, ONLY : FileData_ArrInit
-
-# include "MAPL_Generic.h"
 !
 ! !INPUT PARAMETERS:
 !
@@ -87,10 +92,10 @@ CONTAINS
 !
     INTEGER                    :: II, JJ, LL, TT
     INTEGER                    :: I, J, L, T
-    INTEGER                    :: STAT
+    INTEGER                    :: STAT, status
     REAL,             POINTER  :: Ptr3D(:,:,:)
     REAL,             POINTER  :: Ptr2D(:,:)
-    TYPE(ESMF_State), POINTER  :: IMPORT
+    TYPE(ESMF_State), POINTER  :: importState
     CHARACTER(LEN=255)         :: MSG
     CHARACTER(LEN=255), PARAMETER :: LOC = 'HCOIO_READ (hcoio_read_mapl_mod.F90)'
     CHARACTER(LEN=ESMF_MAXSTR) :: Iam
@@ -107,9 +112,9 @@ CONTAINS
         RETURN
     ENDIF
 
-    ! Point to ESMF IMPORT object
-    IMPORT => HcoState%IMPORT
-    ASSERT_(ASSOCIATED(IMPORT))
+    ! Point to ESMF import state object
+    importState => HcoState%importState
+    _ASSERT(ASSOCIATED(importState),'HEMCO import state must be associated!')
 
     ! Init pointers
     Ptr3D => NULL()
@@ -127,8 +132,13 @@ CONTAINS
     IF ( Lct%Dct%Dta%SpaceDim == 3 ) THEN
 
        ! Get data
-       CALL MAPL_GetPointer( IMPORT, Ptr3D, &
-                             TRIM(Lct%Dct%Dta%ncFile), RC=STAT )
+#ifdef MAPL3
+       CALL MAPL_StateGetPointer( importState, Ptr3D, &
+            TRIM(Lct%Dct%Dta%ncFile), _RC )
+#else
+      CALL MAPL_GetPointer( importState, Ptr3D, &
+                             TRIM(Lct%Dct%Dta%ncFile), __RC__ )
+#endif
 
        ! Check for MAPL error
        IF( STAT /= ESMF_SUCCESS ) THEN
@@ -161,7 +171,7 @@ CONTAINS
        !Lct%Dct%Dta%V3(1)%Val(:,:,:) = Ptr3D(:,:,LL:1:-1)
 
        ! ewl debugging
-       if ( mapl_am_i_root() ) then
+       if ( HcoState%amIRoot ) then
           print *, "HEMCO: array pointer vertically flipped relative to MAPL Import ", trim(Lct%Dct%Dta%ncFile)
        endif
 
@@ -171,10 +181,15 @@ CONTAINS
     ELSEIF ( Lct%Dct%Dta%SpaceDim == 2 ) THEN
 
        ! Get data
-       CALL MAPL_GetPointer( IMPORT, Ptr2D, &
-                             TRIM(Lct%Dct%Dta%ncFile), RC=STAT )
+#ifdef MAPL3
+       CALL MAPL_StateGetPointer( importState, Ptr2D, &
+            TRIM(Lct%Dct%Dta%ncFile), _RC )
+#else
+      CALL MAPL_GetPointer( importState, Ptr2D, &
+           TRIM(Lct%Dct%Dta%ncFile), __RC__ )
+#endif
 
-       ! Check for MAPL error
+      ! Check for MAPL error
        IF( STAT /= ESMF_SUCCESS ) THEN
           MSG = 'Cannot get xy pointer: ' // TRIM(Lct%Dct%Dta%ncFile)
           CALL HCO_ERROR( MSG, RC )
@@ -208,7 +223,7 @@ CONTAINS
     !-----------------------------------------------------------------
     Ptr3D  => NULL()
     Ptr2D  => NULL()
-    IMPORT => NULL()
+    importState => NULL()
 
     ! Return w/ success
     CALL HCO_LEAVE ( HcoState%Config%Err,  RC )

--- a/src/Core/hcoio_util_mod.F90
+++ b/src/Core/hcoio_util_mod.F90
@@ -26,7 +26,7 @@ MODULE HCOIO_Util_Mod
 !
 ! !PUBLIC MEMBER FUNCTIONS:
 !
-#if !defined(ESMF_)
+#ifndef MAPL_ESMF
   PUBLIC :: GET_TIMEIDX
   PUBLIC :: Check_AvailYMDhm
   PUBLIC :: prefYMDhm_Adjust
@@ -64,7 +64,7 @@ MODULE HCOIO_Util_Mod
 
 CONTAINS
 !EOC
-#if !defined( ESMF_ )
+#ifndef MAPL_ESMF
 !------------------------------------------------------------------------------
 !                   Harmonized Emissions Component (HEMCO)                    !
 !------------------------------------------------------------------------------

--- a/src/Core/hcoio_write_mapl_mod.F90
+++ b/src/Core/hcoio_write_mapl_mod.F90
@@ -84,10 +84,10 @@ CONTAINS
 ! !USES:
 !
 #ifdef MAPL3
-# include "MAPL.h"
+#include "MAPL.h"
     USE mapl3g_State_API, only: MAPL_StateGetPointer
 #else
-# include "MAPL_Generic.h"
+#include "MAPL_Generic.h"
     USE MAPLBase_MOD
 #endif
     USE HCO_Types_Mod, ONLY : DiagnCont
@@ -182,7 +182,7 @@ CONTAINS
           CALL MAPL_StateGetPointer ( HcoState%exportState, Ptr2D, &
                TRIM(ThisDiagn%cName), RC=STAT )
 #else
-          CALL MAPL_GetPointer ( HcoState%EXPORT, Ptr2D, &
+          CALL MAPL_GetPointer ( HcoState%exportState, Ptr2D, &
                TRIM(ThisDiagn%cName), NotFoundOk=.TRUE., RC=STAT )
 #endif
 
@@ -199,7 +199,7 @@ CONTAINS
           CALL MAPL_StateGetPointer ( HcoState%exportState, Ptr3D, &
                TRIM(ThisDiagn%cName), RC=STAT )
 #else
-          CALL MAPL_GetPointer ( HcoState%EXPORT, Ptr3D, &
+          CALL MAPL_GetPointer ( HcoState%exportState, Ptr3D, &
                TRIM(ThisDiagn%cName), NotFoundOk=.TRUE., RC=STAT )
 #endif
           IF ( ASSOCIATED(Ptr3D) ) THEN

--- a/src/Core/hcoio_write_mapl_mod.F90
+++ b/src/Core/hcoio_write_mapl_mod.F90
@@ -1,5 +1,5 @@
 !BOC
-#if defined ( ESMF_ )
+#ifdef MAPL_ESMF
 ! The 'standard' HEMCO I/O module is used for:
 ! - GEOS-Chem High Performance / GCHP and GEOS (ESMF_)
 !EOC
@@ -83,12 +83,15 @@ CONTAINS
 !
 ! !USES:
 !
-    USE ESMF
+#ifdef MAPL3
+# include "MAPL.h"
+    USE mapl3g_State_API, only: MAPL_StateGetPointer
+#else
+# include "MAPL_Generic.h"
     USE MAPLBase_MOD
+#endif
     USE HCO_Types_Mod, ONLY : DiagnCont
     USE HCO_State_Mod, ONLY : HCO_State
-
-# include "MAPL_Generic.h"
 !
 ! !INPUT PARAMETERS:
 !
@@ -175,8 +178,14 @@ CONTAINS
 
        ! 2D...
        IF ( ThisDiagn%SpaceDim == 2 ) THEN
+#ifdef MAPL3
+          CALL MAPL_StateGetPointer ( HcoState%exportState, Ptr2D, &
+               TRIM(ThisDiagn%cName), RC=STAT )
+#else
           CALL MAPL_GetPointer ( HcoState%EXPORT, Ptr2D, &
-             TRIM(ThisDiagn%cName), NotFoundOk=.TRUE., RC=STAT )
+               TRIM(ThisDiagn%cName), NotFoundOk=.TRUE., RC=STAT )
+#endif
+
           IF ( ASSOCIATED(Ptr2D) ) THEN
              IF ( ASSOCIATED(ThisDiagn%Arr2D) ) THEN
                 Ptr2D = ThisDiagn%Arr2D%Val
@@ -186,8 +195,13 @@ CONTAINS
 
        ! ... or 3D
        ELSEIF ( ThisDiagn%SpaceDim == 3 ) THEN
+#ifdef MAPL3
+          CALL MAPL_StateGetPointer ( HcoState%exportState, Ptr3D, &
+               TRIM(ThisDiagn%cName), RC=STAT )
+#else
           CALL MAPL_GetPointer ( HcoState%EXPORT, Ptr3D, &
-             TRIM(ThisDiagn%cName), NotFoundOk=.TRUE., RC=STAT )
+               TRIM(ThisDiagn%cName), NotFoundOk=.TRUE., RC=STAT )
+#endif
           IF ( ASSOCIATED(Ptr3D) ) THEN
              IF ( ASSOCIATED(ThisDiagn%Arr3D) ) THEN
                 Ptr3D(:,:,:) = ThisDiagn%Arr3D%Val(:,:,HcoState%NZ:1:-1)

--- a/src/Extensions/hcox_megan_mod.F90
+++ b/src/Extensions/hcox_megan_mod.F90
@@ -408,11 +408,11 @@ CONTAINS
     Inst%FLUXSOAP   = 0.0_sp
     Inst%FLUXSOAS   = 0.0_sp
 
-#if defined( ESMF_ ) || defined( MODEL_GEOS )
+#ifdef MAPL_ESMF
 
     !----------------------------------------------------------------
-    ! %%%%% ESMF environment: execute these on every call  %%%%%
-    ! %%%%% because this will fill from the External State %%%%%
+    ! %%%%% MAPL/ESMF environment: execute these on every call  %%%%%
+    ! %%%%% because this will fill from the External State      %%%%%
     !----------------------------------------------------------------
 
     ! Generate annual emission factors for MEGAN inventory
@@ -431,7 +431,7 @@ CONTAINS
        RETURN
     ENDIF
 
-    ! Fill restart variables.
+    ! Fill restart variables
     CALL FILL_RESTART_VARS( HcoState, ExtState, Inst, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        MSG = 'Error encountered in MEGAN routine FILL_RESTART_VARS!'
@@ -1233,10 +1233,6 @@ CONTAINS
        ENDIF
 
     ENDIF
-
-    ! ----------------------------------------------------------------
-    ! Eventually copy internal values to ESMF internal state object
-    ! ----------------------------------------------------------------
 
     ! LAI_PREVDAY
     CALL HCO_RestartWrite( HcoState, &

--- a/src/Interfaces/GEOS/CMakeLists.txt
+++ b/src/Interfaces/GEOS/CMakeLists.txt
@@ -9,7 +9,7 @@ esma_add_library (
   SRCS ${srcs}
   DEPENDENCIES Chem_Shared MAPL HCOI_Standalone HCOI_MAPL_ESMF
   )
-target_compile_definitions (${this} PRIVATE ESMF_ DEVEL GEOS_FP)
+target_compile_definitions (${this} PRIVATE USE_ESMF MAPL_ESMF DEVEL GEOS_FP)
 target_include_directories (${this} PUBLIC ${INC_ESMF} ${INC_NETCDF})
 
 set (acg_headers

--- a/src/Interfaces/GEOS/HEMCO_GridCompMod.F90
+++ b/src/Interfaces/GEOS/HEMCO_GridCompMod.F90
@@ -1248,7 +1248,7 @@ CONTAINS
 
     ! Get imports
 #ifdef MAPL3
-    !    CALL MAPL_StateGetPointer ( HcoState%importState,      TH,      'TH', _RC ) 
+    !CALL MAPL_StateGetPointer ( HcoState%importState,      TH,      'TH', _RC ) 
     CALL MAPL_StateGetPointer ( HcoState%importState,     PLE,     'PLE', _RC ) 
     CALL MAPL_StateGetPointer ( HcoState%importState,     ZLE,     'ZLE', _RC ) 
     CALL MAPL_StateGetPointer ( HcoState%importState,       Q,       'Q', _RC ) 
@@ -1256,7 +1256,7 @@ CONTAINS
     CALL MAPL_StateGetPointer ( HcoState%importState,    AREA,    'AREA', _RC )
     CALL MAPL_StateGetPointer ( HcoState%importState, AIRDENS, 'AIRDENS', _RC )
 #else
-    CALL MAPL_GetPointer ( HcoState%importState,      TH,      'TH', __RC__ )
+    !CALL MAPL_GetPointer ( HcoState%importState,      TH,      'TH', __RC__ )
     CALL MAPL_GetPointer ( HcoState%importState,     PLE,     'PLE', __RC__ )
     CALL MAPL_GetPointer ( HcoState%importState,     ZLE,     'ZLE', __RC__ )
     CALL MAPL_GetPointer ( HcoState%importState,       Q,       'Q', __RC__ )

--- a/src/Interfaces/GEOS/HEMCO_GridCompMod.F90
+++ b/src/Interfaces/GEOS/HEMCO_GridCompMod.F90
@@ -1,4 +1,8 @@
+#ifdef MAPL3
+#include "MAPL.h"
+#else
 #include "MAPL_Generic.h"
+#endif
 !------------------------------------------------------------------------------
 !     NASA/GSFC, Global Modeling and Assimilation Office, Code 610.1          !
 !------------------------------------------------------------------------------
@@ -892,9 +896,9 @@ CONTAINS
     ! Manually set some settings
 
     ! Pass ESMF/MAPL states to HEMCO state object
-    Inst%HcoState%GRIDCOMP => GC
-    Inst%HcoState%IMPORT   => Import
-    Inst%HcoState%EXPORT   => Export
+    Inst%HcoState%gridComp    => GC
+    Inst%HcoState%importState => Import
+    Inst%HcoState%exportState => Export
 
     ! Don't let HEMCO schedule the diag output (will be scheduled manually)
     Inst%HcoState%Options%HcoWritesDiagn = .FALSE.
@@ -934,9 +938,9 @@ CONTAINS
     _ASSERT(HCRC==HCO_SUCCESS,'needs informative message')
 
     ! Nullify pointers
-    Inst%HcoState%GRIDCOMP => NULL()
-    Inst%HcoState%IMPORT   => NULL() 
-    Inst%HcoState%EXPORT   => NULL() 
+    Inst%HcoState%gridComp    => NULL()
+    Inst%HcoState%importState => NULL() 
+    Inst%HcoState%exportState => NULL() 
 
     ! Return w/ success
     RETURN_(ESMF_SUCCESS)
@@ -1007,9 +1011,9 @@ CONTAINS
     ! ------------------------------------------------------------------
 
     ! Pass ESMF/MAPL states to HEMCO state object
-    Inst%HcoState%GRIDCOMP => GC
-    Inst%HcoState%IMPORT   => Import
-    Inst%HcoState%EXPORT   => Export
+    Inst%HcoState%gridComp    => GC
+    Inst%HcoState%importState => Import
+    Inst%HcoState%exportState => Export
 
     ! ------------------------------------------------------------------
     ! Set time 
@@ -1085,9 +1089,9 @@ CONTAINS
     ! ------------------------------------------------------------------
 
     ! Nullify pointers
-    Inst%HcoState%GRIDCOMP => NULL()
-    Inst%HcoState%IMPORT   => NULL() 
-    Inst%HcoState%EXPORT   => NULL() 
+    Inst%HcoState%gridComp    => NULL()
+    Inst%HcoState%importState => NULL() 
+    Inst%HcoState%exportState => NULL() 
 
     ! Return w/ success
     RETURN_(ESMF_SUCCESS)
@@ -1243,14 +1247,24 @@ CONTAINS
     ExtState => Inst%ExtState
 
     ! Get imports
-!    CALL MAPL_GetPointer ( HcoState%IMPORT,      TH,      'TH', __RC__ ) 
-    CALL MAPL_GetPointer ( HcoState%IMPORT,     PLE,     'PLE', __RC__ ) 
-    CALL MAPL_GetPointer ( HcoState%IMPORT,     ZLE,     'ZLE', __RC__ ) 
-    CALL MAPL_GetPointer ( HcoState%IMPORT,       Q,       'Q', __RC__ ) 
-    CALL MAPL_GetPointer ( HcoState%IMPORT,      PS,      'PS', __RC__ ) 
-    CALL MAPL_GetPointer ( HcoState%IMPORT,    AREA,    'AREA', __RC__ )
-    CALL MAPL_GetPointer ( HcoState%IMPORT, AIRDENS, 'AIRDENS', __RC__ )
-
+#ifdef MAPL3
+    !    CALL MAPL_StateGetPointer ( HcoState%importState,      TH,      'TH', _RC ) 
+    CALL MAPL_StateGetPointer ( HcoState%importState,     PLE,     'PLE', _RC ) 
+    CALL MAPL_StateGetPointer ( HcoState%importState,     ZLE,     'ZLE', _RC ) 
+    CALL MAPL_StateGetPointer ( HcoState%importState,       Q,       'Q', _RC ) 
+    CALL MAPL_StateGetPointer ( HcoState%importState,      PS,      'PS', _RC ) 
+    CALL MAPL_StateGetPointer ( HcoState%importState,    AREA,    'AREA', _RC )
+    CALL MAPL_StateGetPointer ( HcoState%importState, AIRDENS, 'AIRDENS', _RC )
+#else
+    CALL MAPL_GetPointer ( HcoState%importState,      TH,      'TH', __RC__ )
+    CALL MAPL_GetPointer ( HcoState%importState,     PLE,     'PLE', __RC__ )
+    CALL MAPL_GetPointer ( HcoState%importState,     ZLE,     'ZLE', __RC__ )
+    CALL MAPL_GetPointer ( HcoState%importState,       Q,       'Q', __RC__ )
+    CALL MAPL_GetPointer ( HcoState%importState,      PS,      'PS', __RC__ )
+    CALL MAPL_GetPointer ( HcoState%importState,    AREA,    'AREA', __RC__ )
+    CALL MAPL_GetPointer ( HcoState%importState, AIRDENS, 'AIRDENS', __RC__ )
+#endif
+    
     ! ---------------------------------------------------------------- 
     ! Define grid quantities 
     ! ---------------------------------------------------------------- 
@@ -1400,7 +1414,7 @@ CONTAINS
        ExtState%SZAFACT%Arr%Val(:,:) = 0.0_hp
 
        ! Emission time step
-       CALL MAPL_GetObjectFromGC ( HcoState%GRIDCOMP, STATE, __RC__ ) 
+       CALL MAPL_GetObjectFromGC ( HcoState%gridComp, STATE, __RC__ ) 
        CALL MAPL_Get( STATE, RUNALARM=ALARM, __RC__ ) 
        CALL ESMF_AlarmGet( ALARM, RingInterval=emisInterval, __RC__ )
        CALL ESMF_TimeIntervalGet( emisInterval, s_r8=dt_r8, __RC__ )
@@ -1443,7 +1457,7 @@ CONTAINS
 
 !       CALL GET_SUMCOSZA(HcoState,Clock,HcoState%NX,HcoState%NY,tsEmis,SUMCOSZA, __RC__ )
 
-!       CALL MAPL_GetObjectFromGC ( HcoState%GRIDCOMP, STATE, __RC__ ) 
+!       CALL MAPL_GetObjectFromGC ( HcoState%gridComp, STATE, __RC__ ) 
 !       CALL MAPL_Get( STATE, RUNALARM=ALARM, __RC__ ) 
 !       CALL ESMF_AlarmGet( ALARM, RingInterval=emisInterval, __RC__ )
 !       CALL ESMF_TimeIntervalGet( emisInterval, s_r8=dt_r8, __RC__ )
@@ -1455,7 +1469,7 @@ CONTAINS
 !
 !       ! Get the Orbit object (of type MAPL_SunOrbit),
 !       ! which is used in the call to MAPL_SunGetInsolation
-!       CALL MAPL_GetObjectFromGC ( HcoState%GRIDCOMP, STATE, __RC__ ) 
+!       CALL MAPL_GetObjectFromGC ( HcoState%gridComp, STATE, __RC__ ) 
 !       CALL MAPL_Get( STATE,                       &
 !                      LONS      = lonCtr,             &
 !                      LATS      = latCtr,             &
@@ -1596,7 +1610,7 @@ CONTAINS
 
     ! Get the Orbit object (of type MAPL_SunOrbit),
     ! which is used in the call to MAPL_SunGetInsolation
-    CALL MAPL_GetObjectFromGC ( HcoState%GRIDCOMP, STATE, __RC__ ) 
+    CALL MAPL_GetObjectFromGC ( HcoState%gridComp, STATE, __RC__ ) 
     CALL MAPL_Get( STATE,           &
                    LONS   = lonCtr, &
                    LATS   = latCtr, &
@@ -1759,7 +1773,7 @@ CONTAINS
     CALL ESMF_TimeGet( currTime, dayOfYear=DOY, h=HOUR, __RC__ )
 
     ! Get grid centers
-    CALL MAPL_GetObjectFromGC ( HcoState%GRIDCOMP, STATE, __RC__ ) 
+    CALL MAPL_GetObjectFromGC ( HcoState%gridComp, STATE, __RC__ ) 
     CALL MAPL_Get( STATE,           &
                    LONS   = lonCtr, &
                    LATS   = latCtr, &

--- a/src/Interfaces/MAPL_ESMF/hcoi_esmf_mod.F90
+++ b/src/Interfaces/MAPL_ESMF/hcoi_esmf_mod.F90
@@ -622,8 +622,8 @@ CONTAINS
          ASSERT_( ASSOCIATED(HcoState%importState) )
          CALL MAPL_StateGetPointer( HcoState%importState, Ptr2D, TRIM(FldName), _RC )
 #else
-         ASSERT_( ASSOCIATED(HcoState%IMPORT) )
-         CALL MAPL_GetPointer( HcoState%IMPORT, Ptr2D, TRIM(FldName), __RC__ )
+         ASSERT_( ASSOCIATED(HcoState%importState) )
+         CALL MAPL_GetPointer( HcoState%importState, Ptr2D, TRIM(FldName), __RC__ )
 #endif
          CALL HCO_ArrAssert( ExtDat%Arr, HcoState%NX, HcoState%NY, STAT )
          ASSERT_(STAT==HCO_SUCCESS)
@@ -702,8 +702,8 @@ CONTAINS
          ASSERT_( ASSOCIATED(HcoState%importState) )
          CALL MAPL_StateGetPointer( HcoState%importState, Ptr3D, TRIM(FldName), _RC )
 #else
-         ASSERT_( ASSOCIATED(HcoState%IMPORT) )
-         CALL MAPL_GetPointer( HcoState%IMPORT, Ptr3D, TRIM(FldName), __RC__ )
+         ASSERT_( ASSOCIATED(HcoState%importState) )
+         CALL MAPL_GetPointer( HcoState%importState, Ptr3D, TRIM(FldName), __RC__ )
 #endif
          ASSERT_( ASSOCIATED(Ptr3D) )
 
@@ -796,8 +796,8 @@ CONTAINS
          ASSERT_( ASSOCIATED(HcoState%importState) )
          CALL MAPL_StateGetPointer( HcoState%importState, Ptr2D, TRIM(FldName), _RC )
 #else
-         ASSERT_( ASSOCIATED(HcoState%IMPORT) )
-         CALL MAPL_GetPointer( HcoState%IMPORT, Ptr2D, TRIM(FldName), __RC__ )
+         ASSERT_( ASSOCIATED(HcoState%importState) )
+         CALL MAPL_GetPointer( HcoState%importState, Ptr2D, TRIM(FldName), __RC__ )
 #endif
 
          CALL HCO_ArrAssert( ExtDat%Arr, HcoState%NX, HcoState%NY, STAT )
@@ -890,8 +890,8 @@ CONTAINS
          ASSERT_( ASSOCIATED(HcoState%importState) )
          CALL MAPL_StateGetPointer( HcoState%importState, Ptr3D, TRIM(FldName), _RC )
 #else
-         ASSERT_( ASSOCIATED(HcoState%IMPORT) )
-         CALL MAPL_GetPointer( HcoState%IMPORT, Ptr3D, TRIM(FldName), __RC__ )
+         ASSERT_( ASSOCIATED(HcoState%importState) )
+         CALL MAPL_GetPointer( HcoState%importState, Ptr3D, TRIM(FldName), __RC__ )
 #endif
          ASSERT_( ASSOCIATED(Ptr3D) )
 
@@ -978,8 +978,8 @@ CONTAINS
          ASSERT_( ASSOCIATED(HcoState%importState) )
          CALL MAPL_StateGetPointer( HcoState%importState, Ptr2D, TRIM(FldName), _RC )
 #else
-         ASSERT_( ASSOCIATED(HcoState%IMPORT) )
-         CALL MAPL_GetPointer( HcoState%IMPORT, Ptr2D, TRIM(FldName), __RC__ )
+         ASSERT_( ASSOCIATED(HcoState%importState) )
+         CALL MAPL_GetPointer( HcoState%importState, Ptr2D, TRIM(FldName), __RC__ )
 #endif
 
          CALL HCO_ArrAssert( ExtDat%Arr, HcoState%NX, HcoState%NY, STAT )

--- a/src/Interfaces/MAPL_ESMF/hcoi_esmf_mod.F90
+++ b/src/Interfaces/MAPL_ESMF/hcoi_esmf_mod.F90
@@ -500,12 +500,8 @@ CONTAINS
       IF ( STATUS /= ESMF_SUCCESS ) THEN
          WRITE(*,*) 'Cannot add to export: ',TRIM(SNAME)
          ASSERT_(.FALSE.)
-      !ELSE
-      !   IF ( am_I_Root ) WRITE(*,*) 'adding HEMCO export: ', TRIM(cName)
       ENDIF
 #endif
-
-! ewl: why does this file use ESMF_SUCCESS?
 
       ! Return w/ success
       RETURN_(ESMF_SUCCESS)

--- a/src/Interfaces/MAPL_ESMF/hcoi_esmf_mod.F90
+++ b/src/Interfaces/MAPL_ESMF/hcoi_esmf_mod.F90
@@ -14,15 +14,23 @@ MODULE HCOI_ESMF_MOD
 !
 ! !USES:
 !
+  USE ESMF
   USE HCO_ERROR_MOD
   USE HCO_Types_Mod
 
-#if defined (ESMF_)
+#ifdef MAPL_ESMF
+#ifdef MAPL3
+#include "MAPL.h"
+  USE mapl3
+  USE mapl3g_State_API, ONLY : MAPL_StateGetPointer
+  USE mapl3g_generic,   ONLY : MAPL_GridCompAddSpec
+#else
 #include "MAPL_Generic.h"
-  USE ESMF
   USE MAPLBase_Mod
   USE MAPL_GenericMod
-
+#endif
+#endif
+  
   IMPLICIT NONE
   PRIVATE
 !
@@ -126,7 +134,6 @@ CONTAINS
 ! !LOCAL VARIABLES:
 !
       INTEGER                    :: LUN, ExtNr, Cat, Hier, SpaceDim
-      INTEGER                    :: DIMS, VLOC
       INTEGER                    :: I, FLAG, nSpc, nDiagn
       INTEGER                    :: DefaultDim
       LOGICAL                    :: EOF
@@ -139,6 +146,10 @@ CONTAINS
       TYPE(ListCont),    POINTER :: CurrCont
       CHARACTER(LEN=255)         :: LOC
 
+#ifndef MAPL3
+      INTEGER                    :: DIMS, VLOC
+#endif
+      
       ! ================================================================
       ! HCO_SetServices begins here
       ! ================================================================
@@ -195,24 +206,47 @@ CONTAINS
          ! Import 2D data
          ELSEIF ( CurrCont%Dct%Dta%SpaceDim == 2 ) THEN
 
+#ifdef MAPL3
+            ! ewl: need to set restart attribute?
+            CALL MAPL_GridCompAddSpec(gridcomp=GC,              &
+               short_name    = TRIM(CurrCont%Dct%Dta%ncFile),   &
+               standard_name = TRIM(CurrCont%Dct%Dta%ncFile),   &
+               units         = TRIM(CurrCont%Dct%Dta%OrigUnit), &
+               dims          = 'xy',                            &
+               vstagger      = VERTICAL_STAGGER_NONE,           &
+               state_intent  = ESMF_STATEINTENT_IMPORT,         &
+               _RC                                               )
+            IF ( am_I_Root ) WRITE(*,*) 'HCO_SetServices: adding HEMCO 2D import: ', TRIM(CurrCont%Dct%Dta%ncFile)
+#else
             CALL MAPL_AddImportSpec(GC,                      &
                SHORT_NAME = TRIM(CurrCont%Dct%Dta%ncFile),   &
                LONG_NAME  = TRIM(CurrCont%Dct%Dta%ncFile),   &
                UNITS      = TRIM(CurrCont%Dct%Dta%OrigUnit), &
                DIMS       = MAPL_DimsHorzOnly,               &
                VLOCATION  = MAPL_VLocationNone,              &
-               RESTART    = MAPL_RestartSkip,                &
+               RESTART    = MAPL_RestartSkip,                & 
                RC         = STATUS                            )
 
-            ! Error trap
             IF ( STATUS /= ESMF_SUCCESS ) THEN
                WRITE(*,*) '2D import error: ', TRIM(CurrCont%Dct%Dta%ncFile)
-               VERIFY_(STATUS)
+               _VERIFY(STATUS)
             ENDIF
-
+#endif
          ! Import 3D data: Assume central location in vertical dimension!
          ELSEIF ( CurrCont%Dct%Dta%SpaceDim == 3 ) THEN
 
+#ifdef MAPL3
+            ! ewl: Need to add restart attribute?
+            CALL MAPL_GridCompAddSpec(gridcomp=GC,              &
+               short_name    = TRIM(CurrCont%Dct%Dta%ncFile),   &
+               standard_name = TRIM(CurrCont%Dct%Dta%ncFile),   &
+               units         = TRIM(CurrCont%Dct%Dta%OrigUnit), &
+               dims          = 'xyz',                           &
+               vstagger      = VERTICAL_STAGGER_CENTER,         &
+               state_intent  = ESMF_STATEINTENT_IMPORT,         &
+               _RC                                               )
+            IF ( am_I_Root ) WRITE(*,*) 'HCO_SetServices: adding HEMCO 3D import: ', TRIM(CurrCont%Dct%Dta%ncFile)
+#else
             CALL MAPL_AddImportSpec(GC,                      &
                SHORT_NAME = TRIM(CurrCont%Dct%Dta%ncFile),   &
                LONG_NAME  = TRIM(CurrCont%Dct%Dta%ncFile),   &
@@ -221,12 +255,11 @@ CONTAINS
                VLOCATION  = MAPL_VLocationCenter,            &
                RESTART    = MAPL_RestartSkip,                &
                RC         = STATUS                            )
-
-            ! Error trap
             IF ( STATUS /= ESMF_SUCCESS ) THEN
                WRITE(*,*) '3D import error: ', TRIM(CurrCont%Dct%Dta%ncFile)
-               VERIFY_(STATUS)
+               _VERIFY(STATUS)
             ENDIF
+#endif
 
          ! Return w/ error if not 2D or 3D data
          ELSE
@@ -270,15 +303,6 @@ CONTAINS
             ! Leave here if end of file
             IF ( EOF ) EXIT
 
-            ! Define vertical dimension
-            IF ( SpaceDim == 3 ) THEN
-               DIMS = MAPL_DimsHorzVert
-               VLOC = MAPL_VLocationCenter
-            ELSE
-               DIMS = MAPL_DimsHorzOnly
-               VLOC = MAPL_VLocationNone
-            ENDIF
-
             ! Remove any underscores in unit name by spaces
             DO I = 1, LEN(TRIM(ADJUSTL(UnitName)))
                IF ( UnitName(I:I) == '_' ) UnitName(I:I) = ' '
@@ -288,6 +312,35 @@ CONTAINS
             ENDDO
 
             ! Add to export state
+#ifdef MAPL3
+            IF ( SpaceDim == 3 ) THEN
+               CALL MAPL_GridCompAddSpec(gridcomp=GC,        &
+                    short_name    = trim(cName),             &
+                    standard_name = trim(lName),             &
+                    units         = TRIM(UnitName),          &
+                    dims          = 'xyz',                   &
+                    vstagger      = VERTICAL_STAGGER_CENTER, &
+                    state_intent  = ESMF_STATEINTENT_EXPORT, &
+                    _RC                                       )
+            ELSE
+               CALL MAPL_GridCompAddSpec(gridcomp=GC,        &
+                    short_name    = trim(cName),             &
+                    standard_name = trim(lName),             &
+                    units         = TRIM(UnitName),          &
+                    dims          = 'xy',                    &
+                    vstagger      = VERTICAL_STAGGER_NONE,   &
+                    state_intent  = ESMF_STATEINTENT_EXPORT, &
+                    _RC                                       )
+            ENDIF
+            IF ( am_I_Root ) WRITE(*,*) 'HCO_SetServices: adding HEMCO export: ', TRIM(cName)
+#else
+            IF ( SpaceDim == 3 ) THEN
+               DIMS = MAPL_DimsHorzVert
+               VLOC = MAPL_VLocationCenter
+            ELSE
+               DIMS = MAPL_DimsHorzOnly
+               VLOC = MAPL_VLocationNone
+            ENDIF
             CALL MAPL_AddExportSpec(GC,       &
                SHORT_NAME         = cName,    &
                LONG_NAME          = lName,    &
@@ -295,13 +348,14 @@ CONTAINS
                DIMS               = DIMS,     &
                VLOCATION          = VLOC,     &
                RC                 = STATUS     )
+
             IF ( STATUS /= ESMF_SUCCESS ) THEN
-               WRITE(*,*) 'Cannot add to export: ',TRIM(SNAME)
+               WRITE(*,*) 'Cannot add to export: ',TRIM(cNAME)
                ASSERT_(.FALSE.)
             ELSE
                IF ( am_I_Root ) WRITE(*,*) 'adding HEMCO export: ', TRIM(cName)
             ENDIF
-
+#endif
          ENDDO
 
          ! Close file
@@ -394,7 +448,9 @@ CONTAINS
 !
 ! !LOCAL VARIABLES:
 !
+#ifndef MAPL3
       INTEGER  :: DIMS, VLOC
+#endif
 
       ! ================================================================
       ! Diagn2Exp begins here
@@ -403,7 +459,29 @@ CONTAINS
       ! For MAPL/ESMF error handling (defines Iam and STATUS)
       __Iam__('Diagn2Exp (HCOI_ESMF_MOD.F90)')
 
-      ! Set horizontal variables
+      ! Add to export state
+#ifdef MAPL3
+      IF ( NDIM == 3 ) THEN
+         CALL MAPL_GridCompAddSpec(gridcomp=GC,        &
+              short_name    = TRIM(SNAME),             &
+              standard_name = TRIM(LNAME),             &
+              units         = TRIM(UNITS),             &
+              dims          = 'xyz',                   &
+              vstagger      = VERTICAL_STAGGER_CENTER, &
+              state_intent  = ESMF_STATEINTENT_EXPORT, &
+              _RC                                       )
+      ELSE
+         CALL MAPL_GridCompAddSpec(gridcomp=GC,        &
+              short_name    = TRIM(SNAME),             &
+              standard_name = TRIM(LNAME),             &
+              units         = TRIM(UNITS),             &
+              dims          = 'xy',                    &
+              vstagger      = VERTICAL_STAGGER_NONE,   &
+              state_intent  = ESMF_STATEINTENT_EXPORT, &
+              _RC                                       )
+      ENDIF
+      !IF ( am_I_Root ) WRITE(*,*) 'HCO_SetServices: adding HEMCO export: ', TRIM(cName)
+#else
       IF ( NDIM == 3 ) THEN
          DIMS = MAPL_DimsHorzVert
          VLOC = MAPL_VLocationCenter
@@ -411,19 +489,23 @@ CONTAINS
          DIMS = MAPL_DimsHorzOnly
          VLOC = MAPL_VLocationNone
       ENDIF
+      CALL MAPL_AddExportSpec(GC,     &
+         SHORT_NAME = TRIM(SNAME),    &
+         LONG_NAME  = TRIM(LNAME),    &
+         UNITS      = TRIM(UNITS),    &
+         DIMS       = DIMS,           &
+         VLOCATION  = VLOC,           &
+         RC         = STATUS           )
 
-      ! Add to export state
-      CALL MAPL_AddExportSpec(GC,                               &
-        SHORT_NAME         = SNAME,                             &
-         LONG_NAME          = LNAME,                            &
-         UNITS              = UNITS,                            &
-         DIMS               = DIMS,                             &
-         VLOCATION          = VLOC,                             &
-         RC                 = STATUS                             )
       IF ( STATUS /= ESMF_SUCCESS ) THEN
          WRITE(*,*) 'Cannot add to export: ',TRIM(SNAME)
          ASSERT_(.FALSE.)
+      !ELSE
+      !   IF ( am_I_Root ) WRITE(*,*) 'adding HEMCO export: ', TRIM(cName)
       ENDIF
+#endif
+
+! ewl: why does this file use ESMF_SUCCESS?
 
       ! Return w/ success
       RETURN_(ESMF_SUCCESS)
@@ -476,7 +558,7 @@ CONTAINS
       ! Get pointers to fields
       CALL HCO_Imp2Ext ( HcoState, ExtState%BYNCY, 'BYNCY', __RC__ )
 
-#if defined( MODEL_GEOS )
+#ifdef MODEL_GEOS
       ! Get pointers to fields
       CALL HCO_Imp2Ext ( HcoState, ExtState%LFR, 'LFR', __RC__ )
 #endif
@@ -536,8 +618,13 @@ CONTAINS
 
       ! Only do if being used...
       IF ( ExtDat%DoUse ) THEN
+#ifdef MAPL3
+         ASSERT_( ASSOCIATED(HcoState%importState) )
+         CALL MAPL_StateGetPointer( HcoState%importState, Ptr2D, TRIM(FldName), _RC )
+#else
          ASSERT_( ASSOCIATED(HcoState%IMPORT) )
          CALL MAPL_GetPointer( HcoState%IMPORT, Ptr2D, TRIM(FldName), __RC__ )
+#endif
          CALL HCO_ArrAssert( ExtDat%Arr, HcoState%NX, HcoState%NY, STAT )
          ASSERT_(STAT==HCO_SUCCESS)
          ExtDat%Arr%Val = 0.0
@@ -611,8 +698,13 @@ CONTAINS
       ! Only do if being used...
       IF ( ExtDat%DoUse ) THEN
 
+#ifdef MAPL3
+         ASSERT_( ASSOCIATED(HcoState%importState) )
+         CALL MAPL_StateGetPointer( HcoState%importState, Ptr3D, TRIM(FldName), _RC )
+#else
          ASSERT_( ASSOCIATED(HcoState%IMPORT) )
          CALL MAPL_GetPointer( HcoState%IMPORT, Ptr3D, TRIM(FldName), __RC__ )
+#endif
          ASSERT_( ASSOCIATED(Ptr3D) )
 
          ! Make sure the array in ExtDat is allocated and has the right size
@@ -700,8 +792,13 @@ CONTAINS
       ! Only do if being used...
       IF ( ExtDat%DoUse ) THEN
 
+#ifdef MAPL3
+         ASSERT_( ASSOCIATED(HcoState%importState) )
+         CALL MAPL_StateGetPointer( HcoState%importState, Ptr2D, TRIM(FldName), _RC )
+#else
          ASSERT_( ASSOCIATED(HcoState%IMPORT) )
-         CALL MAPL_GetPointer( HcoState%IMPORT, Ptr2D, TRIM(FldName), NotFoundOk=.TRUE., __RC__ )
+         CALL MAPL_GetPointer( HcoState%IMPORT, Ptr2D, TRIM(FldName), __RC__ )
+#endif
 
          CALL HCO_ArrAssert( ExtDat%Arr, HcoState%NX, HcoState%NY, STAT )
          ASSERT_(STAT==HCO_SUCCESS)
@@ -789,8 +886,13 @@ CONTAINS
       ! Only do if being used...
       IF ( ExtDat%DoUse ) THEN
 
+#ifdef MAPL3
+         ASSERT_( ASSOCIATED(HcoState%importState) )
+         CALL MAPL_StateGetPointer( HcoState%importState, Ptr3D, TRIM(FldName), _RC )
+#else
          ASSERT_( ASSOCIATED(HcoState%IMPORT) )
          CALL MAPL_GetPointer( HcoState%IMPORT, Ptr3D, TRIM(FldName), __RC__ )
+#endif
          ASSERT_( ASSOCIATED(Ptr3D) )
 
          ! Make sure the array in ExtDat is allocated and has the right size
@@ -872,8 +974,13 @@ CONTAINS
       ! Only do if being used...
       IF ( ExtDat%DoUse ) THEN
 
+#ifdef MAPL3
+         ASSERT_( ASSOCIATED(HcoState%importState) )
+         CALL MAPL_StateGetPointer( HcoState%importState, Ptr2D, TRIM(FldName), _RC )
+#else
          ASSERT_( ASSOCIATED(HcoState%IMPORT) )
          CALL MAPL_GetPointer( HcoState%IMPORT, Ptr2D, TRIM(FldName), __RC__ )
+#endif
 
          CALL HCO_ArrAssert( ExtDat%Arr, HcoState%NX, HcoState%NY, STAT )
          ASSERT_(STAT==HCO_SUCCESS)
@@ -898,5 +1005,5 @@ CONTAINS
 
       END SUBROUTINE HCO_Imp2Ext2I
 !EOC
-#endif
 END MODULE HCOI_ESMF_MOD
+

--- a/src/Shared/Headers/CMakeLists.txt
+++ b/src/Shared/Headers/CMakeLists.txt
@@ -4,9 +4,9 @@ add_library(HeadersHco STATIC EXCLUDE_FROM_ALL
 	hco_inquireMod.F90
 	hco_precision_mod.F90
 )
-target_link_libraries(HeadersHco
-	PUBLIC HEMCOBuildProperties
+target_link_libraries(HeadersHco PUBLIC
+	HEMCOBuildProperties
 )
-target_include_directories(HeadersHco
-	INTERFACE ${HEMCO_BINARY_DIR}/mod
+target_include_directories(HeadersHco INTERFACE
+	${HEMCO_BINARY_DIR}/mod
 )

--- a/src/Shared/Headers/hco_inquireMod.F90
+++ b/src/Shared/Headers/hco_inquireMod.F90
@@ -53,8 +53,13 @@ MODULE HCO_inquireMod
 !
 ! !USES:
 !
+#ifdef MAPL_ESMF
 #ifdef MAPL3
     USE mapl_ErrorHandlingMod, only: MAPL_Verify
+#else
+    USE ESMF
+    USE MAPLBase_Mod
+#endif
 #endif
 
     IMPLICIT NONE
@@ -80,7 +85,17 @@ MODULE HCO_inquireMod
     LOGICAL                    :: exists        ! File existence
     LOGICAL                    :: found         ! Detect unused logical unit
     LOGICAL                    :: open          ! Is open?
+#ifdef MAPL3
     LOGICAL                    :: rc
+#else
+    INTEGER                    :: rc
+
+#ifdef MAPL_ESMF
+    CHARACTER(LEN=ESMF_MAXSTR) :: Iam
+#else
+    CHARACTER(LEN=255)         :: Iam
+#endif
+#endif
 !
 ! !DEFINED PARAMETERS
 !
@@ -91,7 +106,12 @@ MODULE HCO_inquireMod
     !======================================================================
 
     status = 0
-    
+
+#ifndef MAPL3
+    Iam = "GEOSCHEMCHEM::findFreeLUN"
+    rc     = 0
+#endif
+
     !======================================================================
     ! Find an available logical unit
     !======================================================================

--- a/src/Shared/Headers/hco_inquireMod.F90
+++ b/src/Shared/Headers/hco_inquireMod.F90
@@ -1,7 +1,9 @@
-#ifdef ESMF_
-! We only need to refer to this include file if we are connecting
-! to the GEOS-5 GCM via the ESMF/MAPL framework (bmy, 8/3/12)
+#ifdef MAPL_ESMF
+#ifdef MAPL3
+#include "MAPL.h"
+#else
 #include "MAPL_Generic.h"
+#endif
 #endif
 !------------------------------------------------------------------------
 !     NASA/GSFC, Global Modeling and Assimilation Office, Code 910.1    !
@@ -19,12 +21,6 @@ MODULE HCO_inquireMod
 !
 ! !USES:
 !
-#ifdef ESMF_
-  ! We only need to refer to these modules if we are connecting
-  ! to the GEOS-5 GCM via the ESMF/MAPL framework (bmy, 8/3/12)
-  USE ESMF
-  USE MAPLBase_Mod
-#endif
 
   IMPLICIT NONE
   PRIVATE
@@ -57,6 +53,10 @@ MODULE HCO_inquireMod
 !
 ! !USES:
 !
+#ifdef MAPL3
+    USE mapl_ErrorHandlingMod, only: MAPL_Verify
+#endif
+
     IMPLICIT NONE
 !
 ! !INPUT PARAMETERS:
@@ -76,16 +76,11 @@ MODULE HCO_inquireMod
 !
 ! !LOCAL VARIABLES:
 !
-    INTEGER                    :: i, rc, status
+    INTEGER                    :: i, status
     LOGICAL                    :: exists        ! File existence
     LOGICAL                    :: found         ! Detect unused logical unit
     LOGICAL                    :: open          ! Is open?
-
-#ifdef ESMF_
-    CHARACTER(LEN=ESMF_MAXSTR) :: Iam
-#else
-    CHARACTER(LEN=255)         :: Iam
-#endif
+    LOGICAL                    :: rc
 !
 ! !DEFINED PARAMETERS
 !
@@ -94,10 +89,9 @@ MODULE HCO_inquireMod
     !======================================================================
     ! Initialization
     !======================================================================
-    Iam = "GEOSCHEMCHEM::findFreeLUN"
-    status = 0
-    rc     = 0
 
+    status = 0
+    
     !======================================================================
     ! Find an available logical unit
     !======================================================================
@@ -115,11 +109,16 @@ MODULE HCO_inquireMod
 
     IF ( .NOT. found ) THEN
        status = 1
-       PRINT *,TRIM( Iam ) // ": No available logical units"
+       PRINT *, "findFreeLUN in hco_inquireMod.F90: No available logical units"
     ENDIF
 
-#ifdef ESMF_
+#ifdef MAPL_ESMF
+#ifdef MAPL3
+    ! Comment out for now
+    !_VERIFY(status)
+#else
     VERIFY_(status)
+#endif
 #endif
 
   END FUNCTION findFreeLUN


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This is a no diff update to bring in MAPL3-only code. All MAPL3 code blocks are in C-preprocessor `ifdef MAPL3` blocks and will not be compiled. MAPL3 is still in development.

Other no diff changes include:
- Renamed subroutine `HCO_CopyFromIntnal_ESMF` to `HCO_CopyFromInternal_ESMF` for clarity
- Renamed state objects `HcoState%IMPORT` and `HcoStateEXPORT` to `HcoState%internalState` and `HcoState%exportState` respectively
- Removed C-preprocessor switch `ESMF_`

### Expected changes

This is a no diff update.

### Reference(s)

None

### Related Github Issue

None
