### PR TITLE
Added files for the HEMCO repository suggested by Claude Code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Normalize line endings to LF for text files by default.
+# This repo is built and run on Linux/HPC clusters, so CRLF endings in
+# scripts/source break shebangs, Fortran preprocessing, and compilation.
+* text=auto eol=lf
+
+# Binary assets — never diff/merge as text.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,3 +18,7 @@ If this is a science update, please provide a literature citation.
 ### Related Github Issue
 
 Please link to the corresponding Github issue(s) here. If fixing a bug, there should be an issue describing it with steps to reproduce.
+
+### AI disclosure
+
+Please disclose if AI tools (e.g. Claude, ChatGPT) were used in the preparation of this pull request.

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -37,8 +37,37 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install dependencies
-        run: brew install netcdf netcdf-fortran
+      - name: Install NetCDF-C (Homebrew)
+        run: brew install netcdf
+
+      - name: Cache NetCDF-Fortran (built from source)
+        id: netcdf-fortran-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/netcdf-fortran
+          key: netcdf-fortran-4.6.3-gcc${{ matrix.gcc_version }}-${{ runner.os }}-${{ runner.arch }}
+
+      # Homebrew's netcdf-fortran bottle is always built against whatever "gcc" formula
+      # Homebrew currently treats as default/latest, which does not necessarily match the
+      # gfortran-${{ matrix.gcc_version }} used to compile HEMCO below. gfortran .mod files
+      # are not compatible across major GCC versions, so mixing them causes:
+      #   "Cannot read module file 'netcdf.mod' ... created by a different version of GNU Fortran"
+      # Building NetCDF-Fortran from source with the exact matrix compiler avoids that mismatch.
+      - name: Build NetCDF-Fortran from source
+        if: steps.netcdf-fortran-cache.outputs.cache-hit != 'true'
+        run: |
+          git clone --depth 1 --branch v4.6.3 https://github.com/Unidata/netcdf-fortran.git "$RUNNER_TEMP/netcdf-fortran-src"
+          cmake -S "$RUNNER_TEMP/netcdf-fortran-src" -B "$RUNNER_TEMP/netcdf-fortran-build" \
+            -D CMAKE_INSTALL_PREFIX=$HOME/netcdf-fortran \
+            -D CMAKE_Fortran_COMPILER=gfortran-${{ matrix.gcc_version }} \
+            -D CMAKE_PREFIX_PATH=$(brew --prefix netcdf)
+          cmake --build "$RUNNER_TEMP/netcdf-fortran-build" --parallel
+          cmake --install "$RUNNER_TEMP/netcdf-fortran-build"
+
+      - name: Add NetCDF-Fortran to environment
+        run: |
+          echo "NetCDF_Fortran_ROOT=$HOME/netcdf-fortran" >> "$GITHUB_ENV"
+          echo "$HOME/netcdf-fortran/bin" >> "$GITHUB_PATH"
 
       - name: Run Cmake
         run: cmake -S . -B build -D CMAKE_BUILD_TYPE=${{ matrix.build_type }}

