### PR TITLE
Fix unit conversions clobbering the HCO_MISSVAL missing-value sentinel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed an error in `src/Shared/GeosUtil/hco_regrid_a2a_mod.F90` where an accumulator was uninitialized before reuse, which may inherit junk data from the previous iteration if the southmost source cell is not found
 - Fixed IF-block logic errors in `SrcFile_Parse` that led to incorrect time-cycling behavior
+- Fixed `HCO_MISSVAL` missing-value sentinel getting unit converted or scaled, leading to crashes when files had negative FillValues
 
 #### Removed
 - Removed C-preprocessor switch `ESMF_`

--- a/src/Core/hco_unit_mod.F90
+++ b/src/Core/hco_unit_mod.F90
@@ -191,9 +191,14 @@ CONTAINS
         RETURN
     ENDIF
 
-    ! Apply correction factor
+    ! Apply correction factor. Skip missing values so that the
+    ! HCO_MISSVAL sentinel stays detectable downstream (missing data
+    ! is identified by comparing against HCO_MISSVAL, e.g. in
+    ! hco_calc_mod.F90).
     IF ( Factor /= 1.0_hp ) THEN
-       ARRAY(:,:,:,:) = ARRAY(:,:,:,:) * Factor
+       WHERE ( ARRAY(:,:,:,:) /= HCO_MISSVAL )
+          ARRAY(:,:,:,:) = ARRAY(:,:,:,:) * Factor
+       END WHERE
     ENDIF
 
     ! Eventually return factor
@@ -271,9 +276,14 @@ CONTAINS
         RETURN
     ENDIF
 
-    ! Apply correction factor
+    ! Apply correction factor. Skip missing values so that the
+    ! HCO_MISSVAL sentinel stays detectable downstream (missing data
+    ! is identified by comparing against HCO_MISSVAL, e.g. in
+    ! hco_calc_mod.F90).
     IF ( Factor /= 1.0_hp ) THEN
-       ARRAY(:,:,:,:) = ARRAY(:,:,:,:) * Factor
+       WHERE ( ARRAY(:,:,:,:) /= HCO_MISSVAL )
+          ARRAY(:,:,:,:) = ARRAY(:,:,:,:) * Factor
+       END WHERE
     ENDIF
 
     ! Eventually return factor

--- a/src/Core/hcoio_read_pio_mod.F90
+++ b/src/Core/hcoio_read_pio_mod.F90
@@ -1248,7 +1248,8 @@ CONTAINS
        ELSEIF ( AreaFlag == 3 .AND. TimeFlag == 1 ) THEN
           Lct%Dct%Dta%IsConc = .TRUE.
 
-          ncArr = ncArr * HcoState%TS_EMIS
+          ! Preserve HCO_MISSVAL sentinels when scaling
+          WHERE ( ncArr /= HCO_MISSVAL ) ncArr = ncArr * HcoState%TS_EMIS
           MSG = 'Data converted from kg/m3/s to kg/m3: ' // &
                 TRIM(Lct%Dct%cName) // ': ' // TRIM(thisUnit)
           IF ( HcoState%Config%doVerbose ) CALL HCO_WARNING( MSG )
@@ -1263,7 +1264,8 @@ CONTAINS
 
        ! Emission data that is not per time (kg/m2): convert to kg/m2/s
        ELSEIF ( AreaFlag == 2 .AND. TimeFlag == 0 ) THEN
-          ncArr = ncArr / HcoState%TS_EMIS
+          ! Preserve HCO_MISSVAL sentinels when scaling
+          WHERE ( ncArr /= HCO_MISSVAL ) ncArr = ncArr / HcoState%TS_EMIS
           MSG = 'Data converted from kg/m2 to kg/m2/s: ' // &
                 TRIM(Lct%Dct%cName) // ': ' // TRIM(thisUnit)
           IF ( HcoState%Config%doVerbose ) CALL HCO_WARNING( MSG )

