### PR TITLE
Regrid_A2A fix in MPI environments: uninitialized accumulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Fixed an error in `src/Shared/GeosUtil/hco_regrid_a2a_mod.F90` where an accumulator was uninitialized before reuse, which may inherit junk data from the previous iteration if the southmost source cell is not found
+
 ## [3.12.1] - 2026-04-08
 ### Changed
 - Updated GitHub Actions to the latest versions

--- a/src/Shared/GeosUtil/hco_regrid_a2a_mod.F90
+++ b/src/Shared/GeosUtil/hco_regrid_a2a_mod.F90
@@ -723,6 +723,11 @@ CONTAINS
        dlat = 0.0d0
        j0 = 1
        do 555 j=1,jn-ig
+          ! Reset qsum and dlat at the start of every target-j iteration.
+          ! Without this, a target cell whose south-most source cell is
+          ! missing would inherit qsum, dlat from the previous j.
+          qsum = 0.0d0
+          dlat = 0.0d0
        do 100 m=j0,jm-ig
 
           !=========================================================
@@ -742,6 +747,9 @@ CONTAINS
                 if( abs(q1(i,m)-miss)>tiny_r8 ) then
                    dlat= sin1(m+1)-sin2(j)
                    qsum=(sin1(m+1)-sin2(j))*q1(i,m)
+                else
+                   dlat=0.0d0
+                   qsum=0.0d0
                 endif
 
                 do mm=m+1,jm-ig
@@ -923,6 +931,11 @@ CONTAINS
        dlat = 0.0d0
        j0 = 1
        do 555 j=1,jn-ig
+          ! Reset qsum and dlat at the start of every target-j iteration.
+          ! Without this, a target cell whose south-most source cell is
+          ! missing would inherit qsum, dlat from the previous j.
+          qsum = 0.0d0
+          dlat = 0.0d0
        do 100 m=j0,jm-ig
 
           !=========================================================
@@ -942,6 +955,9 @@ CONTAINS
                 if( abs(q1(i,m)-miss)>tiny_r4 ) then
                    dlat= sin1(m+1)-sin2(j)
                    qsum=(sin1(m+1)-sin2(j))*q1(i,m)
+                else
+                   dlat=0.0d0
+                   qsum=0.0d0
                 endif
 
                 do mm=m+1,jm-ig
@@ -1123,6 +1139,11 @@ CONTAINS
        dlat = 0.0d0
        j0 = 1
        do 555 j=1,jn-ig
+          ! Reset qsum and dlat at the start of every target-j iteration.
+          ! Without this, a target cell whose south-most source cell is
+          ! missing would inherit qsum, dlat from the previous j.
+          qsum = 0.0d0
+          dlat = 0.0d0
        do 100 m=j0,jm-ig
 
           !=========================================================
@@ -1142,6 +1163,9 @@ CONTAINS
                 if( abs(q1(i,m)-miss)>tiny_r8 ) then
                    dlat= sin1(m+1)-sin2(j)
                    qsum=(sin1(m+1)-sin2(j))*q1(i,m)
+                else
+                   dlat=0.0d0
+                   qsum=0.0d0
                 endif
 
                 do mm=m+1,jm-ig
@@ -1322,6 +1346,11 @@ CONTAINS
        dlat = 0.0
        j0 = 1
        do 555 j=1,jn-ig
+          ! Reset qsum and dlat at the start of every target-j iteration.
+          ! Without this, a target cell whose south-most source cell is
+          ! missing would inherit qsum, dlat from the previous j.
+          qsum = 0.0
+          dlat = 0.0
        do 100 m=j0,jm-ig
 
           !=========================================================
@@ -1341,6 +1370,9 @@ CONTAINS
                 if( abs(q1(i,m)-miss)>tiny_r4 ) then
                    dlat=sin1(m+1)-sin2(j)
                    qsum=dlat*q1(i,m)
+                else
+                   dlat=0.0
+                   qsum=0.0
                 endif
 
                 do mm=m+1,jm-ig


### PR DESCRIPTION
### Name and Institution (Required)

Name: Haipeng Lin
Institution: NCAR

### Describe the update

Resets `qsum`, `dlat` in `regrid_a2a_mod`'s `ymap_*` subroutines at the beginning of individual iterations and when the southmost source cell (where the search starts) is missing (matches the behavior of `xmap_*`)

`xmap` behavior, e.g.:
https://github.com/geoschem/HEMCO/blob/07da3c29fd85abc3824cb6288578b0b68c2395a3/src/Shared/GeosUtil/hco_regrid_a2a_mod.F90#L1674-L1683

`ymap` did not have this
https://github.com/geoschem/HEMCO/blob/07da3c29fd85abc3824cb6288578b0b68c2395a3/src/Shared/GeosUtil/hco_regrid_a2a_mod.F90#L741-L747

This was causing different MPI decompositions in CESM to have different answers at the leftmost few cells in each MPI rank. It also affects OpenMP (no MPI) runs as well since it affects all ranks.

### Expected changes

This will cause answer differences due to fixing a bug in the accumulator not being reset.

I think the fixed version is more correct. But it should be noted that it does change model answers very very slightly, since the buggy version inherits junk data left behind from the previous iteration if the current iteration does not match a southmost source cell fraction.

### Reference(s)

N/A

### Related Github Issue

https://github.com/ESCOMP/HEMCO_CESM/issues/31 - tagging @lizziel 