--- a/.release/changeVersionNumbers.sh
+++ b/.release/changeVersionNumbers.sh
@@ -23,7 +23,7 @@ function replace() {
 
     #========================================================================
     # Function to replace text in a file via sed.
-    # 
+    #
     # 1st argument: Search pattern
     # 2nd argument: Replacement text
     # 3rd argument: File in which to search and replace
@@ -32,7 +32,7 @@ function replace() {
     sed -i -e "s/${1}/${2}/" "${3}"
 }
 
- 
+
 function exitWithError() {
 
     #========================================================================
@@ -55,6 +55,9 @@ function main() {
     # New version number
     version="${1}"
 
+    # Current date
+    date=$(date -Idate)
+
     # Save this directory path and change to root directory
     thisDir=$(pwd -P)
     cd ..
@@ -62,7 +65,7 @@ function main() {
     #========================================================================
     # Update version numbers in various files
     #========================================================================
-    
+
     # Pattern to match: X.Y.Z
     pattern='[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*'
 
@@ -86,9 +89,21 @@ function main() {
 
     # Pattern to match: "[Unreleased] - TBD"
     pattern='\[.*Unreleased.*\].*'
-    date=$(date -Idate)
     replace "${pattern}" "\[${version}\] - ${date}" "CHANGELOG.md"
     echo "HEMCO version updated to ${version} in CHANGELOG.md"
+
+    #========================================================================
+    # Update date and version in CITATION.cff
+    # NOTE: Only update version but not cff-version
+    #========================================================================
+
+    # Pattern to match: X.Y.Z
+    pattern='^version: .*'
+    replace "${pattern}" "version: ${version}" "CITATION.cff"
+
+    # Pattern to match: YYYY-MM-DD
+    pattern='^date-released: .*'
+    replace "${pattern}" "date-released: ${date}" "CITATION.cff"
 
     # Return to the starting directory
     cd "${thisDir}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Renamed subroutine `HCO_CopyFromIntnal_ESMF` to `HCO_CopyFromInternal_ESMF`
 - Renamed state objects `HcoState%IMPORT` and `HcoStateEXPORT` to `HcoState%importState` and `HcoState%exportState` respectively
+- Added AI disclosure section to `.github/PULL_REQUEST_TEMPLATE.md`
 
 ### Fixed
 - Fixed an error in `src/Shared/GeosUtil/hco_regrid_a2a_mod.F90` where an accumulator was uninitialized before reuse, which may inherit junk data from the previous iteration if the southmost source cell is not found

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed an error in `src/Shared/GeosUtil/hco_regrid_a2a_mod.F90` where an accumulator was uninitialized before reuse, which may inherit junk data from the previous iteration if the southmost source cell is not found
 - Fixed IF-block logic errors in `SrcFile_Parse` that led to incorrect time-cycling behavior
+- Fixed Mac GitHub Actions workflow (`mac.yml`) failing with a `gfortran` module-version mismatch by building NetCDF-Fortran from source against each matrix `gcc_version`, instead of relying on Homebrew's bottle (which is always built against Homebrew's own default/latest `gcc`)
 
 #### Removed
 - Removed C-preprocessor switch `ESMF_`

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,56 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+title: "HEMCO: The Harmonized Emissions Component"
+type: software
+authors:
+  - name: "The International GEOS-Chem User Community"
+version: 3.12.1
+date-released: 2026-04-08
+doi: 10.5281/zenodo.4618253
+url: "https://hemco.readthedocs.io"
+repository-code: "https://github.com/geoschem/HEMCO"
+license: MIT
+keywords:
+  - atmospheric-chemistry
+  - atmospheric-composition
+  - atmospheric-modeling
+  - aws
+  - climate-modeling
+  - cloud-computing
+  - geos-chem
+  - atmospheric-computing
+  - scientific-computing
+preferred-citation:
+  type: article
+  title: "Harmonized Emissions Component (HEMCO) 3.0 as a versatile emissions component for atmospheric models: application in the GEOS-Chem, NASA GEOS, WRF-GC, CESM2, NOAA GEFS-Aerosol, and NOAA UFS models"
+  authors:
+    - family-names: Lin
+      given-names: Haipeng
+    - family-names: Jacob
+      given-names: Daniel J.
+    - family-names: Lundgren
+      given-names: Elizabeth W.
+    - family-names: Sulprizio
+      given-names: Melissa P.
+    - family-names: Keller
+      given-names: Christoph A.
+    - family-names: Fritz
+      given-names: Thibaud M.
+    - family-names: Eastham
+      given-names: Sebastian D.
+    - family-names: Emmons
+      given-names: Louisa K.
+    - family-names: Campbell
+      given-names: Patrick C.
+    - family-names: Baker
+      given-names: Barron
+    - family-names: Saylor
+      given-names: Rick D.
+    - family-names: Montuoro
+      given-names: Raffaele
+  journal: "Geoscientific Model Development"
+  volume: 14
+  start: 5487
+  end: 5506
+  year: 2021
+  doi: 10.5194/gmd-14-5487-2021

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,67 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this repository is
+
+**HEMCO** (Harmonized Emissions Component) is a Fortran component for computing atmospheric emissions from multiple data inventories, scale factors, and non-linear parameterizations ("extensions"). It is not run standalone in most contexts — this repo is normally checked out as a **git submodule** of a host model:
+
+- `geoschem/GCClassic` — GEOS-Chem Classic (couples via the `gcclassic` interface)
+- NASA GEOS / MAPL/ESMF-based models (couples via the `mapl`/ESMF interface)
+- CESM2, WRF-GC, NOAA GEFS-Aerosol/UFS (couple via their own build systems, bypassing CMake)
+
+It can also be built and run in **standalone mode** (`HEMCO_EXTERNAL_CONFIG` not set), driven entirely by `.rc` config files in `run/`, with no host atmospheric model.
+
+If you arrived here via the GCClassic superproject, remember: `run`/`test` there are symlinks into the GEOS-Chem submodule, not this one. This repo's own `run/` directory holds the HEMCO **standalone** run-directory templates.
+
+## Building
+
+The build is CMake-based. In standalone mode it self-configures without a host model:
+
+```console
+cmake -S . -B build -D CMAKE_BUILD_TYPE=Release   # Debug also supported
+cmake --build build --verbose
+```
+
+Key CMake options (see top-level `CMakeLists.txt`):
+- `USE_REAL8` (ON/OFF, default ON) — HEMCO precision (`hp`) as 8-byte real
+- `OMP` (TRUE/FALSE, default TRUE) — OpenMP threading
+- `SANITIZE` (ON/OFF, GNU only, standalone builds) — address/leak/UB sanitizers
+- `RUNDIR` — path to a HEMCO standalone run directory (must contain `HEMCO_sa_Spec.rc`); defaults to `..`
+- `CMAKE_BUILD_TYPE` — `Release` (default), `Debug`, `RelWithDebInfo`
+
+Only **Intel** and **GNU** Fortran compilers are supported (`HEMCO_SUPPORTED_COMPILER_IDS`); anything else is a hard CMake error.
+
+When HEMCO is built as a submodule, the parent project sets `HEMCO_EXTERNAL_CONFIG` plus one of `GCCLASSIC_WRAPPER` or `MAPL_ESMF` (and optionally `MAPL3`), which determines `HEMCO_INTERFACE` (`standalone` / `gcclassic` / `mapl`) — see "Interface selection" below.
+
+CI (`.github/workflows/ubuntu.yml`, `mac.yml`) builds the standalone target across a compiler/build-type matrix and runs `ctest`; there is currently no populated test suite (`ctest` finds nothing to run), so CI is effectively a compile check across Intel/GNU × Debug/Release combinations.
+
+## Architecture
+
+### Directory layout (`src/`)
+
+- **`Core/`** — the HEMCO engine itself: config file parsing (`hco_config_mod`, `hco_extlist_mod`),   the emissions list and calculation engine (`hco_emislist_mod`, `hco_calc_mod`, `hco_readlist_mod`),   state objects (`hco_state_mod`, `hco_types_mod`), diagnostics (`hco_diagn_mod`, `hcoio_diagn_mod`),   and I/O backends (`hcoio_read_*_mod.F90` / `hcoio_write_*_mod.F90` — std/mapl/pio variants, selected   at CMake configure time based on `HEMCO_INTERFACE`). `hco_driver_mod.F90` is the INIT/RUN/FINAL driver for everything *not* handled by an extension.
+- **`Extensions/`** — self-contained emission/parameterization modules (`hcox_*_mod.F90`): MEGAN (biogenic), GFED/FINN/GFAS (biomass burning), sea salt/seaflux/paranox, dust, lightning NOx, soil NOx, volcano, iodine, POPs, Rn-Pb-Be, TOMAS aerosol variants, etc. `hcox_driver_mod.F90` is the registry: `HCOX_Init`/`HCOX_Run`/`HCOX_Final` each contain one `IF (ExtState%<Ext>) CALL HCOX_<Ext>_{Init,Run,Final}(...)` block per extension, gated by whether that extension was enabled in `HEMCO_Config.rc`. **Adding a new extension means adding it here** (plus a CMakeLists.txt entry and a config-file section) — `hcox_template_mod.F90x` is the copy-paste skeleton for a new extension module, following the `InstGet`/`InstCreate`/`InstRemove` pattern for supporting multiple simultaneous instances of the same extension.
+- **`Interfaces/`** — the boundary between HEMCO and each host model:
+  - `Standalone/` — `hemco_standalone.F90` + `hcoi_standalone_mod.F90`, the standalone driver/executable.
+  - `GEOS/` — ESMF `GridComp` wrapper (`HEMCO_GridCompMod.F90`) plus GEOS-specific `.rc` files, for
+    NASA GEOS/GOCART/GMI coupling.
+  - `MAPL_ESMF/` — `hcoi_esmf_mod.F90`, the MAPL/ESMF coupling layer (shared by GEOS and other
+    MAPL-based hosts; behavior branches further on `MAPL3`).
+  - `Shared/` — `hco_interface_common.F90`, code shared across interfaces regardless of host.
+- **`Shared/`** — host-agnostic utility code: `GeosUtil/` (regridding, Julian day, Henry's law
+  constants), `Headers/` (precision kinds in `hco_precision_mod.F90`, string parsing), `NcdfUtil/` (netCDF read/write wrappers, `hco_m_netcdf_io_*`).
+
+### Interface selection (`HEMCO_INTERFACE`)
+
+`src/Core/CMakeLists.txt` picks the I/O backend (`hcoio_read_std_mod`/`hcoio_read_mapl_mod`/etc.) based on `HEMCO_INTERFACE`, which is set once near the top of the top-level `CMakeLists.txt` depending on which of `HEMCO_EXTERNAL_CONFIG`/`GCCLASSIC_WRAPPER`/`MAPL_ESMF`/`MAPL3` the parent build defines. Non-CMake hosts (WRF-GC, CESM2-GC) bypass this and set the equivalent C-preprocessor switches themselves, so any change to an `hcoio_*` module or the switches guarding it must stay consistent with those external, non-CMake build systems too (see the discussion linked in `src/Core/CMakeLists.txt`, geoschem/HEMCO#87).
+
+### Configuration-driven behavior
+
+Most HEMCO behavior (which extensions run, which data files feed which species, scale factors, masks, time cycling) is controlled at runtime through `HEMCO_Config.rc` (template: `run/HEMCO_Config.rc.sample`) and `HEMCO_Diagn.rc`, not through recompilation. `hco_config_mod.F90`/`hco_extlist_mod.F90` parse these files at startup; extension-specific options are read via `GetExtOpt`. When changing emissions behavior, check whether the change belongs in Fortran code or is actually just a config-file/`run/` scripting concern.
+
+## Versioning and changes
+
+- Bump `PROJECT VERSION` in `CMakeLists.txt` **and** the matching version string in `src/Core/hco_error_mod.F90` together — there's an explicit reminder comment for this in `CMakeLists.txt`.
+- `CHANGELOG.md` follows Keep a Changelog / SemVer; update it for any user-facing change (this is also called out explicitly in `CONTRIBUTING.md`).
+- Changes affecting run directories/config files should be mirrored for GCHP and GEOS-Chem Classic where applicable, and use Fortran-90 free-format style consistent with surrounding code (this codebase has decades of contributions with inconsistent conventions — match nearby code rather than imposing a new style).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,31 @@
+# Governance
+
+HEMCO is developed under the same grass-roots, open-access governance as [GEOS-Chem](https://geoschem.github.io/community.html), of which it is a core component. This document summarizes how development priorities are set and how code moves from a contributor's changes into an official release. For the practical, step-by-step process of submitting a change, see `CONTRIBUTING.md`.
+
+## Roles
+
+### GEOS-Chem Steering Committee (GCSC)
+
+The [GEOS-Chem Steering Committee](https://geoschem.github.io/steering-committee.html) provides scientific direction for the model, including HEMCO. It meets quarterly to set [GEOS-Chem model development priorities](http://wiki.geos-chem.org/GEOS-Chem_model_development_priorities) and to slate submitted updates for inclusion into upcoming releases.
+
+### Working Groups
+
+[GEOS-Chem Working Groups](https://geoschem.github.io/working-groups.html) identify priority development needs within their science areas and advise the GCSC accordingly. Working Group chairs are the first point of contact for contributors who want to propose a HEMCO update, and can advise on timing for submitting code tied to a mature development.
+
+### GEOS-Chem Support Team (GCST)
+
+The [GEOS-Chem Support Team](https://geoschem.github.io/support-team.html), based at Harvard University and Washington University in St. Louis, manages this codebase day to day: it reviews and merges pull requests into the development branch for an upcoming version, and validates incoming updates before release. If an issue is found with a submitted update, the GCST works with the contributor on corrective action.
+
+## How a change becomes an official release
+
+1. A contributor proposes an update to their relevant Working Group chair(s).
+
+2. The Working Group forwards the request to the GCSC, which sets its priority and target version at a quarterly meeting.
+
+3. The contributor submits the update as a pull request against this repository, following the checklist in `CONTRIBUTING.md` (Fortran-90 free format, thorough comments, a `CHANGELOG.md` entry, and matching GCHP/GEOS-Chem Classic config updates where applicable).
+
+4. The GCST reviews and merges the update into the development branch, then includes it in the next tagged release. Releases here are picked up as pinned submodule updates by the host models that couple to HEMCO — [GCClassic](https://github.com/geoschem/GCClassic), [GCHP](https://github.com/geoschem/GCHP), NASA GEOS, CESM2, WRF-GC, and NOAA GEFS-Aerosol/UFS.
+
+## Sponsors
+
+HEMCO development is supported by the US NASA Earth Science Division, the Canadian National Sciences and Engineering Research Council, and the Nanjing University of Information Science and Technology.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Supported Versions
+
+HEMCO does not maintain long-term-support branches. Security fixes are only provided for the most recently released version, listed in `CHANGELOG.md`.
+
+## Reporting a Vulnerability
+
+If you believe you have found a security vulnerability in this repository — for example, a supply-chain issue in a GitHub Actions workflow, or an issue in a run-directory/data-download script (`run/download_data.py`, `run/createRunDir.sh`, etc.) that could lead to unintended code execution — please report it privately using GitHub's **[Report a vulnerability](https://github.com/geoschem/hemco/security/advisories/new)** feature (Security tab) rather than opening a public issue.
+
+If the issue is specific to a host model that couples to HEMCO (GCClassic, GCHP, GEOS-Chem, Cloud-J, HETP) rather than to this repository, please report it there instead.
+
+This project is maintained by the **GEOS-Chem Support Team (GCST)** on a best-effort basis, so there is no guaranteed response SLA, but we will acknowledge reports as promptly as we can and work with you on a fix and coordinated disclosure.
+
+## Out of Scope
+
+Scientific-correctness bugs, numerical issues, and general "how do I..." questions are **not** security reports. Please use the normal channels described in `SUPPORT.md` and `CONTRIBUTING.md` ([GitHub issues](https://github.com/geoschem/geos-chem/issues/new/choose)) for those instead.


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update

We have added the following files (suggested by Claude Code):

| File | Description |
|---|---|
| `.gitattributes` | Specifies Git behavior regarding line endings |
| `CITATION.cff` | Instructions on how to cite if you use HEMCO |
| `CLAUDE.md` | Provides guidance to Claude Code AI |
| `GOVERNANCE.md` | Summarizes the GEOS-Chem governance structure (taken from existing documentation) |
| `SECURITY.md` | Specifies the security policy used for this repo |

The following files were modified:

| File | Description |
|---|---|
| `.release/changeVersionNumbers.sh` | Modified to update version number & date in `CITATION.cff` |
| `CHANGELOG.md` | Updated accordingly |

### Additional bundled fix

We have also bundled into this PR an update to the GitHub Action config file `.github/workflows/mac.yml` to build netCDF-Fortran from scratch with the same compiler used to run the tests.  This is necessary because Homebrew apparently does not support netCDF-Fortran built with later versions of GCC.

### Expected changes
This is a zero-diff update.