--- a/src/Core/hcoio_read_std_mod.F90
+++ b/src/Core/hcoio_read_std_mod.F90
@@ -1264,7 +1264,8 @@ CONTAINS
        ELSEIF ( AreaFlag == 3 .AND. TimeFlag == 1 ) THEN
           Lct%Dct%Dta%IsConc = .TRUE.
 
-          ncArr = ncArr * HcoState%TS_EMIS
+          ! Preserve HCO_MISSVAL sentinels when scaling
+          WHERE ( ncArr /= HCO_MISSVAL ) ncArr = ncArr * HcoState%TS_EMIS
           MSG = 'Data converted from kg/m3/s to kg/m3: ' // &
                 TRIM(Lct%Dct%cName) // ': ' // TRIM(thisUnit)
           IF ( HcoState%Config%doVerbose ) CALL HCO_WARNING( MSG )
@@ -1279,7 +1280,8 @@ CONTAINS
 
        ! Emission data that is not per time (kg/m2): convert to kg/m2/s
        ELSEIF ( AreaFlag == 2 .AND. TimeFlag == 0 ) THEN
-          ncArr = ncArr / HcoState%TS_EMIS
+          ! Preserve HCO_MISSVAL sentinels when scaling
+          WHERE ( ncArr /= HCO_MISSVAL ) ncArr = ncArr / HcoState%TS_EMIS
           MSG = 'Data converted from kg/m2 to kg/m2/s: ' // &
                 TRIM(Lct%Dct%cName) // ': ' // TRIM(thisUnit)
           IF ( HcoState%Config%doVerbose ) CALL HCO_WARNING( MSG )

--- a/src/Core/hcoio_util_mod.F90
+++ b/src/Core/hcoio_util_mod.F90
@@ -1465,8 +1465,10 @@ CONTAINS
        AREA = ( 2_hp * HcoState%Phys%PI * DLAT * HcoState%Phys%Re**2 ) &
               / REAL(nlon,hp)
 
-       ! convert array data to m-2
-       ARRAY(:,J,:,:) = ARRAY(:,J,:,:) / AREA
+       ! convert array data to m-2, preserving HCO_MISSVAL sentinels
+       WHERE ( ARRAY(:,J,:,:) /= HCO_MISSVAL )
+          ARRAY(:,J,:,:) = ARRAY(:,J,:,:) / AREA
+       END WHERE
     ENDDO
 
     ! Prompt a warning


### PR DESCRIPTION
### Name and Institution (Required)

Name: Haipeng Lin
Institution: NCAR

### Describe the update

Missing data in HEMCO is carried through the read path as `HCO_MISSVAL` (`-1e31`) sentinel value. This value is matched by equality checks in `hco_calc_mode.F90` etc. so it can zero missing base emissions and set missing scale factors to 1, but other parts of HEMCO are not appropriately aware of this, leading to `HCO_MISSVAL` itself being masked, scaled, and unit converted. There are a few places where this happens:

- HCO_UNIT_CHANGE (SP and DP): Array = Array * Factor
- HCOIO_Read kg/m3/s -> kg/m3 and kg/m2 -> kg/m2/s timestep conversions (hcoio_read_std_mod.F90 and hcoio_read_pio_mod.F90)
- NORMALIZE_AREA per-area normalization (hcoio_util_mod.F90)

For any input file carrying missing_value/_FillValue whose units require conversion (e.g. molec/cm2/s), these fill values would get unit-converted so they are no longer equal to `HCO_MISSVAL`. An obvious effect of this is that if you had a file with `_FillValue = -999` for example and had `Negative values` setting to crash, and that field with fillvalues needed a unit conversion, the model would crash even though the negative values are missing values. Or the scaled "missing values" actually become part of emissions leading to errors.

All scaling operations are now restricted to non-missing pixels with WHERE masks so the sentinel survives to the downstream checks.

Fields in units needing no conversion (factor 1) are bitwise unaffected.

### Expected changes

Fields necessitating unit conversions and having missing values may result in answer changes due to this corrected behavior.

### Reference(s)

N/A

### Related Github Issue

Fixes #365 